### PR TITLE
compatibility layer for sklearn 0.18 model_selection

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -20,6 +20,7 @@ The CHANGELOG for the current development version is available via
 ##### Changes
 
 - All plotting functions have been moved to `mlxtend.plotting` for compatibility reasons with continuous integration services and to make the installation of `matplotlib` optional for users of mlxtend's core functionality.
+- Added a compatibility layer for scikit-learn 0.18 using the new `model_selection` module  while maintaining backwards compatibility to scikit-learn 0.17
 
 ##### Bug Fixes
 

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -6,16 +6,23 @@
 # License: BSD 3 clause
 
 from mlxtend.classifier import StackingCVClassifier
-from sklearn.grid_search import GridSearchCV
-from sklearn import cross_validation
+
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import GaussianNB
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.utils.validation import NotFittedError
 import numpy as np
 from sklearn import datasets
 from mlxtend.utils import assert_raises
-
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.utils.validation import NotFittedError
+    from sklearn.cross_validation import cross_val_score
+    from sklearn.grid_search import GridSearchCV
+else:
+    from sklearn.model_selection import GridSearchCV
+    from sklearn.exceptions import NotFittedError
+    from sklearn.model_selection import cross_val_score
 
 iris = datasets.load_iris()
 X, y = iris.data[:, 1:3], iris.target
@@ -30,11 +37,11 @@ def test_StackingClassifier():
                                 meta_classifier=meta,
                                 shuffle=False)
 
-    scores = cross_validation.cross_val_score(sclf,
-                                              X,
-                                              y,
-                                              cv=5,
-                                              scoring='accuracy')
+    scores = cross_val_score(sclf,
+                             X,
+                             y,
+                             cv=5,
+                             scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
     assert scores_mean == 0.93
 
@@ -49,11 +56,11 @@ def test_StackingClassifier_proba():
                                 meta_classifier=meta,
                                 shuffle=False)
 
-    scores = cross_validation.cross_val_score(sclf,
-                                              X,
-                                              y,
-                                              cv=5,
-                                              scoring='accuracy')
+    scores = cross_val_score(sclf,
+                             X,
+                             y,
+                             cv=5,
+                             scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
     assert scores_mean == 0.93
 
@@ -74,9 +81,14 @@ def test_gridsearch():
     grid = GridSearchCV(estimator=sclf, param_grid=params, cv=5)
     grid.fit(iris.data, iris.target)
 
-    mean_scores = []
-    for params, mean_score, scores in grid.grid_scores_:
-        mean_scores.append(round(mean_score, 2))
+    if Version(sklearn_version) < '0.18':
+        mean_scores = []
+        for params, mean_score, scores in grid.grid_scores_:
+            mean_scores.append(round(mean_score, 2))
+    else:
+        mean_scores = [round(s, 2) for s
+                       in grid.cv_results_['mean_test_score']]
+
     assert mean_scores == [0.96, 0.95, 0.96, 0.95]
 
 
@@ -107,11 +119,11 @@ def test_use_probas():
                                 meta_classifier=meta,
                                 shuffle=False)
 
-    scores = cross_validation.cross_val_score(sclf,
-                                              X,
-                                              y,
-                                              cv=5,
-                                              scoring='accuracy')
+    scores = cross_val_score(sclf,
+                             X,
+                             y,
+                             cv=5,
+                             scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
     assert scores_mean == 0.94, scores_mean
 
@@ -126,11 +138,11 @@ def test_use_features_in_secondary():
                                 meta_classifier=meta,
                                 shuffle=False)
 
-    scores = cross_validation.cross_val_score(sclf,
-                                              X,
-                                              y,
-                                              cv=5,
-                                              scoring='accuracy')
+    scores = cross_val_score(sclf,
+                             X,
+                             y,
+                             cv=5,
+                             scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
     assert scores_mean == 0.93, scores_mean
 
@@ -144,11 +156,11 @@ def test_do_not_stratify():
                                 meta_classifier=meta,
                                 stratify=False)
 
-    scores = cross_validation.cross_val_score(sclf,
-                                              X,
-                                              y,
-                                              cv=5,
-                                              scoring='accuracy')
+    scores = cross_val_score(sclf,
+                             X,
+                             y,
+                             cv=5,
+                             scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
     assert scores_mean == 0.94
 

--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -18,8 +18,13 @@ from sklearn.metrics import get_scorer
 from sklearn.base import clone
 from sklearn.base import BaseEstimator
 from sklearn.base import MetaEstimatorMixin
-from sklearn.cross_validation import cross_val_score
 from ..externals.name_estimators import _name_estimators
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.cross_validation import cross_val_score
+else:
+    from sklearn.model_selection import cross_val_score
 
 
 class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):

