### PR TITLE
Sdq ordering

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,7 +24,7 @@ The CHANGELOG for the current development version is available at
 ##### Bug Fixes
 
 - Fixed wrong default value for `k_features` in `SequentialFeatureSelector`
-- Fixed sdq so that it will not stay stuck if the k_idx are different permutations of the same combination.
+- Fixed sdq so that it will not stay stuck if the k_idx are different permutations of the same combination(via [zacwellmer](https://github.com/zacwellmer)).
 
 
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,7 +24,7 @@ The CHANGELOG for the current development version is available at
 ##### Bug Fixes
 
 - Fixed wrong default value for `k_features` in `SequentialFeatureSelector`
-
+- Fixed sdq so that it will not stay stuck if the k_idx are different permutations of the same combination.
 
 
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,7 +24,7 @@ The CHANGELOG for the current development version is available at
 ##### Bug Fixes
 
 - Fixed wrong default value for `k_features` in `SequentialFeatureSelector`
-- Fixed sdq so that it will not stay stuck if the k_idx are different permutations of the same combination(via [zacwellmer](https://github.com/zacwellmer)).
+- Cast selected feature subsets in the SequentialFeautureSubsets as sets to prevent the iterator from getting stuck if the k_idx are different permutations of the same combination (via [zacwellmer](https://github.com/zacwellmer)).
 
 
 

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -261,7 +261,10 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
                         'cv_scores': cv_scores,
                         'avg_score': k_score
                     }
-                sdq.append(k_idx)
+
+                #k_idx must be a set otherwise different permutations would not be found as
+                #equal in _is_stuck
+                sdq.append(set(k_idx))
 
                 if self.verbose == 1:
                     sys.stderr.write('\rFeatures: %d/%s' % (

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -262,8 +262,8 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
                         'avg_score': k_score
                     }
 
-                #k_idx must be a set otherwise different permutations would not be found as
-                #equal in _is_stuck
+                # k_idx must be a set otherwise different permutations
+                # would not be found as equal in _is_stuck
                 sdq.append(set(k_idx))
 
                 if self.verbose == 1:


### PR DESCRIPTION
### Description
Cast selected feature subsets in the SequentialFeautureSubsets as sets to prevent the iterator from getting stuck if the k_idx are different permutations of the same combination
### Issue
This branch was built in response to ordering issue found in [issue #132](https://github.com/rasbt/mlxtend/issues/132) 

