### PR TITLE
fix default value for k_features in SFS

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -23,7 +23,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- -
+- Fixed wrong default value for `k_features` in `SequentialFeatureSelector`
 
 
 

--- a/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
+++ b/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
@@ -1557,7 +1557,7 @@
      "text": [
       "## SequentialFeatureSelector\n",
       "\n",
-      "*SequentialFeatureSelector(estimator, k_features='best', forward=True, floating=False, print_progress=False, verbose=1, scoring=None, cv=5, skip_if_stuck=True, n_jobs=1, pre_dispatch='2*n_jobs', clone_estimator=True)*\n",
+      "*SequentialFeatureSelector(estimator, k_features=1, forward=True, floating=False, verbose=1, scoring=None, cv=5, skip_if_stuck=True, n_jobs=1, pre_dispatch='2*n_jobs', clone_estimator=True)*\n",
       "\n",
       "Sequential Feature Selection for Classification and Regression.\n",
       "\n",
@@ -1734,9 +1734,10 @@
       "\n",
       "**Parameters**\n",
       "\n",
-      "deep: boolean, optional\n",
-      "If True, will return the parameters for this estimator and\n",
-      "contained subobjects that are estimators.\n",
+      "- `deep` : boolean, optional\n",
+      "\n",
+      "    If True, will return the parameters for this estimator and\n",
+      "    contained subobjects that are estimators.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -1790,7 +1791,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -102,7 +102,7 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
               'avg_score' (average cross-validation score)
 
     """
-    def __init__(self, estimator, k_features='best',
+    def __init__(self, estimator, k_features=1,
                  forward=True, floating=False,
                  verbose=1, scoring=None,
                  cv=5, skip_if_stuck=True, n_jobs=1,

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -34,6 +34,18 @@ def dict_compare_utility(d1, d2):
                                      " != d2[%s]['cv_scores']" % (i, i)))
 
 
+def test_run_default():
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+    knn = KNeighborsClassifier()
+    sfs = SFS(estimator=knn,
+              k_features=1,
+              verbose=0)
+    sfs.fit(X, y)
+    assert sfs.k_feature_idx_ == (3, )
+
+
 def test_kfeatures_type_1():
     iris = load_iris()
     X = iris.data
@@ -42,6 +54,7 @@ def test_kfeatures_type_1():
     expect = ('k_features must be a positive integer between 1 and X.shape[1],'
               ' got 0')
     sfs = SFS(estimator=knn,
+              verbose=0,
               k_features=0)
     assert_raises(AttributeError,
                   expect,
@@ -57,6 +70,7 @@ def test_kfeatures_type_2():
     knn = KNeighborsClassifier()
     expect = 'k_features must be a positive integer or tuple'
     sfs = SFS(estimator=knn,
+              verbose=0,
               k_features='abc')
     assert_raises(AttributeError,
                   expect,
@@ -72,6 +86,7 @@ def test_kfeatures_type_3():
     knn = KNeighborsClassifier()
     expect = ('k_features tuple min value must be in range(1, X.shape[1]+1).')
     sfs = SFS(estimator=knn,
+              verbose=0,
               k_features=(0, 5))
     assert_raises(AttributeError,
                   expect,
@@ -87,6 +102,7 @@ def test_kfeatures_type_4():
     knn = KNeighborsClassifier()
     expect = ('k_features tuple max value must be in range(1, X.shape[1]+1).')
     sfs = SFS(estimator=knn,
+              verbose=0,
               k_features=(1, 5))
     assert_raises(AttributeError,
                   expect,
@@ -103,6 +119,7 @@ def test_kfeatures_type_5():
     expect = ('he min k_features value must be'
               ' larger than the max k_features value.')
     sfs = SFS(estimator=knn,
+              verbose=0,
               k_features=(3, 1))
     assert_raises(AttributeError,
                   expect,
@@ -363,8 +380,7 @@ def test_knn_scoring_metric():
                floating=True,
                scoring='f1_macro',
                cv=4,
-               skip_if_stuck=True,
-    )
+               skip_if_stuck=True)
     sfs7 = sfs7.fit(X, y)
     assert round(sfs7.k_score_, 4) == 0.9727, sfs7.k_score_
 


### PR DESCRIPTION
<!-- Please read the following guidelines for new Pull Requests -- thank you! -->

<!--
Make sure that you submit this pull request as a separate topic branch (and not to "master")
-->

<!-- Provide a small summary describing the Pull Request below -->

### Description

Bugfix that changes the default argument for the `k_features` parameter in the `SequentialFeatureSelector` that was accidentally `'best'` instead of `1`.

