### PR TITLE
raise error for unallowed values in DataFrame as input to apriori

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -29,7 +29,7 @@ The CHANGELOG for the current development version is available at
 ##### Changes
 
 - Itemsets generated with `apriori` are now `frozenset`s ([#393](https://github.com/rasbt/mlxtend/issues/393) by [William Laney](https://github.com/WLaney) and [#394](https://github.com/rasbt/mlxtend/issues/394))
-
+- Now raises an error if a input DataFrame to `apriori` contains non 0, 1, True, False values. [#419](https://github.com/rasbt/mlxtend/issues/419))
 
 ##### Bug Fixes
 
@@ -38,7 +38,6 @@ The CHANGELOG for the current development version is available at
 - Allow `StackingClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#408](https://github.com/rasbt/mlxtend/issues/408) by [Floris Hoogenbook](https://github.com/FlorisHoogenboom))
 - Allow `StackingCVRegressor` to work with sparse matrices when `use_features_in_secondary=True`  ([#416](https://github.com/rasbt/mlxtend/issues/416))
 - Allow `StackingCVClassifier` to work with sparse matrices when `use_features_in_secondary=True`  ([#417](https://github.com/rasbt/mlxtend/issues/417))
-
 
 
 

--- a/docs/sources/user_guide/frequent_patterns/apriori.ipynb
+++ b/docs/sources/user_guide/frequent_patterns/apriori.ipynb
@@ -1053,7 +1053,9 @@
       "\n",
       "- `df` : pandas DataFrame or pandas SparseDataFrame\n",
       "\n",
-      "    pandas DataFrame the encoded format. For example,\n",
+      "    pandas DataFrame the encoded format.\n",
+      "    The allowed values are either 0/1 or True/False.\n",
+      "    For example,\n",
       "\n",
       "```\n",
       "    Apple  Bananas  Beer  Chicken  Milk  Rice\n",
@@ -1110,13 +1112,6 @@
     "with open('../../api_modules/mlxtend.frequent_patterns/apriori.md', 'r') as f:\n",
     "    print(f.read())"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -56,7 +56,9 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, n_jobs=1):
     Parameters
     -----------
     df : pandas DataFrame or pandas SparseDataFrame
-      pandas DataFrame the encoded format. For example,
+      pandas DataFrame the encoded format.
+      The allowed values are either 0/1 or True/False.
+      For example,
 
     ```
              Apple  Bananas  Beer  Chicken  Milk  Rice
@@ -100,6 +102,13 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, n_jobs=1):
     http://rasbt.github.io/mlxtend/user_guide/frequent_patterns/apriori/
 
     """
+    allowed_val = {0, 1, True, False}
+    unique_val = np.unique(df.values.ravel())
+    for val in unique_val:
+        if val not in allowed_val:
+            s = ('The allowed values for a DataFrame'
+                 ' are True, False, 0, 1. Found value %s' % (val))
+            raise ValueError(s)
 
     is_sparse = hasattr(df, "to_coo")
     if is_sparse:

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from mlxtend.frequent_patterns import apriori
 from numpy.testing import assert_array_equal
+from mlxtend.utils import assert_raises
 import pandas as pd
 
 dataset = [['Milk', 'Onion', 'Nutmeg', 'Kidney Beans', 'Eggs', 'Yogurt'],
@@ -74,10 +75,10 @@ def test_frozenset_selection():
                   == {'Eggs', 'Kidney Beans'}].values.shape == (1, 2)
     assert res_df[res_df['itemsets']
                   == frozenset(('Eggs', 'Kidney Beans'))].values.shape \
-           == (1, 2)
+        == (1, 2)
     assert res_df[res_df['itemsets']
                   == frozenset(('Kidney Beans', 'Eggs'))].values.shape \
-           == (1, 2)
+        == (1, 2)
 
 
 def test_sparse_apriori():
@@ -91,9 +92,19 @@ def test_sparse_apriori():
                       == {'Eggs', 'Kidney Beans'}].values.shape == (1, 2)
         assert res_df[res_df['itemsets']
                       == frozenset(('Eggs', 'Kidney Beans'))].values.shape \
-               == (1, 2)
+            == (1, 2)
         assert res_df[res_df['itemsets']
                       == frozenset(('Kidney Beans', 'Eggs'))].values.shape \
-               == (1, 2)
+            == (1, 2)
     test_with_fill_values(0)
     test_with_fill_values(False)
+
+
+def test_raise_error_if_input_is_not_binary():
+    df2 = pd.DataFrame(one_ary, columns=cols).copy()
+    df2.iloc[3, 3] = 2
+
+    assert_raises(ValueError,
+                  'The allowed values for a DataFrame are True, '
+                  'False, 0, 1. Found value 2',
+                  apriori, df2)


### PR DESCRIPTION
### Description

Now raises an error if the input to `mlxtend.frequent_patterns.apriori` is not 0, 1, True, or False, to avoid unintended behavior.



### Related issues or pull requests

Fixes #407 



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
