### PR TITLE
deprecation warning for plotting functions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,43 @@
-Please make sure that these boxes are checked before submitting a new pull request -- thank you!
+<!-- Please read the following guidelines for new Pull Requests -- thank you! -->
 
-- [ ] Make sure you submit this pull request as a separate topic branch (and not to "master")
-- [ ] Provide a small summary describing the Pull Request below:
+<!--
+Make sure that you submit this pull request as a separate topic branch (and not to "master")
+-->
 
-- [ ] Link to the respective issue on the [Issue Tracker](https://github.com/rasbt/mlxtend/issues) if one exists. E.g.,
+<!-- Provide a small summary describing the Pull Request below -->
 
-Fixes #<ISSUE_NUMBER>
+### Description
 
-- [ ] Add appropriate unit test functions in the `./mlxtend/*/tests` directories
-- [ ] Run `nosetests ./mlxtend -sv` and make sure that all unit tests pass
-- [ ] Check/improve the test coverage by running `nosetests ./mlxtend --with-coverage`
-- [ ] Check for style issues by running `flake8 ./mlxtend` (you may want to run nosetests again after you made modifications to the code)
-- [ ] Add a note about the modification or contribution to the `./docs/sources/`CHANGELOG.md` file
-- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/`
-- [ ] Push the topic branch to the server and create a pull request
-- [ ] Check the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend
+Insert Description Here
 
-**Note:**  
-**Due to the improved GitHub UI, the squashing of commits is no longer necessary. (Please don't squash commits since they help with keeping track of the changes during the discussion).**
+### Related issues or pull requests
+
+<!-- Please provide a link to the respective issue on the [Issue Tracker](https://github.com/rasbt/mlxtend/issues) if one exists. E.g.,
+
+Fixes #<ISSUE_NUMBER> -->
+
+Link related issues/pull requests here
+
+<!-- Below is a general todo list for typical pull request -->
+
+### Pull Request requirements
+
+- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories
+- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass
+- [ ] Checked the test coverage by running `nosetests ./mlxtend --with-coverage`
+- [ ] Checked for style issues by running `flake8 ./mlxtend`
+- [ ] Added a note about the modification or contribution to the `./docs/sources/`CHANGELOG.md` file
+- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/` (optional)
+- [ ] Checked that the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend
+
+
+
+
+<!--
+NOTE
+
+Due to the improved GitHub UI, the squashing of commits is no longer necessary.
+Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
 
 For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/
+-->

--- a/mlxtend/evaluate/__init__.py
+++ b/mlxtend/evaluate/__init__.py
@@ -6,6 +6,11 @@
 
 from .scoring import scoring
 from .confusion_matrix import confusion_matrix
+from .decision_regions import plot_decision_regions
+from .learning_curves import plot_learning_curves
+from .plot_confusion_matrix import plot_confusion_matrix
 
-
-__all__ = ["scoring", "confusion_matrix"]
+__all__ = ["scoring", "confusion_matrix",
+           "plot_decision_regions",  # deprecated
+           "plot_confusion_matrix",  # deprecated
+           "plot_learning_curves"]  # deprecated

--- a/mlxtend/evaluate/decision_regions.py
+++ b/mlxtend/evaluate/decision_regions.py
@@ -1,0 +1,31 @@
+# Sebastian Raschka 2014-2016
+# mlxtend Machine Learning Library Extensions
+#
+# A function for plotting decision regions of classifiers.
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+import warnings
+
+
+def plot_decision_regions(**args):
+    """Plot decision regions of a classifier.
+
+    Note that importing this function from mlxtend.evaluate has been
+    deprecated and will not longer be supported in mlxtend 0.6.
+    Please use `from mlxtend.plotting import plot_decision_regions` instead.
+
+    """
+
+    from ..plotting import plot_decision_regions
+
+    warnings.warn("Note that importing this function from mlxtend.evaluate"
+                  " has been deprecated and will not longer be supported in"
+                  " mlxtend 0.6. Please use"
+                  "`from mlxtend.plotting import plot_decision_regions` "
+                  "instead.",
+                  DeprecationWarning,
+                  stacklevel=2)
+
+    return plot_decision_regions(**args)

--- a/mlxtend/evaluate/learning_curves.py
+++ b/mlxtend/evaluate/learning_curves.py
@@ -1,0 +1,31 @@
+# Sebastian Raschka 2014-2016
+# mlxtend Machine Learning Library Extensions
+#
+# A function for plotting learning curves of classifiers.
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+import warnings
+
+
+def plot_learning_curves(**args):
+    """
+
+    Note that importing this function from mlxtend.evaluate has been
+    deprecated and will not longer be supported in mlxtend 0.6.
+    Please use `from mlxtend.plotting import plot_learning_curves` instead.
+
+    """
+
+    from ..plotting import plot_learning_curves
+
+    warnings.warn("Note that importing this function from mlxtend.evaluate"
+                  " has been deprecated and will not longer be supported in"
+                  " mlxtend 0.6. Please use"
+                  "`from mlxtend.plotting import plot_learning_curves` "
+                  "instead.",
+                  DeprecationWarning,
+                  stacklevel=2)
+
+    return plot_learning_curves(**args)

--- a/mlxtend/evaluate/plot_confusion_matrix.py
+++ b/mlxtend/evaluate/plot_confusion_matrix.py
@@ -1,0 +1,30 @@
+# Sebastian Raschka 2014-2016
+# mlxtend Machine Learning Library Extensions
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# A function for plotting a confusion matrix.
+# License: BSD 3 clause
+
+import warnings
+
+
+def plot_confusion_matrix(**args):
+    """
+
+    Note that importing this function from mlxtend.evaluate has been
+    deprecated and will not longer be supported in mlxtend 0.6.
+    Please use `from mlxtend.plotting import plot_confusion_matrix` instead.
+
+    """
+
+    from ..plotting import plot_confusion_matrix
+
+    warnings.warn("Note that importing this function from mlxtend.evaluate"
+                  " has been deprecated and will not longer be supported in"
+                  " mlxtend 0.6. Please use"
+                  "`from mlxtend.plotting import plot_confusion_matrix` "
+                  "instead.",
+                  DeprecationWarning,
+                  stacklevel=2)
+
+    return plot_confusion_matrix(**args)

--- a/mlxtend/feature_selection/__init__.py
+++ b/mlxtend/feature_selection/__init__.py
@@ -7,8 +7,10 @@
 from .column_selector import ColumnSelector
 from .sequential_feature_selector import SequentialFeatureSelector
 from .exhaustive_feature_selector import ExhaustiveFeatureSelector
-
+from .plot_sequential_feature_selection import\
+    plot_sequential_feature_selection
 
 __all__ = ["ColumnSelector",
            "SequentialFeatureSelector",
-           "ExhaustiveFeatureSelector"]
+           "ExhaustiveFeatureSelector",
+           "plot_sequential_feature_selection"]  # deprecated

--- a/mlxtend/feature_selection/plot_sequential_feature_selection.py
+++ b/mlxtend/feature_selection/plot_sequential_feature_selection.py
@@ -1,0 +1,32 @@
+# Sebastian Raschka 2014-2016
+# mlxtend Machine Learning Library Extensions
+#
+# Algorithm for plotting sequential feature selection.
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+import warnings
+
+
+def plot_sequential_feature_selection(**args):
+    """
+
+    Note that importing this function from mlxtend.evaluate has been
+    deprecated and will not longer be supported in mlxtend 0.6.
+    Please use `from mlxtend.plotting import plot_sequential_feature_selection`
+    instead.
+
+    """
+
+    from ..plotting import plot_sequential_feature_selection
+
+    warnings.warn("Note that importing this function from mlxtend.evaluate"
+                  " has been deprecated and will not longer be supported in"
+                  " mlxtend 0.6. Please use"
+                  "`from mlxtend.plotting import"
+                  "plot_sequential_feature_selection` instead.",
+                  DeprecationWarning,
+                  stacklevel=2)
+
+    return plot_sequential_feature_selection(**args)

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -48,9 +48,10 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         backward selection otherwise
     floating : bool (default: False)
         Adds a conditional exclusion/inclusion if True.
-    verbose : int (default: 1), level of verbosity to use in logging. If 0, no output,
-        if 1 number of features in current set, if 2 detailed logging including timestamp
-        and cv scores at step.
+    verbose : int (default: 1), level of verbosity to use in logging.
+        If 0, no output,
+        if 1 number of features in current set, if 2 detailed logging i
+        ncluding timestamp and cv scores at step.
     scoring : str or callable (default='accuracy')
         Scoring metric in {accuracy, f1, precision, recall, roc_auc}
         for classifiers,
@@ -146,7 +147,9 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         self.fitted = False
         self.subsets_ = {}
         self.interrupted_ = False
-        self._TESTING_INTERRUPT_MODE = False  # don't mess with this unless testing
+
+        # don't mess with this unless testing
+        self._TESTING_INTERRUPT_MODE = False
 
     def fit(self, X, y):
         """Perform feature selection and learn model from training data.


### PR DESCRIPTION
Fixes #113

Added deprecation warnings so that plotting functions that have been moved from other sub packages into `mlxtend.plotting` can still be used as previously up to mlxtend 0.6