### PR TITLE
Replace random_state occurrences in shuffle_arrays_unison

### DIFF
--- a/docs/sources/user_guide/evaluate/plot_learning_curves.ipynb
+++ b/docs/sources/user_guide/evaluate/plot_learning_curves.ipynb
@@ -126,7 +126,7 @@
     "\n",
     "# Loading some example data\n",
     "X, y = iris_data()\n",
-    "X, y = shuffle_arrays_unison(arrays=[X, y], random_state=123)\n",
+    "X, y = shuffle_arrays_unison(arrays=[X, y], random_seed=123)\n",
     "X_train, X_test = X[:100], X[100:]\n",
     "y_train, y_test = y[:100], y[100:]\n",
     "\n",

--- a/docs/sources/user_guide/preprocessing/shuffle_arrays_unison.ipynb
+++ b/docs/sources/user_guide/preprocessing/shuffle_arrays_unison.ipynb
@@ -175,7 +175,7 @@
       "    >>> from mlxtend.preprocessing import shuffle_arrays_unison\n",
       "    >>> X1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])\n",
       "    >>> y1 = np.array([1, 2, 3])\n",
-      "    >>> X2, y2 = shuffle_arrays_unison(arrays=[X1, y1], random_state=3)\n",
+      "    >>> X2, y2 = shuffle_arrays_unison(arrays=[X1, y1], random_seed=3)\n",
       "    >>> assert(X2.all() == np.array([[4, 5, 6], [1, 2, 3], [7, 8, 9]]).all())\n",
       "    >>> assert(y2.all() == np.array([2, 1, 3]).all())\n",
       "    >>>\n",

--- a/mlxtend/preprocessing/shuffle.py
+++ b/mlxtend/preprocessing/shuffle.py
@@ -29,7 +29,7 @@ def shuffle_arrays_unison(arrays, random_seed=None):
     >>> from mlxtend.preprocessing import shuffle_arrays_unison
     >>> X1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> y1 = np.array([1, 2, 3])
-    >>> X2, y2 = shuffle_arrays_unison(arrays=[X1, y1], random_state=3)
+    >>> X2, y2 = shuffle_arrays_unison(arrays=[X1, y1], random_seed=3)
     >>> assert(X2.all() == np.array([[4, 5, 6], [1, 2, 3], [7, 8, 9]]).all())
     >>> assert(y2.all() == np.array([2, 1, 3]).all())
     >>>


### PR DESCRIPTION
This small PR replaces the `random_state` parameter with `random_seed` in docstrings of `shuffle_arrays_unison`. Solves #81.

