### PR TITLE
fix missing import issue in plot_confusion_matrix

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -22,6 +22,7 @@ The CHANGELOG for the current development version is available at
 ##### Changes
 
 - Addressed deprecations warnings in NumPy 0.15 ([#425](https://github.com/rasbt/mlxtend/pull/425))
+- Fixed an issue with a missing import in `mlxtend.plotting.plot_confusion_matrix` ([#428](https://github.com/rasbt/mlxtend/pull/428))
 
 
 ##### Bug Fixes

--- a/docs/sources/user_guide/plotting/plot_confusion_matrix.ipynb
+++ b/docs/sources/user_guide/plotting/plot_confusion_matrix.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/plotting/plot_confusion_matrix.py
+++ b/mlxtend/plotting/plot_confusion_matrix.py
@@ -6,6 +6,7 @@
 # License: BSD 3 clause
 
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 def plot_confusion_matrix(conf_mat,


### PR DESCRIPTION
### Description

Fixes an issue with a missing import

### Related issues or pull requests

Fixes #427 



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
