### PR TITLE
reindex apriori result

### DIFF
--- a/docs/sources/user_guide/association/apriori.ipynb
+++ b/docs/sources/user_guide/association/apriori.ipynb
@@ -2,42 +2,60 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Frequent Itemsets via Apriori Algorithm"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Apriori function to extract frequent itemsets for association rule mining"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "> from mlxtend.association import apriori"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Overview"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Apriori is a popular algorithm [1] for extracting frequent itemsets with applications in association rule learning. The apriori algorithm has been designed to operate on databases containing transactions, such as purchases by customers of a store. A itemset is considered as \"frequent\" if it meets a user-specified support threshold. For instance, if the support threshold is set to 0.5 (50%), a frequent itemset is defined as a set of items that occur togehter in at least 50% of all transactions in the database."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## References\n",
     "\n",
@@ -46,7 +64,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Example 1"
    ]
@@ -54,7 +75,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "source": [
     "The `apriori` function expects data in a one-hot encoded pandas DataFrame.\n",
@@ -65,7 +88,9 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -78,7 +103,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We can transform it into the right format via the `OnehotTransactions` encoder as follows:"
    ]
@@ -87,7 +115,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -219,7 +249,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Now, let us return the items and itemsets with at least 60% support:"
    ]
@@ -228,7 +261,9 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -241,7 +276,6 @@
        "      <th></th>\n",
        "      <th>support</th>\n",
        "      <th>itemsets</th>\n",
-       "      <th>length</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -249,85 +283,74 @@
        "      <th>0</th>\n",
        "      <td>0.8</td>\n",
        "      <td>[3]</td>\n",
-       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1.0</td>\n",
        "      <td>[5]</td>\n",
-       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[6]</td>\n",
-       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[8]</td>\n",
-       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[10]</td>\n",
-       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>5</th>\n",
        "      <td>0.8</td>\n",
        "      <td>[3, 5]</td>\n",
-       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>6</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[3, 8]</td>\n",
-       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>7</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[5, 6]</td>\n",
-       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>8</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[5, 8]</td>\n",
-       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>9</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[5, 10]</td>\n",
-       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>10</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[3, 5, 8]</td>\n",
-       "      <td>3</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   support   itemsets  length\n",
-       "0      0.8        [3]       1\n",
-       "1      1.0        [5]       1\n",
-       "2      0.6        [6]       1\n",
-       "3      0.6        [8]       1\n",
-       "4      0.6       [10]       1\n",
-       "0      0.8     [3, 5]       2\n",
-       "1      0.6     [3, 8]       2\n",
-       "2      0.6     [5, 6]       2\n",
-       "3      0.6     [5, 8]       2\n",
-       "4      0.6    [5, 10]       2\n",
-       "0      0.6  [3, 5, 8]       3"
+       "    support   itemsets\n",
+       "0       0.8        [3]\n",
+       "1       1.0        [5]\n",
+       "2       0.6        [6]\n",
+       "3       0.6        [8]\n",
+       "4       0.6       [10]\n",
+       "5       0.8     [3, 5]\n",
+       "6       0.6     [3, 8]\n",
+       "7       0.6     [5, 6]\n",
+       "8       0.6     [5, 8]\n",
+       "9       0.6    [5, 10]\n",
+       "10      0.6  [3, 5, 8]"
       ]
      },
      "execution_count": 3,
@@ -343,7 +366,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "By default, `apriori` returns the column indices of the items, which may be useful in downstream operations such as association rule mining. For better readability, we can set `use_colnames=True` to convert these integer values into the respective item names: "
    ]
