### PR TITLE
Support for abstract cv method for StackingCVClassifier

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -26,7 +26,7 @@ The CHANGELOG for the current development version is available at
 - `plot_decision_regions` now supports plotting decision regions for more than 2 training features. (via [James Bourbeau](https://github.com/jrbourbeau)).
 - Parallel execution in `mlxtend.feature_selection.SequentialFeatureSelector` and `mlxtend.feature_selection.ExhaustiveFeatureSelector` is now performed over different feature subsets instead of the different cross-validation folds to better utilize machines with multiple processors if the number of features is large ([#193](https://github.com/rasbt/mlxtend/pull/193), via [@whalebot-helmsman](https://github.com/whalebot-helmsman)).
 - Raise meaningful error messages if pandas `DataFrame`s or Python lists of lists are fed into the StackingCVClassifer as a `fit` arguments.
-- The `StackingCVClassifier` can now accept any kind of cross validation technique by using `cv` argument. E.g. `StackingCVClassifier(..., cv=GroupKFold(n_splits=3))`
+- The `n_folds` parameter of the `StackingCVClassifier` was changed to `cv` and can now accept any kind of cross validation technique that is available from scikit-learn. For example, `StackingCVClassifier(..., cv=StratifiedKFold(n_splits=3)) or StackingCVClassifier(..., cv=GroupKFold(n_splits=3))` (via [Konstantinos Paliouras](https://github.com/sque)).
 
 ##### Bug Fixes
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -26,6 +26,7 @@ The CHANGELOG for the current development version is available at
 - `plot_decision_regions` now supports plotting decision regions for more than 2 training features. (via [James Bourbeau](https://github.com/jrbourbeau)).
 - Parallel execution in `mlxtend.feature_selection.SequentialFeatureSelector` and `mlxtend.feature_selection.ExhaustiveFeatureSelector` is now performed over different feature subsets instead of the different cross-validation folds to better utilize machines with multiple processors if the number of features is large ([#193](https://github.com/rasbt/mlxtend/pull/193), via [@whalebot-helmsman](https://github.com/whalebot-helmsman)).
 - Raise meaningful error messages if pandas `DataFrame`s or Python lists of lists are fed into the StackingCVClassifer as a `fit` arguments.
+- The `StackingCVClassifier` can now accept any kind of cross validation technique by using `cv` argument. E.g. `StackingCVClassifier(..., cv=GroupKFold(n_splits=3))`
 
 ##### Bug Fixes
 

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -15,6 +15,7 @@ import numpy as np
 from sklearn import datasets
 from mlxtend.utils import assert_raises
 from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection import KFold
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import cross_val_score
 
@@ -144,6 +145,28 @@ def test_do_not_stratify():
     sclf = StackingCVClassifier(classifiers=[clf1, clf2],
                                 meta_classifier=meta,
                                 stratify=False)
+
+    scores = cross_val_score(sclf,
+                             X,
+                             y,
+                             cv=5,
+                             scoring='accuracy')
+    scores_mean = (round(scores.mean(), 2))
+    assert scores_mean == 0.94
+
+
+def test_cross_validation_technique():
+    # This is like the `test_do_not_stratify` but instead
+    # autogenerating the cross validation strategy it provides
+    # a pre-created object
+    np.random.seed(123)
+    cv = KFold(n_splits=2, shuffle=True)
+    meta = LogisticRegression()
+    clf1 = RandomForestClassifier()
+    clf2 = GaussianNB()
+    sclf = StackingCVClassifier(classifiers=[clf1, clf2],
+                                meta_classifier=meta,
+                                cv=cv)
 
     scores = cross_val_score(sclf,
                              X,


### PR DESCRIPTION
### Description
Change the API of `StackingCVClassifier` in order to accept any kind of cross-validation technique. 

### Related issues or pull requests

Related #202

### Pull Request requirements

- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass
- [x] Checked the test coverage by running `nosetests ./mlxtend --with-coverage`
- [x] Checked for style issues by running `flake8 ./mlxtend`
- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file
- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/` (optional)
- [ ] Checked that the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend
