### PR TITLE
Addresses numpy 0.15 deprecation warnings

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -21,7 +21,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- -
+- Addressed deprecations warnings in NumPy 0.15 ([#425](https://github.com/rasbt/mlxtend/pull/425))
 
 
 ##### Bug Fixes

--- a/mlxtend/_base/_classifier.py
+++ b/mlxtend/_base/_classifier.py
@@ -16,7 +16,7 @@ class _Classifier(object):
         pass
 
     def _check_target_array(self, y, allowed=None):
-        if not np.issubdtype(y[0], int):
+        if not isinstance(y[0], (int, np.integer)):
             raise AttributeError('y must be an integer array.\nFound %s'
                                  % y.dtype)
         found_labels = np.unique(y)

--- a/mlxtend/_base/_regressor.py
+++ b/mlxtend/_base/_regressor.py
@@ -16,7 +16,7 @@ class _Regressor(object):
         pass
 
     def _check_target_array(self, y, allowed=None):
-        if not np.issubdtype(y[0], float):
+        if not isinstance(y[0], (int, np.float)):
             raise AttributeError('y must be a float array.\nFound %s'
                                  % y.dtype)
 


### PR DESCRIPTION
### Description

Addresses numpy 0.15 deprecation warnings

### Related issues or pull requests

- -



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->