### PR TITLE
rename association rules columns

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -19,7 +19,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- 
+- The `'support'` column returned by `frequent_patterns.association_rules` was renamed to `'antecedant support'`, and an additional `'consequent support'` column was added, to avoid ambiguity. 
 
 ##### Bug Fixes
 

--- a/mlxtend/frequent_patterns/association_rules.py
+++ b/mlxtend/frequent_patterns/association_rules.py
@@ -44,11 +44,14 @@ def association_rules(df, metric="confidence", min_threshold=0.8):
 
     # metrics for association rules
     metric_dict = {
-        "confidence": lambda sXY, sX, _:
-        sXY/sX,
-        "lift": lambda sXY, sX, sY:
-        metric_dict["confidence"](sXY, sX, sY)/sY
+        "antecedent support": lambda _, sX, __: sX,
+        "consequent support": lambda _, __, sY: sY,
+        "confidence": lambda sXY, sX, _: sXY/sX,
+        "lift": lambda sXY, sX, sY: metric_dict["confidence"](sXY, sX, sY)/sY
         }
+
+    columns_ordered = ["antecedent support", "consequent support",
+                       "confidence", "lift"]
 
     # check for metric compliance
     if metric not in metric_dict.keys():
@@ -86,8 +89,7 @@ def association_rules(df, metric="confidence", min_threshold=0.8):
     # check if frequent rule was generated
     if not rule_supports:
         return pd.DataFrame(
-            columns=["antecedants", "consequents", "support"]
-            .append(list(metric_dict.keys())))
+            columns=["antecedants", "consequents"] + columns_ordered)
     else:
         # generate metrics
         rule_supports = np.array(rule_supports).T
@@ -95,9 +97,9 @@ def association_rules(df, metric="confidence", min_threshold=0.8):
         sX = rule_supports[1]
         sY = rule_supports[2]
         df_res = pd.DataFrame(
-            data=list(zip(rule_antecedants, rule_consequents, sX)),
-            columns=["antecedants", "consequents", "support"])
-        for m in sorted(metric_dict.keys()):
+            data=list(zip(rule_antecedants, rule_consequents)),
+            columns=["antecedants", "consequents"])
+        for m in columns_ordered:
             df_res[m] = metric_dict[m](sXY, sX, sY)
 
         return df_res

--- a/mlxtend/frequent_patterns/tests/test_association_rules.py
+++ b/mlxtend/frequent_patterns/tests/test_association_rules.py
@@ -16,24 +16,43 @@ df = pd.DataFrame(one_ary, columns=cols)
 
 df_freq_items = apriori(df, min_support=0.6)
 
+columns_ordered = ['antecedants', 'consequents',
+                   'antecedent support', 'consequent support',
+                   'confidence', 'lift']
+
 
 def test_default():
     res_df = association_rules(df_freq_items)
+    #res_df['antecedants'] = res_df['antecedants'].apply(lambda x: str(x))
+    res_df['antecedants'] = res_df['antecedants'].apply(lambda x: str(frozenset(x)))
+    res_df['consequents'] = res_df['consequents'].apply(lambda x: str(frozenset(x)))
+    res_df.sort_values(columns_ordered, inplace=True)
+    res_df.reset_index(inplace=True, drop=True)
+
     expect = pd.DataFrame([
-        [(8), (5), 0.6, 1.0, 1.0],
-        [(6), (5), 0.6, 1.0, 1.0],
-        [(8, 3), (5), 0.6, 1.0, 1.0],
-        [(8, 5), (3), 0.6, 1.0, 1.25],
-        [(8), (3, 5), 0.6, 1.0, 1.25],
-        [(3), (5), 0.8, 1.0, 1.0],
-        [(5), (3), 1.0, 0.8, 1.0],
-        [(10), (5), 0.6, 1.0, 1.0],
-        [(8), (3), 0.6, 1.0, 1.25]],
-        columns=['antecedants', 'consequents', 'support', 'confidence', 'lift']
+        [(8,), (5,), 0.6, 1.0, 1.0, 1.0],
+        [(6,), (5,), 0.6, 1.0, 1.0, 1.0],
+        [(8, 3), (5,), 0.6, 1.0, 1.0, 1.0],
+        [(8, 5), (3,), 0.6, 0.8, 1.0, 1.25],
+        [(8,), (3, 5), 0.6, 0.8, 1.0, 1.25],
+        [(3,), (5,), 0.8, 1.0, 1.0, 1.0],
+        [(5,), (3,), 1.0, 0.8, 0.8, 1.0],
+        [(10,), (5,), 0.6, 1.0, 1.0, 1.0],
+        [(8,), (3,), 0.6, 0.8, 1.0, 1.25]],
+        columns=columns_ordered
     )
 
-    for a, b in zip(res_df, expect):
-        assert_array_equal(a, b)
+    #expect['antecedants'] = expect['antecedants'].apply(lambda x: str(tuple(x)))
+    #print(expect['antecedants'].values)
+    expect['antecedants'] = expect['antecedants'].apply(lambda x: str(frozenset(x)))
+    expect['consequents'] = expect['consequents'].apply(lambda x: str(frozenset(x)))
+    expect.sort_values(columns_ordered, inplace=True)
+    expect.reset_index(inplace=True, drop=True)
+
+    print(res_df)
+    print(expect)
+
+    assert res_df.equals(expect)
 
 
 def test_no_support_col():
@@ -52,9 +71,13 @@ def test_wrong_metric():
 
 def test_empty_result():
     expect = pd.DataFrame(
-        columns=['antecedants', 'consequents', 'support', 'confidence', 'lift']
+        columns=['antecedants', 'consequents',
+                 'antecedent support', 'consequent support',
+                 'confidence', 'lift']
     )
     res_df = association_rules(df_freq_items, min_threshold=2)
 
-    for a, b in zip(res_df, expect):
-        assert_array_equal(a, b)
+    print(res_df)
+    print(expect)
+
+    assert res_df.equals(expect)

--- a/mlxtend/frequent_patterns/tests/test_association_rules.py
+++ b/mlxtend/frequent_patterns/tests/test_association_rules.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from mlxtend.frequent_patterns import apriori, association_rules
-from numpy.testing import assert_array_equal, assert_raises
+from numpy.testing import assert_raises
 
 one_ary = np.array([[0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1],
                     [0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1],
@@ -23,9 +23,10 @@ columns_ordered = ['antecedants', 'consequents',
 
 def test_default():
     res_df = association_rules(df_freq_items)
-    #res_df['antecedants'] = res_df['antecedants'].apply(lambda x: str(x))
-    res_df['antecedants'] = res_df['antecedants'].apply(lambda x: str(frozenset(x)))
-    res_df['consequents'] = res_df['consequents'].apply(lambda x: str(frozenset(x)))
+    res_df['antecedants'] = res_df['antecedants'].apply(
+        lambda x: str(frozenset(x)))
+    res_df['consequents'] = res_df['consequents'].apply(
+        lambda x: str(frozenset(x)))
     res_df.sort_values(columns_ordered, inplace=True)
     res_df.reset_index(inplace=True, drop=True)
 
@@ -42,10 +43,10 @@ def test_default():
         columns=columns_ordered
     )
 
-    #expect['antecedants'] = expect['antecedants'].apply(lambda x: str(tuple(x)))
-    #print(expect['antecedants'].values)
-    expect['antecedants'] = expect['antecedants'].apply(lambda x: str(frozenset(x)))
-    expect['consequents'] = expect['consequents'].apply(lambda x: str(frozenset(x)))
+    expect['antecedants'] = expect['antecedants'].apply(
+        lambda x: str(frozenset(x)))
+    expect['consequents'] = expect['consequents'].apply(
+        lambda x: str(frozenset(x)))
     expect.sort_values(columns_ordered, inplace=True)
     expect.reset_index(inplace=True, drop=True)
 


### PR DESCRIPTION
- The `'support'` column returned by `frequent_patterns.association_rules` was renamed to `'antecedant support'`, and an additional `'consequent support'` column was added, to avoid ambiguity. 