### PR TITLE
Nose is not required for running

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -32,7 +32,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- -
+- `nose` is not required to use the library ([#302](https://github.com/rasbt/mlxtend/issues/302))
 
 ### Version 0.9.1 (2017-11-19)
 

--- a/mlxtend/evaluate/permutation.py
+++ b/mlxtend/evaluate/permutation.py
@@ -9,7 +9,12 @@
 import numpy as np
 from itertools import combinations
 from math import factorial
-from nose.tools import nottest
+try:
+    from nose.tools import nottest
+except ImportError:
+    # Use a no-op decorator if nose is not available
+    def nottest(f):
+        return f
 
 
 # decorator to prevent nose to consider


### PR DESCRIPTION
### Description
Library does not require `nose` to run.  I did a quick grep and a quick `from mlxtend import *` to confirm 

### Related issues or pull requests
Fixes #302 

### Pull Request requirements

I did not add a test! We tested for "not requiring matplotlib" in `pymc3`, and it was a bit of a pain.  I can do the same here if you feel strongly.  Also, there are a bunch of flake8 failures not related to this change - it seems like this would be a bad PR adressing those.

- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass
- [x] Checked the test coverage by running `nosetests ./mlxtend --with-coverage`
- [~] Checked for style issues by running `flake8 ./mlxtend`
- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file
- [ ] Modify documentation in the appropriate location under `mlxtend/docs/sources/` (optional)
- [ ] Checked that the Travis-CI build passed at https://travis-ci.org/rasbt/mlxtend