--- a/mlxtend/feature_selection/tests/test_column_selector.py
+++ b/mlxtend/feature_selection/tests/test_column_selector.py
@@ -11,7 +11,12 @@ from mlxtend.feature_selection import ColumnSelector
 from sklearn.linear_model import LogisticRegression
 from sklearn.datasets import load_iris
 from sklearn.pipeline import make_pipeline
-from sklearn.grid_search import GridSearchCV
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.grid_search import GridSearchCV
+else:
+    from sklearn.model_selection import GridSearchCV
 
 
 def test_ColumnSelector():

--- a/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
@@ -15,6 +15,12 @@ from sklearn.linear_model import LinearRegression
 from sklearn.datasets import load_boston
 from mlxtend.utils import assert_raises
 from mlxtend.classifier import SoftmaxRegression
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    MEAN_SQUARED_ERROR = 'mean_squared_error'
+else:
+    MEAN_SQUARED_ERROR = 'neg_mean_squared_error'
 
 
 def dict_compare_utility(d1, d2):
@@ -171,7 +177,7 @@ def test_regression():
     efs_r = EFS(lr,
                 min_features=3,
                 max_features=4,
-                scoring='mean_squared_error',
+                scoring=MEAN_SQUARED_ERROR,
                 cv=10,
                 print_progress=False)
     efs_r = efs_r.fit(X, y)

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -14,6 +14,12 @@ from sklearn.datasets import load_iris
 from sklearn.linear_model import LinearRegression
 from sklearn.datasets import load_boston
 from mlxtend.utils import assert_raises
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    MEAN_SQUARED_ERROR = 'mean_squared_error'
+else:
+    MEAN_SQUARED_ERROR = 'neg_mean_squared_error'
 
 
 def dict_compare_utility(d1, d2):
@@ -351,12 +357,22 @@ def test_knn_scoring_metric():
                k_features=3,
                forward=False,
                floating=True,
-               scoring='precision',
                cv=4,
                skip_if_stuck=True,
                print_progress=False)
     sfs6 = sfs6.fit(X, y)
-    assert round(sfs6.k_score_, 4) == 0.9737
+    assert round(sfs6.k_score_, 4) == 0.9728
+
+    sfs7 = SFS(knn,
+               k_features=3,
+               forward=False,
+               floating=True,
+               scoring='f1_macro',
+               cv=4,
+               skip_if_stuck=True,
+               print_progress=False)
+    sfs7 = sfs7.fit(X, y)
+    assert round(sfs7.k_score_, 4) == 0.9727, sfs7.k_score_
 
 
 def test_regression():
@@ -367,7 +383,7 @@ def test_regression():
                 k_features=13,
                 forward=True,
                 floating=False,
-                scoring='mean_squared_error',
+                scoring=MEAN_SQUARED_ERROR,
                 cv=10,
                 skip_if_stuck=True,
                 print_progress=False)
@@ -384,7 +400,7 @@ def test_regression_in_range():
                 k_features=(1, 13),
                 forward=True,
                 floating=False,
-                scoring='mean_squared_error',
+                scoring=MEAN_SQUARED_ERROR,
                 cv=10,
                 skip_if_stuck=True,
                 print_progress=False)

--- a/mlxtend/plotting/tests/test_learning_curves.py
+++ b/mlxtend/plotting/tests/test_learning_curves.py
@@ -6,9 +6,14 @@
 
 from mlxtend.plotting import plot_learning_curves
 from sklearn import datasets
-from sklearn.cross_validation import train_test_split
 from sklearn.tree import DecisionTreeClassifier
 import numpy as np
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.cross_validation import train_test_split
+else:
+    from sklearn.model_selection import train_test_split
 
 
 def test_training_size():

--- a/mlxtend/preprocessing/tests/test_copy_transformer.py
+++ b/mlxtend/preprocessing/tests/test_copy_transformer.py
@@ -8,14 +8,18 @@ import numpy as np
 from mlxtend.preprocessing import CopyTransformer
 from sklearn.datasets import load_iris
 from sklearn.pipeline import make_pipeline
-from sklearn.grid_search import GridSearchCV
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import TfidfTransformer
 from scipy.sparse import issparse
 from mlxtend.utils import assert_raises
 import sys
-
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.grid_search import GridSearchCV
+else:
+    from sklearn.model_selection import GridSearchCV
 
 iris = load_iris()
 X, y = iris.data, iris.target

