### PR TITLE
Stacking classifiers from different feature subsets

### DIFF
--- a/docs/sources/user_guide/classifier/EnsembleVoteClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/EnsembleVoteClassifier.ipynb
@@ -441,7 +441,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "clf1 = LogisticRegression(random_state=1)\n",
@@ -762,7 +764,9 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn import model_selection\n",
@@ -816,6 +820,61 @@
    "metadata": {},
    "source": [
     "However, please note that `refit=False` is incompatible to any form of cross-validation that is done in e.g., `model_selection.cross_val_score` or `model_selection.GridSearchCV`, etc., since it would require the classifiers to be refit to the training folds. Thus, only use `refit=False` if you want to make a prediction directly without cross-validation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 6 - Ensembles of Classifiers that Operate on Different Feature Subsets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If desired, the different classifiers can be fit to different subsets of features in the training dataset. The following example illustrates how this can be done on a technical level using scikit-learn pipelines and the `ColumnSelector`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EnsembleVoteClassifier(clfs=[Pipeline(steps=[('columnselector', ColumnSelector(cols=(0, 2))), ('logisticregression', LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+       "          intercept_scaling=1, max_iter=100, multi_class='ovr', n_jobs=1,\n",
+       "          penalty='l2', random_state=None, solver='libl...='l2', random_state=None, solver='liblinear', tol=0.0001,\n",
+       "          verbose=0, warm_start=False))])],\n",
+       "            refit=True, verbose=0, voting='hard', weights=None)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from mlxtend.classifier import EnsembleVoteClassifier\n",
+    "from mlxtend.feature_selection import ColumnSelector\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "iris = load_iris()\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "\n",
+    "pipe1 = make_pipeline(ColumnSelector(cols=(0, 2)),\n",
+    "                      LogisticRegression())\n",
+    "pipe2 = make_pipeline(ColumnSelector(cols=(1, 2, 3)),\n",
+    "                      LogisticRegression())\n",
+    "\n",
+    "eclf = EnsembleVoteClassifier(clfs=[pipe1, pipe2])\n",
+    "\n",
+    "eclf.fit(X, y)"
    ]
   },
   {

--- a/docs/sources/user_guide/classifier/StackingCVClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/StackingCVClassifier.ipynb
@@ -427,6 +427,68 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Example 4 - Stacking of Classifiers that Operate on Different Feature Subsets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The different level-1 classifiers can be fit to different subsets of features in the training dataset. The following example illustrates how this can be done on a technical level using scikit-learn pipelines and the `ColumnSelector`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "StackingCVClassifier(classifiers=[Pipeline(steps=[('columnselector', ColumnSelector(cols=(0, 2))), ('logisticregression', LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+       "          intercept_scaling=1, max_iter=100, multi_class='ovr', n_jobs=1,\n",
+       "          penalty='l2', random_state=None, solve...='l2', random_state=None, solver='liblinear', tol=0.0001,\n",
+       "          verbose=0, warm_start=False))])],\n",
+       "           cv=2,\n",
+       "           meta_classifier=LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+       "          intercept_scaling=1, max_iter=100, multi_class='ovr', n_jobs=1,\n",
+       "          penalty='l2', random_state=None, solver='liblinear', tol=0.0001,\n",
+       "          verbose=0, warm_start=False),\n",
+       "           shuffle=True, stratify=True, use_features_in_secondary=False,\n",
+       "           use_probas=False, verbose=0)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from mlxtend.classifier import StackingCVClassifier\n",
+    "from mlxtend.feature_selection import ColumnSelector\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "iris = load_iris()\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "\n",
+    "pipe1 = make_pipeline(ColumnSelector(cols=(0, 2)),\n",
+    "                      LogisticRegression())\n",
+    "pipe2 = make_pipeline(ColumnSelector(cols=(1, 2, 3)),\n",
+    "                      LogisticRegression())\n",
+    "\n",
+    "sclf = StackingCVClassifier(classifiers=[pipe1, pipe2], \n",
+    "                            meta_classifier=LogisticRegression())\n",
+    "\n",
+    "sclf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# API"
    ]
   },

--- a/docs/sources/user_guide/classifier/StackingClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/StackingClassifier.ipynb
@@ -404,6 +404,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Example 4 - Stacking of Classifiers that Operate on Different Feature Subsets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The different level-1 classifiers can be fit to different subsets of features in the training dataset. The following example illustrates how this can be done on a technical level using scikit-learn pipelines and the `ColumnSelector`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "StackingClassifier(average_probas=False,\n",
+       "          classifiers=[Pipeline(steps=[('columnselector', ColumnSelector(cols=(0, 2))), ('logisticregression', LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+       "          intercept_scaling=1, max_iter=100, multi_class='ovr', n_jobs=1,\n",
+       "          penalty='l2', random_state=None, solve...='l2', random_state=None, solver='liblinear', tol=0.0001,\n",
+       "          verbose=0, warm_start=False))])],\n",
+       "          meta_classifier=LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+       "          intercept_scaling=1, max_iter=100, multi_class='ovr', n_jobs=1,\n",
+       "          penalty='l2', random_state=None, solver='liblinear', tol=0.0001,\n",
+       "          verbose=0, warm_start=False),\n",
+       "          use_features_in_secondary=False, use_probas=False, verbose=0)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from mlxtend.classifier import StackingClassifier\n",
+    "from mlxtend.feature_selection import ColumnSelector\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "iris = load_iris()\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "\n",
+    "pipe1 = make_pipeline(ColumnSelector(cols=(0, 2)),\n",
+    "                      LogisticRegression())\n",
+    "pipe2 = make_pipeline(ColumnSelector(cols=(1, 2, 3)),\n",
+    "                      LogisticRegression())\n",
+    "\n",
+    "sclf = StackingClassifier(classifiers=[pipe1, pipe2], \n",
+    "                          meta_classifier=LogisticRegression())\n",
+    "\n",
+    "sclf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# API"
    ]
   },


### PR DESCRIPTION
This PR adds examples showing how to use scikit-learn pipelines and the `ColumnSelector` to stack classifiers that were fit to different feature subsets.