### PR TITLE
fix broken link to learning curves

### DIFF
--- a/mlxtend/plotting/learning_curves.py
+++ b/mlxtend/plotting/learning_curves.py
@@ -62,7 +62,7 @@ def plot_learning_curves(X_train, y_train,
     Examples
     -----------
     For usage examples, please see
-    http://rasbt.github.io/mlxtend/user_guide/plotting/learning_curves/
+    http://rasbt.github.io/mlxtend/user_guide/plotting/plot_learning_curves/
 
     """
     if scoring != 'misclassification error':


### PR DESCRIPTION
### Description

Fixes a broken link to the `plot_learning_curves` function in the documentation



### Related issues or pull requests

Fixes #397 



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
