### PR TITLE
Option to pass orig features to meta regressor in stackingregressor

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,6 +24,7 @@ The CHANGELOG for the current development version is available at
 - Two new functions, `vectorspace_orthonormalization` and `vectorspace_dimensionality` were added to `mlxtend.math` to use the Gram-Schmidt process to convert a set of linearly independent vectors into a set of orthonormal basis vectors, and to compute the dimensionality of a vectorspace, respectively. ([#382](https://github.com/rasbt/mlxtend/pull/382))
 - `mlxtend.frequent_patterns.apriori` now supports pandas `SparseDataFrame`s to generate frequent itemsets. ([#404](https://github.com/rasbt/mlxtend/pull/404) via [Daniel Morales](https://github.com/rasbt/mlxtend/pull/404))
 - The `plot_confusion_matrix` function now has the ability to show normalized confusion matrix coefficients in addition to or instead of absolute confusion matrix coefficients with or without a colorbar. The text display method has been changed so that the full range of the colormap is used. The default size is also now set based on the number of classes.
+- Adding support for merging the meta features with the original input features in `StackingRegressor` (via `use_features_in_secondary`) like it is already supported in the other Stacking classes. ([#418](https://github.com/rasbt/mlxtend/pull/418))
 
 ##### Changes
 

--- a/docs/sources/user_guide/regressor/StackingRegressor.ipynb
+++ b/docs/sources/user_guide/regressor/StackingRegressor.ipynb
@@ -634,7 +634,7 @@
      "text": [
       "## StackingRegressor\n",
       "\n",
-      "*StackingRegressor(regressors, meta_regressor, verbose=0, store_train_meta_features=False, refit=True)*\n",
+      "*StackingRegressor(regressors, meta_regressor, verbose=0, use_features_in_secondary=False, store_train_meta_features=False, refit=True)*\n",
       "\n",
       "A Stacking regressor for scikit-learn estimators for regression.\n",
       "\n",
@@ -663,6 +663,14 @@
       "    - `verbose>2`: Changes `verbose` param of the underlying regressor to\n",
       "    self.verbose - 2\n",
       "\n",
+      "- `use_features_in_secondary` : bool (default: False)\n",
+      "\n",
+      "    If True, the meta-regressor will be trained both on\n",
+      "    the predictions of the original regressors and the\n",
+      "    original dataset.\n",
+      "    If False, the meta-regressor will be trained only on\n",
+      "    the predictions of the original regressors.\n",
+      "\n",
       "- `store_train_meta_features` : bool (default: False)\n",
       "\n",
       "    If True, the meta-features computed from the training data\n",
@@ -670,6 +678,7 @@
       "    meta-regressor stored in the `self.train_meta_features_` array,\n",
       "    which can be\n",
       "    accessed after calling `fit`.\n",
+      "\n",
       "\n",
       "**Attributes**\n",
       "\n",
@@ -880,6 +889,13 @@
     "with open('../../api_modules/mlxtend.regressor/StackingRegressor.md', 'r') as f:\n",
     "    print(f.read())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -899,7 +915,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
### Description

Adding support for merging the meta features with the original input features in `StackingRegressor` (via `use_features_in_secondary`) like it is already supported in the other Stacking classes. 


### Related issues or pull requests

Fixes #418


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->