### PR TITLE
Unit tests to check if frozensets don't cause problems in Python 2.7

### DIFF
--- a/mlxtend/frequent_patterns/tests/test_association_rules.py
+++ b/mlxtend/frequent_patterns/tests/test_association_rules.py
@@ -16,6 +16,8 @@ df = pd.DataFrame(one_ary, columns=cols)
 
 df_freq_items = apriori(df, min_support=0.6)
 
+df_freq_items_with_colnames = apriori(df, min_support=0.6, use_colnames=True)
+
 columns_ordered = ['antecedants', 'consequents',
                    'antecedent support', 'consequent support',
                    'support',
@@ -88,9 +90,43 @@ def test_leverage():
                                metric='leverage')
     assert res_df.values.shape[0] == 6
 
+    res_df = association_rules(df_freq_items_with_colnames,
+                               min_threshold=0.1,
+                               metric='leverage')
+    assert res_df.values.shape[0] == 6
+
 
 def test_conviction():
     res_df = association_rules(df_freq_items,
                                min_threshold=1.5,
                                metric='conviction')
     assert res_df.values.shape[0] == 11
+
+    res_df = association_rules(df_freq_items_with_colnames,
+                               min_threshold=1.5,
+                               metric='conviction')
+    assert res_df.values.shape[0] == 11
+
+
+def test_lift():
+    res_df = association_rules(df_freq_items,
+                               min_threshold=1.1,
+                               metric='lift')
+    assert res_df.values.shape[0] == 6
+
+    res_df = association_rules(df_freq_items_with_colnames,
+                               min_threshold=1.1,
+                               metric='lift')
+    assert res_df.values.shape[0] == 6
+
+
+def test_confidence():
+    res_df = association_rules(df_freq_items,
+                               min_threshold=0.8,
+                               metric='confidence')
+    assert res_df.values.shape[0] == 9
+
+    res_df = association_rules(df_freq_items_with_colnames,
+                               min_threshold=0.8,
+                               metric='confidence')
+    assert res_df.values.shape[0] == 9


### PR DESCRIPTION
### Description

Adds unit tests to check if frozensets don't cause problems in Python 2.7 if use_colnames=True in `apriori` function

### Related Issues

#390 


### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
