### PR TITLE
Typo fixes

### DIFF
--- a/docs/sources/user_guide/evaluate/feature_importance_permutation.ipynb
+++ b/docs/sources/user_guide/evaluate/feature_importance_permutation.ipynb
@@ -41,7 +41,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The *permutation importance* is an intuitive, model-agnostic method to estimate the feature importance for classifier and regression models. The approach is relatively simple and straigh-forward:\n",
+    "The *permutation importance* is an intuitive, model-agnostic method to estimate the feature importance for classifier and regression models. The approach is relatively simple and straight-forward:\n",
     "\n",
     "1. Take a model that was fit to the training dataset\n",
     "2. Estimate the predictive performance of the model on an independent dataset (e.g., validation dataset) and record it as the baseline performance\n",
@@ -624,7 +624,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/docs/sources/user_guide/preprocessing/minmax_scaling.ipynb
+++ b/docs/sources/user_guide/preprocessing/minmax_scaling.ipynb
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -316,7 +316,7 @@
       "\n",
       "    minimum value after rescaling.\n",
       "\n",
-      "- `min_val` : `int` or `float`, optional (default=`1`)\n",
+      "- `max_val` : `int` or `float`, optional (default=`1`)\n",
       "\n",
       "    maximum value after rescaling.\n",
       "\n",
@@ -339,6 +339,13 @@
     "with open('../../api_modules/mlxtend.preprocessing/minmax_scaling.md', 'r') as f:\n",
     "    print(f.read())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -358,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/preprocessing/scaling.py
+++ b/mlxtend/preprocessing/scaling.py
@@ -21,7 +21,7 @@ def minmax_scaling(array, columns, min_val=0, max_val=1):
         or column indices [0, 2, 4, ...]
     min_val : `int` or `float`, optional (default=`0`)
         minimum value after rescaling.
-    min_val : `int` or `float`, optional (default=`1`)
+    max_val : `int` or `float`, optional (default=`1`)
         maximum value after rescaling.
 
     Returns


### PR DESCRIPTION
### Description

Fixes typo in minmax_scaling docstring mentioned in #355 and another grammar issue
