### PR TITLE
change max_score - line 243

### DIFF
--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -240,7 +240,7 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
                 sys.stderr.flush()
 
         if select_in_range:
-            max_score = -1
+            max_score = float('-inf')
             for k in self.subsets_:
                 if self.subsets_[k]['avg_score'] > max_score:
                     max_score = self.subsets_[k]['avg_score']

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -372,6 +372,7 @@ def test_regression():
                 skip_if_stuck=True,
                 print_progress=False)
     sfs_r = sfs_r.fit(X, y)
+    assert len(sfs_r.k_feature_idx_) == 13
     assert round(sfs_r.k_score_, 4) == -34.7631
     
 def test_regression_in_range():
@@ -379,7 +380,7 @@ def test_regression_in_range():
     X, y = boston.data, boston.target
     lr = LinearRegression()
     sfs_r = SFS(lr,
-                k_features=(1,13),
+                k_features=(1, 13),
                 forward=True,
                 floating=False,
                 scoring='mean_squared_error',
@@ -387,6 +388,7 @@ def test_regression_in_range():
                 skip_if_stuck=True,
                 print_progress=False)
     sfs_r = sfs_r.fit(X, y)
+    assert len(sfs_r.k_feature_idx_) == 9
     assert round(sfs_r.k_score_, 4) == -31.1537
 
 

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -373,6 +373,21 @@ def test_regression():
                 print_progress=False)
     sfs_r = sfs_r.fit(X, y)
     assert round(sfs_r.k_score_, 4) == -34.7631
+    
+def test_regression_in_range():
+    boston = load_boston()
+    X, y = boston.data, boston.target
+    lr = LinearRegression()
+    sfs_r = SFS(lr,
+                k_features=(1,13),
+                forward=True,
+                floating=False,
+                scoring='mean_squared_error',
+                cv=10,
+                skip_if_stuck=True,
+                print_progress=False)
+    sfs_r = sfs_r.fit(X, y)
+    assert round(sfs_r.k_score_, 4) == -31.1537
 
 
 def test_clone_params_fail():


### PR DESCRIPTION
Change max_score in line 243 to accommodate smaller negative values. For example, when using 'mean_squared_error', the call to get_scorer results in a make_scorer function with 'greater_is_better = False', such that values less than -1 can occur (the sign is flipped on the result of mse). Changed to float('-inf'), or could be -10**9, etc.