### PR TITLE
fix bug where backw selection selected more features than specified

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,7 +24,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- /
+- Fixed a bug where the `SequentialFeatureSelector` selected a feature subset larger than then specified via the `k_features` tuple max-value
 
 
 ### Version 0.7.0 (2017-06-22)

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -212,7 +212,7 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
                                      ' range(1, X.shape[1]+1).')
 
             if self.k_features[0] > self.k_features[1]:
-                raise AttributeError('The min k_features value must be larger'
+                raise AttributeError('The min k_features value must be smaller'
                                      ' than the max k_features value.')
 
         if self.skip_if_stuck:
@@ -244,7 +244,7 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
                 'cv_scores': k_score,
                 'avg_score': k_score.mean()
             }
-
+        print(' k_to_select',  k_to_select)
         best_subset = None
         k_score = 0
         try:
@@ -323,6 +323,8 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         if select_in_range:
             max_score = float('-inf')
             for k in self.subsets_:
+                if k < self.k_features[0] or k > self.k_features[1]:
+                    continue
                 if self.subsets_[k]['avg_score'] > max_score:
                     max_score = self.subsets_[k]['avg_score']
                     best_subset = k

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -119,8 +119,8 @@ def test_kfeatures_type_5():
     X = iris.data
     y = iris.target
     knn = KNeighborsClassifier()
-    expect = ('he min k_features value must be'
-              ' larger than the max k_features value.')
+    expect = ('The min k_features value must be'
+              ' smaller than the max k_features value.')
     sfs = SFS(estimator=knn,
               verbose=0,
               k_features=(3, 1))
@@ -583,3 +583,20 @@ def test_string_scoring_clf():
 
     assert sfs1.k_score_ == sfs2.k_score_
     assert sfs1.k_score_ == sfs3.k_score_
+
+
+def test_max_feature_subset_size_in_tuple_range():
+    boston = load_boston()
+    X, y = boston.data, boston.target
+
+    lr = LinearRegression()
+
+    sfs = SFS(lr,
+              k_features=(1, 5),
+              forward=False,
+              floating=True,
+              scoring='neg_mean_squared_error',
+              cv=10)
+
+    sfs = sfs.fit(X, y)
+    assert len(sfs.k_feature_idx_) == 5


### PR DESCRIPTION
Fixes a bug where the `SequentialFeatureSelector` selected a feature subset larger than then specified via the `k_features` tuple max-value