### PR TITLE
Sparse support for StackingCVClassifier

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -36,6 +36,7 @@ The CHANGELOG for the current development version is available at
 - Fixes bug to allow the correct use of `refit=False` in `StackingRegressor` and `StackingCVRegressor`  ([#384](https://github.com/rasbt/mlxtend/pull/384) and ([#385](https://github.com/rasbt/mlxtend/pull/385)) by [selay01](https://github.com/selay01))
 - Allow `StackingClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#408](https://github.com/rasbt/mlxtend/issues/408) by [Floris Hoogenbook](https://github.com/FlorisHoogenboom))
 - Allow `StackingCVRegressor` to work with sparse matrices when `use_features_in_secondary=True`  ([#416](https://github.com/rasbt/mlxtend/issues/416))
+- Allow `StackingCVClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#417](https://github.com/rasbt/mlxtend/issues/417))
 
 
 

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -7,6 +7,7 @@
 
 import pandas as pd
 import numpy as np
+from scipy import sparse
 from mlxtend.classifier import StackingCVClassifier
 from mlxtend.externals.estimator_checks import NotFittedError
 from mlxtend.utils import assert_raises
@@ -360,3 +361,38 @@ def test_clone():
                                  meta_classifier=lr,
                                  store_train_meta_features=True)
     clone(stclf)
+
+
+def test_sparse_inputs():
+    rf = RandomForestClassifier(random_state=1)
+    lr = LogisticRegression()
+    stclf = StackingCVClassifier(classifiers=[rf, rf],
+                                 meta_classifier=lr)
+    X_train, X_test, y_train,  y_test = train_test_split(X_breast, y_breast,
+                                                         test_size=0.3)
+
+    # dense
+    stclf.fit(X_train, y_train)
+    assert round(stclf.score(X_train, y_train), 2) == 0.99
+
+    # sparse
+    stclf.fit(sparse.csr_matrix(X_train), y_train)
+    assert round(stclf.score(X_train, y_train), 2) == 0.99
+
+
+def test_sparse_inputs_with_features_in_secondary():
+    rf = RandomForestClassifier(random_state=1)
+    lr = LogisticRegression()
+    stclf = StackingCVClassifier(classifiers=[rf, rf],
+                                 meta_classifier=lr,
+                                 use_features_in_secondary=True)
+    X_train, X_test, y_train,  y_test = train_test_split(X_breast, y_breast,
+                                                         test_size=0.3)
+
+    # dense
+    stclf.fit(X_train, y_train)
+    assert round(stclf.score(X_train, y_train), 2) == 0.98
+
+    # sparse
+    stclf.fit(sparse.csr_matrix(X_train), y_train)
+    assert round(stclf.score(X_train, y_train), 2) == 0.98


### PR DESCRIPTION
### Description

Allow `StackingCVClassifier` to work with sparse matrices when `use_features_in_secondary=True`



### Related issues or pull requests

Fixes #413 
Fixes #408 


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->