### PR TITLE
StackingClassifier, StackingRegressor: allow multi-target y

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -16,7 +16,7 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - The `EnsembleVoteClassifier` has a new `refit` attribute that prevents refitting classifiers if `refit=False` to save computational time.
-- `StackingClassifier` and `StackingRegressor` support multivariate targets if the underlying models do.
+- `StackingClassifier` and `StackingRegressor` support multivariate targets if the underlying models do (via [kernc](https://github.com/kernc)).
 
 ##### Changes
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -16,6 +16,7 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - The `EnsembleVoteClassifier` has a new `refit` attribute that prevents refitting classifiers if `refit=False` to save computational time.
+- `StackingClassifier` and `StackingRegressor` support multivariate targets if the underlying models do.
 
 ##### Changes
 

--- a/mlxtend/classifier/stacking_classification.py
+++ b/mlxtend/classifier/stacking_classification.py
@@ -79,7 +79,7 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Training vectors, where n_samples is the number of samples and
             n_features is the number of features.
-        y : array-like, shape = [n_samples]
+        y : array-like, shape = [n_samples] or [n_samples, n_outputs]
             Target values.
 
         Returns
@@ -137,7 +137,7 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
             else:
                 vals = np.concatenate(probas, axis=1)
         else:
-            vals = np.asarray([clf.predict(X) for clf in self.clfs_]).T
+            vals = np.column_stack([clf.predict(X) for clf in self.clfs_])
         return vals
 
     def predict(self, X):
@@ -151,7 +151,7 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         Returns
         ----------
-        labels : array-like, shape = [n_samples]
+        labels : array-like, shape = [n_samples] or [n_samples, n_outputs]
             Predicted class labels.
 
         """
@@ -170,7 +170,8 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         Returns
         ----------
-        proba : array-like, shape = [n_samples, n_classes]
+        proba : array-like, shape = [n_samples, n_classes] or a list of \
+                n_outputs of such arrays if n_outputs > 1.
             Probability for each class per sample.
 
         """

--- a/mlxtend/classifier/tests/test_stacking_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_classifier.py
@@ -8,6 +8,7 @@ from mlxtend.classifier import StackingClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import GaussianNB
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.neighbors import KNeighborsClassifier
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import cross_val_score
 from sklearn.exceptions import NotFittedError
@@ -19,6 +20,7 @@ from nose.tools import assert_almost_equal
 
 iris = datasets.load_iris()
 X, y = iris.data[:, 1:3], iris.target
+y2 = np.c_[y, y]
 
 
 def test_StackingClassifier():
@@ -102,6 +104,18 @@ def test_StackingClassifier_avg_vs_concat():
     assert_almost_equal(np.sum(r2[0]), 2.0, places=6)
     assert_almost_equal(np.sum(r2[1]), 2.0, places=6)
     np.array_equal(r2[0][:3], r2[0][3:])
+
+
+def test_multivariate_class():
+    np.random.seed(123)
+    meta = KNeighborsClassifier()
+    clf1 = RandomForestClassifier()
+    clf2 = KNeighborsClassifier()
+    sclf = StackingClassifier(classifiers=[clf1, clf2],
+                              meta_classifier=meta)
+    y_pred = sclf.fit(X, y2).predict(X)
+    ca = .973
+    assert round((y_pred == y2).mean(), 3) == ca
 
 
 def test_gridsearch():

--- a/mlxtend/regressor/stacking_regression.py
+++ b/mlxtend/regressor/stacking_regression.py
@@ -73,7 +73,7 @@ class StackingRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
         X : {array-like, sparse matrix}, shape = [n_samples, n_features]
             Training vectors, where n_samples is the number of samples and
             n_features is the number of features.
-        y : array-like, shape = [n_samples]
+        y : array-like, shape = [n_samples] or [n_samples, n_targets]
             Target values.
 
         Returns
@@ -131,7 +131,7 @@ class StackingRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             return out
 
     def _predict_meta_features(self, X):
-        return np.asarray([r.predict(X) for r in self.regr_]).T
+        return np.column_stack([r.predict(X) for r in self.regr_])
 
     def predict(self, X):
         """ Predict target values for X.
@@ -144,7 +144,7 @@ class StackingRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
 
         Returns
         ----------
-        y_target : array-like, shape = [n_samples]
+        y_target : array-like, shape = [n_samples] or [n_samples, n_targets]
             Predicted target values.
         """
         meta_features = self._predict_meta_features(X)

--- a/mlxtend/regressor/tests/test_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_regression.py
@@ -19,6 +19,7 @@ X1 = np.sort(5 * np.random.rand(40, 1), axis=0)
 X2 = np.sort(5 * np.random.rand(40, 2), axis=0)
 y = np.sin(X1).ravel()
 y[::5] += 3 * (0.5 - np.random.rand(8))
+y2 = np.sin(X2)
 
 
 def test_different_models():
@@ -44,7 +45,18 @@ def test_multivariate():
     stregr.fit(X2, y).predict(X2)
     mse = 0.218
     got = np.mean((stregr.predict(X2) - y) ** 2)
-    print(got)
+    assert round(got, 3) == mse
+
+
+def test_multivariate_class():
+    lr = LinearRegression()
+    ridge = Ridge(random_state=1)
+    meta = LinearRegression(normalize=True)
+    stregr = StackingRegressor(regressors=[lr, ridge],
+                               meta_regressor=meta)
+    stregr.fit(X2, y2).predict(X2)
+    mse = 0.122
+    got = np.mean((stregr.predict(X2) - y2) ** 2)
     assert round(got, 3) == mse
 
 


### PR DESCRIPTION
### Description

Some sklearn models (RF, KNN, LinearRegression, MLP, ...) support fitting target (`y`) in a multivariate way or at least support multiple targets fitted simultaneously. Provided all underlying models support this, there is no reason for `StackingClassifier` and `StackingRegressor` not to.

### Pull Request requirements

- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass
- [x] Checked the test coverage by running `nosetests ./mlxtend --with-coverage`
- [x] Checked for style issues by running `flake8 ./mlxtend`
- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file
- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/` (optional)
- [x] Checked that the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend