### PR TITLE
Refactor StackingCVRegressor so that users can obtain meta_features

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -17,6 +17,7 @@ The CHANGELOG for the current development version is available at
 - New `max_len` parameter for the frequent itemset generation via the `apriori` function to allow for early stopping. ([#270](https://github.com/rasbt/mlxtend/pull/270))
 - New `store_train_meta_features` parameter for `fit` in StackingCVRegressor. if True, train meta-features are stored in `self.train_meta_features_`.
     New `pred_meta_features` method for StackingCVRegressor. People can get test meta-features using this method. ([#294](https://github.com/rasbt/mlxtend/pull/294))
+    via [takashioya](https://github.com/takashioya))
 
 ##### Changes
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -15,6 +15,8 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - New `max_len` parameter for the frequent itemset generation via the `apriori` function to allow for early stopping. ([#270](https://github.com/rasbt/mlxtend/pull/270))
+- New `store_train_meta_features` parameter for `fit` in StackingCVRegressor. if True, train meta-features are stored in `self.train_meta_features_`.
+    New `pred_meta_features` method for StackingCVRegressor. People can get test meta-features using this method. ([#294](https://github.com/rasbt/mlxtend/pull/294))
 
 ##### Changes
 

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -67,8 +67,16 @@ class StackingCVRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
         argument is a specific cross validation technique, this argument is
         omitted.
     store_train_meta_features : bool (default: False)
-        If True, meta-features for training data is stored when you `fit`
-        training data. You can get them by `self.train_meta_features_`.
+        If True, the meta-features computed from the training data used for fitting the
+        meta-regressor stored in the `self.train_meta_features_` array, which can be
+        accessed after calling `fit`.
+
+    Attributes
+    ----------
+    train_meta_features : numpy array, shape = [n_samples, len(self.regressors)]
+        meta-features for training data, where n_samples is the number of samples
+        in training data and len(self.regressors) is the number of regressors.
+
     """
     def __init__(self, regressors, meta_regressor, cv=5,
                  shuffle=True,

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -173,11 +173,21 @@ class StackingCVRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             return self.meta_regr_.predict(meta_features)
 
     def predict_meta_features(self, X):
-        #
-        # If you pass test data, you can get test meta-features.
-        # If you would like to get training meta-features,
-        # please use self.train_meta_features_
-        #
+        """ Get meta-features of test-data.
+
+        Parameters
+        ----------
+        X : numpy array, shape = [n_samples, n_features]
+            Test vectors, where n_samples is the number of samples and
+            n_features is the number of features.
+
+        Returns
+        -------
+        meta-features : numpy array, shape = [n_samples, len(self.regressors)]
+            meta-features for test data, where n_samples is the number of
+            samples in test data and len(self.regressors) is the number of regressors.
+
+        """
         return np.column_stack([regr.predict(X) for regr in self.regr_])
 
     def get_params(self, deep=True):

--- a/mlxtend/regressor/tests/test_cv_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_cv_stacking_regression.py
@@ -12,7 +12,7 @@ from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import Ridge
 from sklearn.svm import SVR
 import numpy as np
-from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection import GridSearchCV, train_test_split
 
 
 # Some test data
@@ -140,3 +140,26 @@ def test_regressor_gridsearch():
     grid.fit(X1, y)
 
     assert len(grid.best_params_['regressors']) == 3
+
+def test_predict_meta_features():
+    lr = LinearRegression()
+    svr_rbf = SVR(kernel='rbf')
+    ridge = Ridge(random_state=1)
+    stregr = StackingCVRegressor(regressors=[lr],
+                                 meta_regressor=svr_rbf)
+    X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size = 0.3)
+    stregr.fit(X_train, y_train)
+    test_meta_features = stregr.predict(X_test)
+    assert test_meta_features.shape[0] == X_test.shape[0]
+
+def test_train_meta_features_():
+    lr = LinearRegression()
+    svr_rbf = SVR(kernel='rbf')
+    ridge = Ridge(random_state=1)
+    stregr = StackingCVRegressor(regressors=[lr],
+                                 meta_regressor=svr_rbf,
+                                 store_train_meta_features = True)
+    X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size = 0.3)
+    stregr.fit(X_train, y_train)
+    train_meta_features = stregr.train_meta_features_
+    assert train_meta_features.shape[0] == X_train.shape[0]

--- a/mlxtend/regressor/tests/test_cv_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_cv_stacking_regression.py
@@ -164,4 +164,4 @@ def test_train_meta_features_():
     X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size=0.3)
     stregr.fit(X_train, y_train)
     train_meta_features = stregr.train_meta_features_
-    assert train_meta_features.shape[0] == X_train.shape[0] 
+    assert train_meta_features.shape[0] == X_train.shape[0]

--- a/mlxtend/regressor/tests/test_cv_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_cv_stacking_regression.py
@@ -147,7 +147,7 @@ def test_predict_meta_features():
     lr = LinearRegression()
     svr_rbf = SVR(kernel='rbf')
     ridge = Ridge(random_state=1)
-    stregr = StackingCVRegressor(regressors=[lr],
+    stregr = StackingCVRegressor(regressors=[lr, ridge],
                                  meta_regressor=svr_rbf)
     X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size=0.3)
     stregr.fit(X_train, y_train)
@@ -159,7 +159,7 @@ def test_train_meta_features_():
     lr = LinearRegression()
     svr_rbf = SVR(kernel='rbf')
     ridge = Ridge(random_state=1)
-    stregr = StackingCVRegressor(regressors=[lr],
+    stregr = StackingCVRegressor(regressors=[lr, ridge],
                                  meta_regressor=svr_rbf,
                                  store_train_meta_features=True)
     X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size=0.3)

--- a/mlxtend/regressor/tests/test_cv_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_cv_stacking_regression.py
@@ -120,7 +120,8 @@ def test_get_params():
               'regressors',
               'ridge',
               'shuffle',
-              'use_features_in_secondary']
+              'store_train_meta_features',
+              'use_features_in_secondary',]
     assert got == expect, got
 
 

--- a/mlxtend/regressor/tests/test_cv_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_cv_stacking_regression.py
@@ -141,16 +141,18 @@ def test_regressor_gridsearch():
 
     assert len(grid.best_params_['regressors']) == 3
 
+
 def test_predict_meta_features():
     lr = LinearRegression()
     svr_rbf = SVR(kernel='rbf')
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr],
                                  meta_regressor=svr_rbf)
-    X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size = 0.3)
+    X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size=0.3)
     stregr.fit(X_train, y_train)
     test_meta_features = stregr.predict(X_test)
     assert test_meta_features.shape[0] == X_test.shape[0]
+
 
 def test_train_meta_features_():
     lr = LinearRegression()
@@ -158,8 +160,8 @@ def test_train_meta_features_():
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr],
                                  meta_regressor=svr_rbf,
-                                 store_train_meta_features = True)
-    X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size = 0.3)
+                                 store_train_meta_features=True)
+    X_train, X_test, y_train, y_test = train_test_split(X2, y, test_size=0.3)
     stregr.fit(X_train, y_train)
     train_meta_features = stregr.train_meta_features_
-    assert train_meta_features.shape[0] == X_train.shape[0]
+    assert train_meta_features.shape[0] == X_train.shape[0] 


### PR DESCRIPTION
<!-- Please read the following guidelines for new Pull Requests -- thank you! -->

<!--
Make sure that you submit this pull request as a separate topic or feature branch and not as master branch. The new feature branch of your fork will then be merged to the master branch of the original repository, following the "Fork-and-Branch Git Workflow:"

1. Fork the original GitHub project
2. Clone the fork to your local machine
3. Create a new topic branch
4. Make your code changes to this new topic branch
5. Commit the changes and push the commit to the topic branch to your fork upstream on GitHub
6. Create a new pull request from the upstream topic branch to the master branch of the original repo
-->

<!-- Provide a small summary describing the Pull Request below -->

### Description

modify fit and add an attribute self.train_meta_features_ for obtaining train meta-features,
and add a method predict_meta_features for obtaining test meta-features.
Sorry, I closed the previous PR https://github.com/rasbt/mlxtend/pull/294 by mistake, so I opened new one.

### Related issues or pull requests

<!-- Please provide a link to the respective issue on the [Issue Tracker](https://github.com/rasbt/mlxtend/issues) if one exists. E.g.,

Fixes #<ISSUE_NUMBER> -->

https://github.com/rasbt/mlxtend/issues/285
https://github.com/rasbt/mlxtend/issues/290
https://github.com/rasbt/mlxtend/pull/294

<!-- Below is a general todo list for typical pull request -->

### Pull Request requirements

- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass
- [x] Checked the test coverage by running `nosetests ./mlxtend --with-coverage`
- [ ] Checked for style issues by running `flake8 ./mlxtend`
- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file
- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/` (optional)
- [x] Checked that the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend




<!--
NOTE

Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).

For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/
-->
