### PR TITLE
Test sparse input for StackingRegressor

### DIFF
--- a/mlxtend/regressor/tests/test_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_regression.py
@@ -4,6 +4,7 @@
 #
 # License: BSD 3 clause
 
+import numpy as np
 from mlxtend.externals.estimator_checks import NotFittedError
 from mlxtend.utils import assert_raises
 from mlxtend.regressor import StackingRegressor
@@ -12,7 +13,7 @@ from sklearn.linear_model import Ridge
 from sklearn.svm import SVR
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import train_test_split
-import numpy as np
+from scipy import sparse
 from numpy.testing import assert_almost_equal
 from nose.tools import raises
 from sklearn.base import clone
@@ -243,3 +244,21 @@ def test_clone():
                                meta_regressor=svr_rbf,
                                store_train_meta_features=True)
     clone(stregr)
+
+
+def test_predictions_from_sparse_matrix():
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    stregr = StackingRegressor(regressors=[svr_lin, lr],
+                               meta_regressor=ridge)
+
+    # dense
+    stregr.fit(X1, y)
+    print(stregr.score(X1, y))
+    assert round(stregr.score(X1, y), 2) == 0.61
+
+    # sparse
+    stregr.fit(sparse.csr_matrix(X1), y)
+    print(stregr.score(X1, y))
+    assert round(stregr.score(X1, y), 2) == 0.61


### PR DESCRIPTION
### Description

Adds a unit test to verify that the `StackingRegressor` supports scipy sparse matrices as input.


### Related issues or pull requests

Fixes #411



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->