### PR TITLE
gram schmidt process for orthonormal basis vectors and checking dimensionality

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -95,6 +95,8 @@ pages:
   - math:
     - user_guide/math/num_combinations.md
     - user_guide/math/num_permutations.md
+    - user_guide/math/vectorspace_dimensionality.md
+    - user_guide/math/vectorspace_orthonormalization.md
   - plotting:
     - user_guide/plotting/category_scatter.md
     - user_guide/plotting/checkerboard_plot.md

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -21,6 +21,7 @@ The CHANGELOG for the current development version is available at
 - The `SequentialFeatureSelector` is now also compatible with Pandas DataFrames and uses DataFrame column-names for more interpretable feature subset reports. ([#379](https://github.com/rasbt/mlxtend/pull/379))
 - `ColumnSelector` now works with Pandas DataFrames columns. ([#378](https://github.com/rasbt/mlxtend/pull/378) by [Manuel Garrido](https://github.com/manugarri))
 - The `ExhaustiveFeatureSelector` estimator in `mlxtend.feature_selection` now is safely stoppable mid-process by control+c. ([#380](https://github.com/rasbt/mlxtend/pull/380))
+- Two new functions, `vectorspace_orthonormalization` and `vectorspace_dimensionality` were added to `mlxtend.math` to use the Gram-Schmidt process to convert an orthogonal vectorspace into orthonormal basis vectors and to compute the dimensionality of a vectorspace, respectively. ([#382](https://github.com/rasbt/mlxtend/pull/382))
 
 
 ##### Changes

--- a/docs/sources/user_guide/math/vectorspace_dimensionality.ipynb
+++ b/docs/sources/user_guide/math/vectorspace_dimensionality.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vectorspace Dimensionality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A function to compute the number of dimensions a set of vectors (arranged as columns in a matrix) spans."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> from mlxtend.math import vectorspace_dimensionality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given a set of vectors, arranged as columns in a matrix, the `vectorspace_dimensionality` computes the number of dimensions (i.e., hyper-volume) that the vectorspace spans using the Gram-Schmidt process [1]. In particular, since the Gram-Schmidt process yields vectors that are zero or normalized to 1 (i.e., an orthonormal vectorset if the input was an orthogonal vectorset), the sum of the vector norms corresponds to the number of dimensions of a vectorset. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "\n",
+    "- [1] https://en.wikipedia.org/wiki/Gram–Schmidt_process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1 - Compute the dimensions of a vectorspace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's assume we have the two basis vectors $x=[1 \\;\\;\\; 0]^T$ and $y=[0\\;\\;\\; 1]^T$ as columns in a matrix. Due to the linear independence of the two vectors, the space that they span is naturally a plane (2D space):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from mlxtend.math import vectorspace_dimensionality\n",
+    "\n",
+    "\n",
+    "a = np.array([[1, 0],\n",
+    "              [0, 1]])\n",
+    "\n",
+    "vectorspace_dimensionality(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, if one vector is a linear combination of the other, it's intuitive to see that the space the vectorset describes is merely a line, aka a 1D space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b = np.array([[1, 2],\n",
+    "              [0, 0]])\n",
+    "\n",
+    "vectorspace_dimensionality(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If 3 vectors are all linearly independent of each other, the dimensionality of the vector space is a volume (i.e., a 3D space):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = np.array([[1, 9,  1],\n",
+    "              [3, 2,  2],\n",
+    "              [5, 4,  3]])\n",
+    "\n",
+    "vectorspace_dimensionality(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, if a pair of vectors is linearly dependent (here: the 1st and the 2nd row), this reduces the dimensionality by 1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c = np.array([[1, 2,  1],\n",
+    "              [3, 6,  2],\n",
+    "              [5, 10, 3]])\n",
+    "\n",
+    "vectorspace_dimensionality(c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## vectorspace_dimensionality\n",
+      "\n",
+      "*vectorspace_dimensionality(ary)*\n",
+      "\n",
+      "Computes the hyper-volume spanned by a vector set\n",
+      "\n",
+      "**Parameters**\n",
+      "\n",
+      "- `ary` : array-like, shape=[num_vectors, num_vectors]\n",
+      "\n",
+      "    An orthogonal set of vectors (arranged as columns in a matrix)\n",
+      "\n",
+      "**Returns**\n",
+      "\n",
+      "- `dimensions` : int\n",
+      "\n",
+      "    An integer indicating the \"dimensionality\" hyper-volume spanned by\n",
+      "    the vector set\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open('../../api_modules/mlxtend.math/vectorspace_dimensionality.md', 'r') as f:\n",
+    "    print(f.read())"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/docs/sources/user_guide/math/vectorspace_orthonormalization.ipynb
+++ b/docs/sources/user_guide/math/vectorspace_orthonormalization.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vectorspace Orthonormalization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A function that converts a set of orthogonal vectors to a set of orthonormal basis vectors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> from mlxtend.math import vectorspace_orthonormalization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `vectorspace_orthonormalization` converts a set of orthogonal vectors to a set of orthonormal basis vectors using the Gram-Schmidt process [1]. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "\n",
+    "- [1] https://en.wikipedia.org/wiki/Gram–Schmidt_process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1 - Convert a set of vector to an orthonormal basis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that to convert a set of orthogonal vectors into a set of orthonormal basis vectors, the `vectorspace_orthonormalization` function expects the vectors to be arranged as columns of a matrix (here: NumPy array). Please keep in mind that the `vectorspace_orthonormalization` function also works for non orthogonal vector sets; however, the resulting vectorset won't be orthonormal as a result. An easy way to check whether all vectors in the input set are orthogonal is to use the `numpy.linalg.det` (determinant) function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input vectors are linearly independent\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.40824829, -0.1814885 ,  0.04982278,  0.89325973],\n",
+       "       [ 0.        ,  0.1088931 ,  0.99349591, -0.03328918],\n",
+       "       [ 0.81649658,  0.50816781, -0.06462163, -0.26631346],\n",
+       "       [ 0.40824829, -0.83484711,  0.07942048, -0.36063281]])"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from mlxtend.math import vectorspace_orthonormalization\n",
+    "    \n",
+    "a = np.array([[2,   0,   4,  12],\n",
+    "              [0,   2,  16,   4],\n",
+    "              [4,  16,   6,   2],\n",
+    "              [2, -12,   4,   6]])\n",
+    "\n",
+    "\n",
+    "s = ''\n",
+    "if np.linalg.det(a) == 0.0:\n",
+    "    s = ' not'\n",
+    "print('Input vectors are%s linearly independent' % s)\n",
+    "\n",
+    "\n",
+    "vectorspace_orthonormalization(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that scaling the inputs equally by a factor should leave the results unchanged:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.40824829, -0.1814885 ,  0.04982278,  0.89325973],\n",
+       "       [ 0.        ,  0.1088931 ,  0.99349591, -0.03328918],\n",
+       "       [ 0.81649658,  0.50816781, -0.06462163, -0.26631346],\n",
+       "       [ 0.40824829, -0.83484711,  0.07942048, -0.36063281]])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vectorspace_orthonormalization(a/2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, in case of linear dependence(the second column is a linear combination of the first column in the example below), the vector elements of one of the dependent vectors will become zero. (For a pair of linear dependent vectors, the one with the larger column index will be the one that's zero-ed.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0.40824829,  0.        ,  0.04155858,  0.82364839],\n",
+       "       [ 0.        ,  0.        ,  0.99740596, -0.06501108],\n",
+       "       [ 0.81649658,  0.        , -0.04155858, -0.52008861],\n",
+       "       [ 0.40824829,  0.        ,  0.04155858,  0.21652883]])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a[:, 1] = a[:, 0] * 2\n",
+    "vectorspace_orthonormalization(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## vectorspace_orthonormalization\n",
+      "\n",
+      "*vectorspace_orthonormalization(ary, eps=1e-13)*\n",
+      "\n",
+      "Transforms a set of column vectors to a orthonormal basis.\n",
+      "\n",
+      "Given a set of orthogonal vectors, this functions converts such\n",
+      "column vectors, arranged in a matrix, into orthonormal basis\n",
+      "vectors.\n",
+      "\n",
+      "**Parameters**\n",
+      "\n",
+      "- `ary` : array-like, shape=[num_vectors, num_vectors]\n",
+      "\n",
+      "    An orthogonal set of vectors (arranged as columns in a matrix)\n",
+      "\n",
+      "\n",
+      "- `eps` : float (default: 1e-13)\n",
+      "\n",
+      "    A small tolerance value to determine whether\n",
+      "    the vector norm is zero or not.\n",
+      "\n",
+      "**Returns**\n",
+      "\n",
+      "- `arr` : array-like, shape=[num_vectors, num_vectors]\n",
+      "\n",
+      "    An orthonormal set of vectors (arranged as columns)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open('../../api_modules/mlxtend.math/vectorspace_orthonormalization.md', 'r') as f:\n",
+    "    print(f.read())"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/mlxtend/math/__init__.py
+++ b/mlxtend/math/__init__.py
@@ -7,6 +7,9 @@
 from .counting import num_combinations
 from .counting import num_permutations
 from .counting import factorial
+from .linalg import vectorspace_orthonormalization
+from .linalg import vectorspace_dimensionality
 
 __all__ = ["num_combinations", "num_permutations",
-           "factorial"]
+           "factorial", "vectorspace_orthonormalization",
+           "vectorspace_dimensionality"]

--- a/mlxtend/math/linalg.py
+++ b/mlxtend/math/linalg.py
@@ -1,0 +1,92 @@
+# Sebastian Raschka 2014-2018
+# mlxtend Machine Learning Library Extensions
+#
+# Functions for different linear algebra operations.
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+import numpy as np
+
+
+def vectorspace_orthonormalization(ary,  # method='gram-schmidt',
+                                   eps=1e-13):
+    """Transforms a set of column vectors to a orthonormal basis.
+
+    Given a set of orthogonal vectors, this functions converts such
+    column vectors, arranged in a matrix, into orthonormal basis
+    vectors.
+
+    Parameters
+    ----------
+    ary : array-like, shape=[num_vectors, num_vectors]
+        An orthogonal set of vectors (arranged as columns in a matrix)
+
+    eps : float (default: 1e-13)
+        A small tolerance value to determine whether
+        the vector norm is zero or not.
+
+    Returns
+    ----------
+    arr : array-like, shape=[num_vectors, num_vectors]
+        An orthonormal set of vectors (arranged as columns)
+
+    """
+
+    # Gram-Schmidt Process
+    #  1) col i for i = 0: keep & normalize:
+    #  2) col i for i > 1:
+    #   2a) project column i+1 onto i
+    #   2b) subtract column i from projection vector
+    #   2c) Normalize if linearly independent,
+    #       and set to zero otherwise
+
+    arr = ary.astype(np.float).copy()
+
+    for i in range(arr.shape[1]):
+        for j in range(i):
+            # 2a) & 2b)
+            arr[:, i] -= np.dot(arr[:, i], arr[:, j]) * arr[:, j]
+        # 2c
+        tmp = np.linalg.norm(arr[:, i])
+        is_linearly_indepedent = tmp > eps
+        if is_linearly_indepedent:
+            arr[:, i] /= tmp
+        else:
+            arr[:, i] = np.zeros(arr[:, i].shape)
+
+    # elif method == 'qr-factorization':
+    #    Q, R = np.linalg.qr(ary)
+    #    arr = Q
+
+    # QR factorization is not used here because of non-useful
+    # results in cases of linear dependence
+
+    # else:
+    #     raise ValueError("Method must be 'gram-schmidt'"
+    #                      "or 'qr-factorization'")
+
+    return arr
+
+
+def vectorspace_dimensionality(ary):
+    """Computes the hyper-volume spanned by a vector set
+
+    Parameters
+    ----------
+    ary : array-like, shape=[num_vectors, num_vectors]
+        An orthogonal set of vectors (arranged as columns in a matrix)
+
+    Returns
+    ----------
+    dimensions : int
+        An integer indicating the "dimensionality" hyper-volume spanned by
+        the vector set
+
+    """
+    # Note that since the vectors of
+    # an orthonormal vectoset have unit length or are zero,
+    # the sum of the individual
+    # norms equals the dimensionality of that vector space
+    return int(np.sum(np.linalg.norm(
+        vectorspace_orthonormalization(ary), axis=0)))

--- a/mlxtend/math/tests/test_linalg.py
+++ b/mlxtend/math/tests/test_linalg.py
@@ -22,11 +22,11 @@ def test_vectorspace_orthonormalization():
        [0.81649658, 0.50816781, -0.06462163, -0.26631346],
        [0.40824829, -0.83484711, 0.07942048, -0.36063281]])
 
-    np.testing.assert_array_equal(
-        vectorspace_orthonormalization(a1), expect1)
+    np.testing.assert_array_almost_equal(
+        vectorspace_orthonormalization(a1), expect1, decimal=7)
 
-    np.testing.assert_array_equal(
-        vectorspace_orthonormalization(a1/2), expect1)
+    np.testing.assert_array_almost_equal(
+        vectorspace_orthonormalization(a1/2), expect1, decimal=7)
 
 
 def test_vectorspace_dimensionality():

--- a/mlxtend/math/tests/test_linalg.py
+++ b/mlxtend/math/tests/test_linalg.py
@@ -1,0 +1,49 @@
+# Sebastian Raschka 2014-2018
+# mlxtend Machine Learning Library Extensions
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+
+import numpy as np
+from mlxtend.math import vectorspace_orthonormalization
+from mlxtend.math import vectorspace_dimensionality
+
+
+def test_vectorspace_orthonormalization():
+    a1 = np.array([[2,   0,   4,  12],
+                   [0,   2,  16,   4],
+                   [4,  16,   6,   2],
+                   [2, -12,   4,   6]])
+
+    expect1 = np.array([
+       [0.40824829, -0.1814885,  0.04982278,  0.89325973],
+       [0., 0.1088931, 0.99349591, -0.03328918],
+       [0.81649658, 0.50816781, -0.06462163, -0.26631346],
+       [0.40824829, -0.83484711, 0.07942048, -0.36063281]])
+
+    np.testing.assert_array_equal(
+        vectorspace_orthonormalization(a1), expect1)
+
+    np.testing.assert_array_equal(
+        vectorspace_orthonormalization(a1/2), expect1)
+
+
+def test_vectorspace_dimensionality():
+    a = np.array([[1, 2, 3],
+                  [1, 2, 3],
+                  [1, 2, 3]])
+    assert vectorspace_dimensionality(a) == 1
+
+    a[:, 1] *= 2
+    a[:, 2] *= 4
+
+    assert vectorspace_dimensionality(a) == 1
+
+    a[:, 1] += np.array([3, 34, 99])
+
+    assert vectorspace_dimensionality(a) == 2
+
+    b = np.array([[1, 2, 3],
+                  [15, 1, 3]])
+    assert vectorspace_dimensionality(b) == 2


### PR DESCRIPTION
### Description

Adds two new functions, `vectorspace_orthonormalization` and `vectorspace_dimensionality` were added to `mlxtend.math` to use the Gram-Schmidt process to convert an orthogonal vectorspace into orthonormal basis vectors and to compute the dimensionality of a vectorspace, respectively.

### Related issues or pull requests

- -


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->