@@ -351,6 +377,125 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>support</th>\n",
+       "      <th>itemsets</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.8</td>\n",
+       "      <td>[Eggs]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>[Kidney Beans]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Milk]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Onion]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Yogurt]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.8</td>\n",
+       "      <td>[Eggs, Kidney Beans]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Eggs, Onion]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Kidney Beans, Milk]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Kidney Beans, Onion]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Kidney Beans, Yogurt]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>0.6</td>\n",
+       "      <td>[Eggs, Kidney Beans, Onion]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    support                     itemsets\n",
+       "0       0.8                       [Eggs]\n",
+       "1       1.0               [Kidney Beans]\n",
+       "2       0.6                       [Milk]\n",
+       "3       0.6                      [Onion]\n",
+       "4       0.6                     [Yogurt]\n",
+       "5       0.8         [Eggs, Kidney Beans]\n",
+       "6       0.6                [Eggs, Onion]\n",
+       "7       0.6         [Kidney Beans, Milk]\n",
+       "8       0.6        [Kidney Beans, Onion]\n",
+       "9       0.6       [Kidney Beans, Yogurt]\n",
+       "10      0.6  [Eggs, Kidney Beans, Onion]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "apriori(df, min_support=0.6, use_colnames=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The advantage of working with pandas `DataFrames` is that we can use its convenient features to filter the results. For instance, let's assume we are only interested in itemsets of length 2 that have a support of at least 80 percent. First, we create the frequent itemsets via `apriori` and add a new column that stores the length of each itemset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -400,37 +545,37 @@
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>5</th>\n",
        "      <td>0.8</td>\n",
        "      <td>[Eggs, Kidney Beans]</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>6</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[Eggs, Onion]</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>7</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[Kidney Beans, Milk]</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>8</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[Kidney Beans, Onion]</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>9</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[Kidney Beans, Yogurt]</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
+       "      <th>10</th>\n",
        "      <td>0.6</td>\n",
        "      <td>[Eggs, Kidney Beans, Onion]</td>\n",
        "      <td>3</td>\n",
@@ -440,41 +585,101 @@
        "</div>"
       ],
       "text/plain": [
-       "   support                     itemsets  length\n",
-       "0      0.8                       [Eggs]       1\n",
-       "1      1.0               [Kidney Beans]       1\n",
-       "2      0.6                       [Milk]       1\n",
-       "3      0.6                      [Onion]       1\n",
-       "4      0.6                     [Yogurt]       1\n",
-       "0      0.8         [Eggs, Kidney Beans]       2\n",
-       "1      0.6                [Eggs, Onion]       2\n",
-       "2      0.6         [Kidney Beans, Milk]       2\n",
-       "3      0.6        [Kidney Beans, Onion]       2\n",
-       "4      0.6       [Kidney Beans, Yogurt]       2\n",
-       "0      0.6  [Eggs, Kidney Beans, Onion]       3"
+       "    support                     itemsets  length\n",
+       "0       0.8                       [Eggs]       1\n",
+       "1       1.0               [Kidney Beans]       1\n",
+       "2       0.6                       [Milk]       1\n",
+       "3       0.6                      [Onion]       1\n",
+       "4       0.6                     [Yogurt]       1\n",
+       "5       0.8         [Eggs, Kidney Beans]       2\n",
+       "6       0.6                [Eggs, Onion]       2\n",
+       "7       0.6         [Kidney Beans, Milk]       2\n",
+       "8       0.6        [Kidney Beans, Onion]       2\n",
+       "9       0.6       [Kidney Beans, Yogurt]       2\n",
+       "10      0.6  [Eggs, Kidney Beans, Onion]       3"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "apriori(df, min_support=0.6, use_colnames=True)"
+    "frequent_itemsets = apriori(df, min_support=0.6, use_colnames=True)\n",
+    "frequent_itemsets['length'] = frequent_itemsets['itemsets'].apply(lambda x: len(x))\n",
+    "frequent_itemsets"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Then, we can select the results that satisfy our desired criteria as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>support</th>\n",
+       "      <th>itemsets</th>\n",
+       "      <th>length</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.8</td>\n",
+       "      <td>[Eggs, Kidney Beans]</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   support              itemsets  length\n",
+       "5      0.8  [Eggs, Kidney Beans]       2"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "frequent_itemsets[ (frequent_itemsets['length'] == 2) &\n",
+    "                   (frequent_itemsets['support'] >= 0.8) ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
     "## API"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -547,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/mlxtend/association/apriori.py
+++ b/mlxtend/association/apriori.py
@@ -84,6 +84,6 @@ def apriori(df, min_support=0.5, use_colnames=False):
         mapping = {idx: item for idx, item in enumerate(df.columns)}
         res_df['itemsets'] = res_df['itemsets'].apply(lambda x: [mapping[i]
                                                       for i in x])
-    res_df['length'] = res_df['itemsets'].apply(lambda x: len(x))
+    res_df = res_df.reset_index(drop=True)
 
     return res_df


### PR DESCRIPTION
Fixes the `apriori` `DataFrame` indexing issue mentioned in #160 and adds a documentation for the itemset length computation mentioned in #161