### PR TITLE
Add support for sparse matrices to StackingCVRegressor if use_features_in_secondary=True

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -34,7 +34,8 @@ The CHANGELOG for the current development version is available at
 
 - Allow mlxtend estimators to be cloned via scikit-learn's `clone` function. ([#374](https://github.com/rasbt/mlxtend/pull/374))
 - Fixes bug to allow the correct use of `refit=False` in `StackingRegressor` and `StackingCVRegressor`  ([#384](https://github.com/rasbt/mlxtend/pull/384) and ([#385](https://github.com/rasbt/mlxtend/pull/385)) by [selay01](https://github.com/selay01))
-- Allow `StackingClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#408](https://github.com/rasbt/mlxtend/issues/408))
+- Allow `StackingClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#408](https://github.com/rasbt/mlxtend/issues/408) by [Floris Hoogenbook](https://github.com/FlorisHoogenboom))
+- Allow `StackingCVRegressor` to work with sparse matrices when `use_features_in_secondary=True`  ([#416](https://github.com/rasbt/mlxtend/issues/416))
 
 
 

--- a/mlxtend/regressor/tests/test_stacking_cv_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_cv_regression.py
@@ -8,6 +8,7 @@
 # License: BSD 3 clause
 
 import numpy as np
+from scipy import sparse
 from mlxtend.externals.estimator_checks import NotFittedError
 from mlxtend.regressor import StackingCVRegressor
 from mlxtend.utils import assert_raises
@@ -203,3 +204,46 @@ def test_clone():
                                  meta_regressor=svr_rbf,
                                  store_train_meta_features=True)
     clone(stregr)
+
+
+def test_sparse_matrix_inputs():
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    svr_rbf = SVR(kernel='rbf')
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
+                                meta_regressor=svr_rbf)
+
+    # dense
+    stack.fit(X1, y).predict(X1)
+    mse = 0.20
+    got = np.mean((stack.predict(X1) - y) ** 2)
+    assert round(got, 2) == mse
+
+    # sparse
+    stack.fit(sparse.csr_matrix(X1), y)
+    mse = 0.20
+    got = np.mean((stack.predict(sparse.csr_matrix(X1)) - y) ** 2)
+    assert round(got, 2) == mse
+
+
+def test_sparse_matrix_inputs_with_features_in_secondary():
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    svr_rbf = SVR(kernel='rbf')
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
+                                meta_regressor=svr_rbf,
+                                use_features_in_secondary=True)
+
+    # dense
+    stack.fit(X1, y).predict(X1)
+    mse = 0.20
+    got = np.mean((stack.predict(X1) - y) ** 2)
+    assert round(got, 2) == mse
+
+    # sparse
+    stack.fit(sparse.csr_matrix(X1), y)
+    mse = 0.20
+    got = np.mean((stack.predict(sparse.csr_matrix(X1)) - y) ** 2)
+    assert round(got, 2) == mse


### PR DESCRIPTION

### Description

add support for sparse matrices to StackingCVRegressor if use_features_in_secondary=True

### Related issues or pull requests

Fixes #412 


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->