### PR TITLE
fix formatting in findfiles docstring

### DIFF
--- a/docs/sources/user_guide/file_io/find_files.ipynb
+++ b/docs/sources/user_guide/file_io/find_files.ipynb
@@ -180,9 +180,13 @@
       "- `path` : `str`\n",
       "\n",
       "    Path where to look.\n",
-      "    recursive: `bool`\n",
+      "\n",
+      "- `recursive` : `bool`\n",
+      "\n",
       "    If true, searches subdirectories recursively.\n",
-      "    check_ext: `str`\n",
+      "\n",
+      "- `check_ext` : `str`\n",
+      "\n",
       "    If string (e.g., '.txt'), only returns files that\n",
       "    match the specified file extension.\n",
       "\n",
@@ -209,6 +213,15 @@
     "with open('../../api_modules/mlxtend.file_io/find_files.md', 'r') as f:\n",
     "    print(f.read())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -227,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/mlxtend/file_io/find_files.py
+++ b/mlxtend/file_io/find_files.py
@@ -20,9 +20,9 @@ def find_files(substring, path, recursive=False,
         Substring of the file to be matched.
     path : `str`
         Path where to look.
-    recursive: `bool`
+    recursive : `bool`
         If true, searches subdirectories recursively.
-    check_ext: `str`
+    check_ext : `str`
         If string (e.g., '.txt'), only returns files that
         match the specified file extension.
     ignore_invisible : `bool`


### PR DESCRIPTION
<!-- Please read the following guidelines for new Pull Requests -- thank you! -->

<!--
Make sure that you submit this pull request as a separate topic branch (and not to "master")
-->

<!-- Provide a small summary describing the Pull Request below -->

### Description

Add missing whitespace to format the `find_files` docstring correctly.

### Related issues or pull requests


Fixes #117
