### PR TITLE
Fix perfomance vs. training size plotting in plot_learning_curve

### DIFF
--- a/mlxtend/plotting/learning_curves.py
+++ b/mlxtend/plotting/learning_curves.py
@@ -94,7 +94,7 @@ def plot_learning_curves(X_train, y_train,
     training_errors = []
     test_errors = []
 
-    rng = [int(i) for i in np.linspace(0, X_train.shape[0], 11)][1:][::-1]
+    rng = [int(i) for i in np.linspace(0, X_train.shape[0], 11)][1:]
     for r in rng:
         model = clf.fit(X_train[:r], y_train[:r])
 


### PR DESCRIPTION
<!-- Please read the following guidelines for new Pull Requests -- thank you! -->

<!--
Make sure that you submit this pull request as a separate topic branch (and not to "master")
-->

<!-- Provide a small summary describing the Pull Request below -->

### Description

I found that picture in [user guide](http://rasbt.github.io/mlxtend/user_guide/plotting/plot_learning_curves/) with learning curve shows (i think) unexpected behaviour (higher misclassification error with larger training size). 