--- a/mlxtend/preprocessing/tests/test_dense_transformer.py
+++ b/mlxtend/preprocessing/tests/test_dense_transformer.py
@@ -8,12 +8,16 @@ import numpy as np
 from mlxtend.preprocessing import DenseTransformer
 from sklearn.datasets import load_iris
 from sklearn.pipeline import make_pipeline
-from sklearn.grid_search import GridSearchCV
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import TfidfTransformer
 from scipy.sparse import issparse
-
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.grid_search import GridSearchCV
+else:
+    from sklearn.model_selection import GridSearchCV
 
 iris = load_iris()
 X, y = iris.data, iris.target

--- a/mlxtend/regressor/tests/test_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_regression.py
@@ -9,10 +9,14 @@ from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import Ridge
 from sklearn.svm import SVR
 import numpy as np
-from sklearn.grid_search import GridSearchCV
 from numpy.testing import assert_almost_equal
 from nose.tools import raises
-
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+if Version(sklearn_version) < '0.18':
+    from sklearn.grid_search import GridSearchCV
+else:
+    from sklearn.model_selection import GridSearchCV
 
 # Generating a sample dataset
 np.random.seed(1)

--- a/mlxtend/text/names.py
+++ b/mlxtend/text/names.py
@@ -11,6 +11,9 @@ import unicodedata
 import string
 import re
 import sys
+from pandas import __version__ as pandas_version
+from distutils.version import LooseVersion as Version
+
 
 if sys.version_info <= (3, 0):
     raise ImportError("Sorry, the text.names module is incompatible"
@@ -116,10 +119,16 @@ def generalize_names_duplcheck(df, col_name):
 
     df_new[col_name] = df_new[col_name].apply(generalize_names)
 
-    dupl = (list(df_new[df_new.duplicated(subset=col_name,
-                                          take_last=True)].index) +
-            list(df_new[df_new.duplicated(subset=col_name,
-                                          take_last=False)].index))
+    if Version(pandas_version) < '0.17':
+        dupl = (list(df_new[df_new.duplicated(subset=col_name,
+                                              keep='last')].index) +
+                list(df_new[df_new.duplicated(subset=col_name,
+                                              keep='first')].index))
+    else:
+        dupl = (list(df_new[df_new.duplicated(subset=col_name,
+                                              keep='last')].index) +
+                list(df_new[df_new.duplicated(subset=col_name,
+                                              keep='first')].index))
 
     firstname_letters = 2
     while len(dupl) > 0:
@@ -127,9 +136,15 @@ def generalize_names_duplcheck(df, col_name):
             df_new.loc[idx, col_name] = generalize_names(
                 df.loc[idx, col_name],
                 firstname_output_letters=firstname_letters)
-        dupl = (list(df_new[df_new.duplicated(subset=col_name,
-                                              take_last=True)].index) +
-                list(df_new[df_new.duplicated(subset=col_name,
-                                              take_last=False)].index))
+        if Version(pandas_version) < '0.17':
+            dupl = (list(df_new[df_new.duplicated(subset=col_name,
+                                                  keep='last')].index) +
+                    list(df_new[df_new.duplicated(subset=col_name,
+                                                  keep='first')].index))
+        else:
+            dupl = (list(df_new[df_new.duplicated(subset=col_name,
+                                                  keep='last')].index) +
+                    list(df_new[df_new.duplicated(subset=col_name,
+                                                  keep='first')].index))
         firstname_letters += 1
     return df_new


### PR DESCRIPTION
Please make sure that these boxes are checked before submitting a new pull request -- thank you!

- [x] Make sure you submit this pull request as a separate topic branch (and not to "master")
- [x] Provide a small summary describing the Pull Request below:

Uses the `model_selection` module that was added to scikit-learn 0.18 to avoid deprecation warning for scikit-learn 0.18 users. These modifications maintain backwards compatibility to 0.17.

- [x] Link to the respective issue on the [Issue Tracker](https://github.com/rasbt/mlxtend/issues)

Fixes #109

- [x] Add appropriate unit test functions in the `./mlxtend/*/tests` directories
- [x] Run `nosetests ./mlxtend -sv` and make sure that all unit tests pass
- [x] Check/improve the test coverage by running `nosetests ./mlxtend --with-coverage`
- [x] Check for style issues by running `flake8 ./mlxtend` (you may want to run nosetests again after you made modifications to the code)
- [x] Add a note about the modification or contribution to the `./docs/sources/`CHANGELOG.md` file
- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/`
- [x] Push the topic branch to the server and create a pull request
- [ ] Check the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend

**Note:**  
**Due to the improved GitHub UI, the squashing of commits is no longer necessary. (Please don't squash commits since they help with keeping track of the changes during the discussion).**

For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/
