### PR TITLE
Removes a few duplicate lines from SequentialFeatureSelector __init__

### DIFF
--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -140,10 +140,6 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         self.pre_dispatch = pre_dispatch
         self.cv = cv
         self.n_jobs = n_jobs
-        self.named_est = {key: value for key, value in
-                          _name_estimators([self.estimator])}
-        self.cv = cv
-        self.n_jobs = n_jobs
         self.verbose = verbose
         self.named_est = {key: value for key, value in
                           _name_estimators([self.estimator])}

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -403,7 +403,8 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         self.fitted = True
         return self
 
-    def _inclusion(self, orig_set, subset, X, y, ignore_feature=None, **fit_params):
+    def _inclusion(self, orig_set, subset, X, y, ignore_feature=None,
+                   **fit_params):
         all_avg_scores = []
         all_cv_scores = []
         all_subsets = []
@@ -415,7 +416,9 @@ class SequentialFeatureSelector(BaseEstimator, MetaEstimatorMixin):
             parallel = Parallel(n_jobs=n_jobs, verbose=self.verbose,
                                 pre_dispatch=self.pre_dispatch)
             work = parallel(delayed(_calc_score)
-                            (self, X, y, tuple(subset | {feature}), **fit_params)
+                            (self, X, y,
+                             tuple(subset | {feature}),
+                             **fit_params)
                             for feature in remaining
                             if feature != ignore_feature)
 


### PR DESCRIPTION
### Description

<!--  
Please insert a brief description of the Pull request here
-->

I ran across a few lines that appear to be duplicates of previous lines in the `SequentialFeatureSelector.__init__` method. This PR simply removes the duplicates. 


### Pull Request Checklist

- [ ] ~~Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)~~
- [ ] ~~Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)~~
- [ ] ~~Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)~~
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
