### PR TITLE
Fixed variable names

### DIFF
--- a/docs/sources/user_guide/evaluate/feature_importance_permutation.ipynb
+++ b/docs/sources/user_guide/evaluate/feature_importance_permutation.ipynb
@@ -283,7 +283,7 @@
     }
    ],
    "source": [
-    "indices = np.argsort(importance_vals)[::-1]\n",
+    "indices = np.argsort(imp_vals)[::-1]\n",
     "plt.figure()\n",
     "plt.title(\"Random Forest feature importance via permutation importance\")\n",
     "plt.bar(range(X.shape[1]), imp_vals[indices])\n",
@@ -341,7 +341,7 @@
     "\n",
     "\n",
     "std = np.std(imp_all, axis=1)\n",
-    "indices = np.argsort(importance_vals)[::-1]\n",
+    "indices = np.argsort(imp_vals)[::-1]\n",
     "\n",
     "plt.figure()\n",
     "plt.title(\"Random Forest feature importance via permutation importance w. std. dev.\")\n",
@@ -425,7 +425,7 @@
     "\n",
     "\n",
     "std = np.std(imp_all, axis=1)\n",
-    "indices = np.argsort(importance_vals)[::-1]\n",
+    "indices = np.argsort(imp_vals)[::-1]\n",
     "\n",
     "plt.figure()\n",
     "plt.title(\"SVM feature importance via permutation importance\")\n",


### PR DESCRIPTION
On several occasions variable importance_vals was used instead of imp_vals.

### Description

<!--  
On several occasions variable importance_vals was used instead of imp_vals.
-->


### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
