### PR TITLE
Apriori use sets

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -26,7 +26,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- -
+- Itemsets generated with `apriori` are now sets ([#344](https://github.com/rasbt/mlxtend/issues/344) by [William Laney](https://github.com/WLaney))
 
 
 ##### Bug Fixes

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -130,7 +130,7 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None):
     all_res = []
     for k in sorted(itemset_dict):
         support = pd.Series(support_dict[k])
-        itemsets = pd.Series([i for i in itemset_dict[k]])
+        itemsets = pd.Series([set(i) for i in itemset_dict[k]])
 
         res = pd.concat((support, itemsets), axis=1)
         all_res.append(res)
@@ -139,9 +139,8 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None):
     res_df.columns = ['support', 'itemsets']
     if use_colnames:
         mapping = {idx: item for idx, item in enumerate(df.columns)}
-        res_df['itemsets'] = res_df['itemsets'].apply(lambda x: [mapping[i]
-                                                      for i in x])
+        res_df['itemsets'] = res_df['itemsets'].apply(lambda x: set([mapping[i]
+                                                      for i in x]))
     res_df = res_df.reset_index(drop=True)
-    res_df['itemsets'] = res_df['itemsets'].apply(lambda x: set(x))
 
     return res_df

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -142,5 +142,6 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None):
         res_df['itemsets'] = res_df['itemsets'].apply(lambda x: [mapping[i]
                                                       for i in x])
     res_df = res_df.reset_index(drop=True)
+    res_df['itemsets'] = res_df['itemsets'].apply(lambda x: set(x))
 
     return res_df

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -57,8 +57,8 @@ def test_max_len():
 def test_itemsets_type():
     res_colindice = apriori(df, use_colnames=False)  # This is defualt behavior
     for i in res_colindice['itemsets']:
-        assert isinstance(i, set) == True
-        
+        assert isinstance(i, set) is True
+
     res_colnames = apriori(df, use_colnames=True)  # This is defualt behavior
     for i in res_colnames['itemsets']:
-        assert isinstance(i, set) == True
+        assert isinstance(i, set) is True

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -52,3 +52,13 @@ def test_max_len():
 
     res_df2 = apriori(df, max_len=2)
     assert len(res_df2.iloc[-1, -1]) == 2
+
+
+def test_itemsets_type():
+    res_colindice = apriori(df, use_colnames=False)  # This is defualt behavior
+    for i in res_colindice['itemsets']:
+        assert isinstance(i, set) == True
+        
+    res_colnames = apriori(df, use_colnames=True)  # This is defualt behavior
+    for i in res_colnames['itemsets']:
+        assert isinstance(i, set) == True

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -55,10 +55,10 @@ def test_max_len():
 
 
 def test_itemsets_type():
-    res_colindice = apriori(df, use_colnames=False)  # This is defualt behavior
+    res_colindice = apriori(df, use_colnames=False)  # This is default behavior
     for i in res_colindice['itemsets']:
         assert isinstance(i, set) is True
 
-    res_colnames = apriori(df, use_colnames=True)  # This is defualt behavior
+    res_colnames = apriori(df, use_colnames=True)
     for i in res_colnames['itemsets']:
         assert isinstance(i, set) is True


### PR DESCRIPTION
### Description
Changes `apriori` to return itemsets as sets instead of lists.
<!--  
Please insert a brief description of the Pull request here
-->



### Related issues or pull requests
Disscused in [issue 344](https://github.com/rasbt/mlxtend/issues/344)
<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
