### PR TITLE
best and parsimonious features for sfs

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -17,12 +17,13 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - Added a `mlxtend.evaluate.bootstrap` that implements the ordinary nonparametric bootstrap to bootstrap a single statistic (for example, the mean. median, R^2 of a regression fit, and so forth) [#232](https://github.com/rasbt/mlxtend/pull/232)
+- `SequentialFeatureSelecor`'s `k_features` now accepts a string argument "best" or "parsimonious" for more "automated" feature selection. For instance, if "best" is provided, the feature selector will return the feature subset with the best cross-validation performance. If "parsimonious" is provided as an argument, the smallest feature subset that is within one standard error of the cross-validation performance will be selected. [#238](https://github.com/rasbt/mlxtend/pull/238)
 
 ##### Changes
 
-- `SequentialFeatureSelector` now uses `np.nanmean` over normal mean to support scorers that may return `np.nan`  [#211](https://github.com/rasbt/mlxtend/pull/211), via [mrkaiser](https://github.com/mrkaiser))
+- `SequentialFeatureSelector` now uses `np.nanmean` over normal mean to support scorers that may return `np.nan`  [#211](https://github.com/rasbt/mlxtend/pull/211) (via [mrkaiser](https://github.com/mrkaiser))
 - The `skip_if_stuck` parameter was removed from `SequentialFeatureSelector` in favor of a more efficient implementation comparing the conditional inclusion/exclusion results (in the floating versions) to the performances of previously sampled feature sets that were cached [#237](https://github.com/rasbt/mlxtend/pull/237)
-- `ExhaustiveFeatureSelector` was modified to consume substantially less memory [#195](https://github.com/rasbt/mlxtend/pull/195), via [Adam Erickson](https://github.com/adam-erickson))
+- `ExhaustiveFeatureSelector` was modified to consume substantially less memory [#195](https://github.com/rasbt/mlxtend/pull/195) (via [Adam Erickson](https://github.com/adam-erickson))
 
 ##### Bug Fixes
 

--- a/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
+++ b/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
@@ -1451,7 +1451,7 @@
       "- `estimator` : scikit-learn classifier or regressor\n",
       "\n",
       "\n",
-      "- `k_features` : int or tuple (new in 0.4.2) (default: 1)\n",
+      "- `k_features` : int or tuple or str (default: 1)\n",
       "\n",
       "    Number of features to select,\n",
       "    where k_features < the full feature set.\n",
@@ -1460,6 +1460,12 @@
       "    min and max that scored highest in cross-validtion. For example,\n",
       "    the tuple (1, 4) will return any combination from\n",
       "    1 up to 4 features instead of a fixed number of features k.\n",
+      "    New in 0.8.0: A string argument \"best\" or \"parsimonious\".\n",
+      "    If \"best\" is provided, the feature selector will return the\n",
+      "    feature subset with the best cross-validation performance.\n",
+      "    If \"parsimonious\" is provided as an argument, the smallest\n",
+      "    feature subset that is within one standard error of the\n",
+      "    cross-validation performance will be selected.\n",
       "\n",
       "- `forward` : bool (default: True)\n",
       "\n",
@@ -1670,6 +1676,15 @@
     "    s = f.read()\n",
     "print(s)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -83,10 +83,10 @@ def test_kfeatures_type_2():
     X = iris.data
     y = iris.target
     knn = KNeighborsClassifier()
-    expect = 'k_features must be a positive integer or tuple'
+    expect = 'k_features must be a positive integer, tuple, or string'
     sfs = SFS(estimator=knn,
               verbose=0,
-              k_features='abc')
+              k_features=set())
     assert_raises(AttributeError,
                   expect,
                   sfs.fit,
@@ -458,10 +458,6 @@ def test_regression_in_range():
 
 
 def test_clone_params_fail():
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
-
     if sys.version_info >= (3, 0):
         objtype = 'class'
     else:
@@ -504,7 +500,6 @@ def test_clone_params_pass():
 def test_transform_not_fitted():
     iris = load_iris()
     X = iris.data
-    y = iris.target
     knn = KNeighborsClassifier(n_neighbors=4)
 
     sfs1 = SFS(knn,
@@ -525,9 +520,6 @@ def test_transform_not_fitted():
 
 
 def test_get_metric_dict_not_fitted():
-    iris = load_iris()
-    X = iris.data
-    y = iris.target
     knn = KNeighborsClassifier(n_neighbors=4)
 
     sfs1 = SFS(knn,
@@ -642,3 +634,33 @@ def test_max_feature_subset_size_in_tuple_range():
 
     sfs = sfs.fit(X, y)
     assert len(sfs.k_feature_idx_) == 5
+
+
+def test_max_feature_subset_best():
+    boston = load_boston()
+    X, y = boston.data, boston.target
+    lr = LinearRegression()
+
+    sfs = SFS(lr,
+              k_features='best',
+              forward=True,
+              floating=False,
+              cv=10)
+
+    sfs = sfs.fit(X, y)
+    assert sfs.k_feature_idx_ == (1, 3, 5, 7, 8, 9, 10, 11, 12)
+
+
+def test_max_feature_subset_parsimonious():
+    boston = load_boston()
+    X, y = boston.data, boston.target
+    lr = LinearRegression()
+
+    sfs = SFS(lr,
+              k_features='parsimonious',
+              forward=True,
+              floating=False,
+              cv=10)
+
+    sfs = sfs.fit(X, y)
+    assert sfs.k_feature_idx_ == (10, 11, 12, 5)


### PR DESCRIPTION
`SequentialFeatureSelecor`'s `k_features` now accepts a string argument "best" or "parsimonious" for more "automated" feature selection. For instance, if "best" is provided, the feature selector will return the feature subset with the best cross-validation performance. If "parsimonious" is provided as an argument, the smallest feature subset that is within one standard error of the cross-validation performance will be selected. [#238](https://github.com/rasbt/mlxtend/pull/238)