### PR TITLE
Adds an explanation about SVM and soft-voting behavior in the ensemble voting classifier

### DIFF
--- a/docs/sources/user_guide/classifier/EnsembleVoteClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/EnsembleVoteClassifier.ipynb
@@ -886,6 +886,83 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Example 7 - A Note about Scikit-Learn SVMs and Soft Voting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section provides some additional technical insights in how probabilities are used when `voting='soft'`. \n",
+    "\n",
+    "\n",
+    "Note that scikit-learn estimates the probabilities for SVMs (more info here: http://scikit-learn.org/stable/modules/svm.html#scores-probabilities) in a way that these may not be consistent with the class labels that the SVM predicts. This is an extreme example, but let's say we have a dataset with 3 class labels, 0, 1, and 2. For a given training example, the SVM classifier may predict class 2. However, the class-membership probabilities may look as follows:\n",
+    "\n",
+    "- class 0: 99%\n",
+    "- class 1: 0.5%\n",
+    "- class 2: 0.5%\n",
+    "\n",
+    "A practical example of this scenario is shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============\n",
+      "Probas from SVM            : [ 0.01192489  0.47662663  0.51144848]\n",
+      "Class from SVM             : 1\n",
+      "Probas from SVM in Ensemble: [ 0.01192489  0.47662663  0.51144848]\n",
+      "Class from SVM in Ensemble : 2\n",
+      "============\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from mlxtend.classifier import EnsembleVoteClassifier\n",
+    "from sklearn.svm import SVC\n",
+    "from sklearn.datasets import load_iris\n",
+    "\n",
+    "iris = load_iris()\n",
+    "X, y = iris.data, iris.target\n",
+    "\n",
+    "clf2 = SVC(probability=True, random_state=4)\n",
+    "clf2.fit(X, y)\n",
+    "eclf = EnsembleVoteClassifier(clfs=[clf2], voting='soft', refit=False)\n",
+    "eclf.fit(X, y)\n",
+    "\n",
+    "for svm_class, e_class, svm_prob, e_prob, in zip(clf2.predict(X),\n",
+    "                                                 eclf.predict(X),\n",
+    "                                                 clf2.predict_proba(X),\n",
+    "                                                 eclf.predict_proba(X)):\n",
+    "    if svm_class != e_class:\n",
+    "        print('============')\n",
+    "        print('Probas from SVM            :', svm_prob)\n",
+    "        print('Class from SVM             :', svm_class)\n",
+    "        print('Probas from SVM in Ensemble:', e_prob)\n",
+    "        print('Class from SVM in Ensemble :', e_class)\n",
+    "        print('============')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Based on the probabilities, we would expect the SVM to predict class 2, because it has the highest probability. Since the `EnsembleVoteClassifier` uses the `argmax` function internally if `voting='soft'`, it would indeed predict class 2 in this case even if the ensemble consists of only one SVM model.\n",
+    "\n",
+    "Note that in practice, this minor technical detail does not need to concern you, but it is useful to keep it in mind in case you are wondering about results from a 1-model SVM ensemble compared to that SVM alone -- this is not a bug."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# API"
    ]
   },


### PR DESCRIPTION
### Description

This extends the documentation explaining how the `voting='soft'` values are used and what it might mean if the SVM probabilities are estimated in a way that deviates from predicted class labels.