### PR TITLE
Add support for sparse matrices in StackingClassifier

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -34,7 +34,7 @@ The CHANGELOG for the current development version is available at
 
 - Allow mlxtend estimators to be cloned via scikit-learn's `clone` function. ([#374](https://github.com/rasbt/mlxtend/pull/374))
 - Fixes bug to allow the correct use of `refit=False` in `StackingRegressor` and `StackingCVRegressor`  ([#384](https://github.com/rasbt/mlxtend/pull/384) and ([#385](https://github.com/rasbt/mlxtend/pull/385)) by [selay01](https://github.com/selay01))
-
+- Allow `StackingClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#408](https://github.com/rasbt/mlxtend/issues/408))
 
 
 

--- a/mlxtend/classifier/stacking_classification.py
+++ b/mlxtend/classifier/stacking_classification.py
@@ -258,6 +258,8 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         if not self.use_features_in_secondary:
             return self.meta_clf_.predict_proba(meta_features)
         elif sparse.issparse(X):
-            return self.meta_clf_.predict_proba(sparse.hstack((X, meta_features)))
+            return self.meta_clf_.predict_proba(
+                sparse.hstack((X, meta_features))
+            )
         else:
             return self.meta_clf_.predict_proba(np.hstack((X, meta_features)))

--- a/mlxtend/classifier/stacking_classification.py
+++ b/mlxtend/classifier/stacking_classification.py
@@ -11,6 +11,7 @@
 from ..externals.estimator_checks import check_is_fitted
 from ..externals.name_estimators import _name_estimators
 from ..externals import six
+from scipy import sparse
 from sklearn.base import BaseEstimator
 from sklearn.base import ClassifierMixin
 from sklearn.base import TransformerMixin
@@ -154,6 +155,8 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         if not self.use_features_in_secondary:
             self.meta_clf_.fit(meta_features, y)
+        elif sparse.issparse(X):
+            self.meta_clf_.fit(sparse.hstack((X, meta_features)), y)
         else:
             self.meta_clf_.fit(np.hstack((X, meta_features)), y)
 
@@ -228,6 +231,8 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         if not self.use_features_in_secondary:
             return self.meta_clf_.predict(meta_features)
+        elif sparse.issparse(X):
+            return self.meta_clf_.predict(sparse.hstack((X, meta_features)))
         else:
             return self.meta_clf_.predict(np.hstack((X, meta_features)))
 
@@ -252,5 +257,7 @@ class StackingClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         if not self.use_features_in_secondary:
             return self.meta_clf_.predict_proba(meta_features)
+        elif sparse.issparse(X):
+            return self.meta_clf_.predict_proba(sparse.hstack((X, meta_features)))
         else:
             return self.meta_clf_.predict_proba(np.hstack((X, meta_features)))

--- a/mlxtend/classifier/tests/test_stacking_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_classifier.py
@@ -6,6 +6,7 @@
 
 from mlxtend.classifier import StackingClassifier
 from mlxtend.externals.estimator_checks import NotFittedError
+from scipy import sparse
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import GaussianNB
 from sklearn.ensemble import RandomForestClassifier
@@ -249,6 +250,40 @@ def test_use_features_in_secondary_predict_proba():
     idx = [0, 1, 2]
     y_pred = sclf.predict_proba(X[idx])[:, 0]
     expect = np.array([0.911, 0.829, 0.885])
+    np.testing.assert_almost_equal(y_pred, expect, 3)
+
+
+def test_use_features_in_secondary_sparse_input_predict():
+    np.random.seed(123)
+    meta = LogisticRegression()
+    clf1 = RandomForestClassifier()
+    sclf = StackingClassifier(classifiers=[clf1],
+                              use_features_in_secondary=True,
+                              meta_classifier=meta)
+
+    scores = cross_val_score(sclf,
+                             sparse.csr_matrix(X),
+                             y,
+                             cv=5,
+                             scoring='accuracy')
+    scores_mean = (round(scores.mean(), 2))
+    assert scores_mean == 0.95, scores_mean
+
+
+def test_use_features_in_secondary_sparse_input_predict_proba():
+    np.random.seed(123)
+    meta = LogisticRegression()
+    clf1 = RandomForestClassifier()
+    sclf = StackingClassifier(classifiers=[clf1],
+                              use_features_in_secondary=True,
+                              meta_classifier=meta)
+
+    sclf.fit(sparse.csr_matrix(X), y)
+    idx = [0, 1, 2]
+    y_pred = sclf.predict_proba(
+        sparse.csr_matrix(X[idx])
+    )[:, 0]
+    expect = np.array([0.910, 0.829, 0.882])
     np.testing.assert_almost_equal(y_pred, expect, 3)
 
 


### PR DESCRIPTION
### Description
This PR adds support for sparse matrices in StackingClassifier when `use_features_in_secondary` in secondary is set to True. To do so, an extra branch in the `fit`, `predict` and `predict_proba` methods has been added to check if the input is a sparse matrix. In that case not `np.hstack` but `scipy.sparse.hstack` is used to merge the predictions of the meta classifiers and the input matrix.



### Related issues or pull requests
This fixxes #408. It does not contain fixxes for e.g. StackingClassifierCV as mentioned in the discussion there. 



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
