### PR TITLE
Extend plot confusion matrix

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -22,7 +22,13 @@ The CHANGELOG for the current development version is available at
 - `ColumnSelector` now works with Pandas DataFrames columns. ([#378](https://github.com/rasbt/mlxtend/pull/378) by [Manuel Garrido](https://github.com/manugarri))
 - The `ExhaustiveFeatureSelector` estimator in `mlxtend.feature_selection` now is safely stoppable mid-process by control+c. ([#380](https://github.com/rasbt/mlxtend/pull/380))
 - Two new functions, `vectorspace_orthonormalization` and `vectorspace_dimensionality` were added to `mlxtend.math` to use the Gram-Schmidt process to convert a set of linearly independent vectors into a set of orthonormal basis vectors, and to compute the dimensionality of a vectorspace, respectively. ([#382](https://github.com/rasbt/mlxtend/pull/382))
+- Two new functions, `vectorspace_orthonormalization` and `vectorspace_dimensionality` were added to `mlxtend.math` to use the Gram-Schmidt process to convert a set of linearly independent vectors into a set of orthonormal basis vectors, and to compute the dimensionality of a vectorspace, respectively. ([#382](https://github.com/rasbt/mlxtend/pull/382))
+- The `plot_decision_regions` function now has the ability to show normalized confusion matrix coefficients in addition to or instead of absolute confusion matrix coefficients with or without a colorbar. The text display method has been changed so that the full range of the colormap is used. The default size is also now set based on the number of classes.
 
+* Add ability to show normalised confusion matrix coefficients.
+* Add ability to show colorbar
+* Change to use full range of colormap
+* Set default size based on number of classes.
 
 ##### Changes
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,11 +25,6 @@ The CHANGELOG for the current development version is available at
 - Two new functions, `vectorspace_orthonormalization` and `vectorspace_dimensionality` were added to `mlxtend.math` to use the Gram-Schmidt process to convert a set of linearly independent vectors into a set of orthonormal basis vectors, and to compute the dimensionality of a vectorspace, respectively. ([#382](https://github.com/rasbt/mlxtend/pull/382))
 - The `plot_decision_regions` function now has the ability to show normalized confusion matrix coefficients in addition to or instead of absolute confusion matrix coefficients with or without a colorbar. The text display method has been changed so that the full range of the colormap is used. The default size is also now set based on the number of classes.
 
-* Add ability to show normalised confusion matrix coefficients.
-* Add ability to show colorbar
-* Change to use full range of colormap
-* Set default size based on number of classes.
-
 ##### Changes
 
 - Itemsets generated with `apriori` are now `frozenset`s ([#393](https://github.com/rasbt/mlxtend/issues/393) by [William Laney](https://github.com/WLaney) and [#394](https://github.com/rasbt/mlxtend/issues/394))

--- a/mlxtend/plotting/plot_confusion_matrix.py
+++ b/mlxtend/plotting/plot_confusion_matrix.py
@@ -1,3 +1,7 @@
+from sklearn.metrics import confusion_matrix
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
 # Sebastian Raschka 2014-2018
 # mlxtend Machine Learning Library Extensions
 # Author: Sebastian Raschka <sebastianraschka.com>
@@ -9,11 +13,14 @@ import matplotlib.pyplot as plt
 
 
 def plot_confusion_matrix(conf_mat,
-                          hide_spines=False, hide_ticks=False,
-                          figsize=(2.5, 2.5),
-                          cmap=None, alpha=0.3):
+                          hide_spines=False,
+                          hide_ticks=False,
+                          figsize=None,
+                          cmap=None,
+                          colorbar=False,
+                          show_absolute=True,
+                          show_normed=False):
     """Plot a confusion matrix via matplotlib.
-
     Parameters
     -----------
     conf_mat : array-like, shape = [n_classes, n_classes]
@@ -26,29 +33,63 @@ def plot_confusion_matrix(conf_mat,
         Height and width of the figure
     cmap : matplotlib colormap (default: `None`)
         Uses matplotlib.pyplot.cm.Blues if `None`
-
+    colorbar : bool (default: False)
+        Shows a colorbar if True
+    show_absolute : bool (default: True)
+        Shows absolute confusion matrix coefficients if True.
+        At least one of  ``show_absolute`` or ``show_normed``
+        must be True.
+    show_normed : bool (default: False)
+        Shows normed confusion matrix coefficients if True.
+        At least one of  ``show_absolute`` or ``show_normed``
+        must be True.
     Returns
     -----------
     fig, ax : matplotlib.pyplot subplot objects
         Figure and axis elements of the subplot.
-
     Examples
     -----------
     For usage examples, please see
     http://rasbt.github.io/mlxtend/user_guide/plotting/plot_confusion_matrix/
-
     """
+    if not (show_absolute or show_normed):
+        raise AssertionError('Both show_absolute and show_normed are False')
+
+    total_samples = conf_mat.sum(axis=1)[:, np.newaxis]
+    normed_conf_mat = conf_mat.astype('float') / total_samples
+
     fig, ax = plt.subplots(figsize=figsize)
+    ax.grid(False)
     if cmap is None:
         cmap = plt.cm.Blues
-    ax.matshow(conf_mat, cmap=cmap, alpha=alpha)
+
+    if figsize is None:
+        figsize = (len(conf_mat)*1.25, len(conf_mat)*1.25)
+
+    if show_absolute:
+        matshow = ax.matshow(conf_mat, cmap=cmap)
+    else:
+        matshow = ax.matshow(normed_conf_mat, cmap=cmap)
+
+    if colorbar:
+        fig.colorbar(matshow)
+
     for i in range(conf_mat.shape[0]):
         for j in range(conf_mat.shape[1]):
+            cell_text = ""
+            if show_absolute:
+                cell_text += format(conf_mat[i, j], 'd')
+                if show_normed:
+                    cell_text += "\n" + '('
+                    cell_text += format(normed_conf_mat[i, j], '.2f') + ')'
+            else:
+                cell_text += format(normed_conf_mat[i, j], '.2f')
             ax.text(x=j,
                     y=i,
-                    s=conf_mat[i, j],
+                    s=cell_text,
                     va='center',
-                    ha='center')
+                    ha='center',
+                    color="white" if normed_conf_mat[i, j] > 0.5 else "black")
 
     if hide_spines:
         ax.spines['right'].set_visible(False)

--- a/mlxtend/plotting/plot_confusion_matrix.py
+++ b/mlxtend/plotting/plot_confusion_matrix.py
@@ -1,7 +1,3 @@
-from sklearn.metrics import confusion_matrix
-from sklearn.datasets import load_iris
-from sklearn.model_selection import train_test_split
-
 # Sebastian Raschka 2014-2018
 # mlxtend Machine Learning Library Extensions
 # Author: Sebastian Raschka <sebastianraschka.com>


### PR DESCRIPTION
### Description

Extends functionality of ``plot_confusion_matrix()``.

### Related issues or pull requests

Pull request made in relation to issue #402



### Pull Request Checklist

- [X] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [X] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [X] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [X] Checked for style issues by running `flake8 ./mlxtend`

<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
