### PR TITLE
Fix antecedEnt typo in docs

### DIFF
--- a/docs/sources/user_guide/frequent_patterns/association_rules.ipynb
+++ b/docs/sources/user_guide/frequent_patterns/association_rules.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "### Metrics\n",
     "\n",
-    "The currently supported metrics for evaluating association rules and setting selection thresholds are listed below. Given a rule \"A -> C\", *A* stands for antecedant and *C* stands for consequent.\n",
+    "The currently supported metrics for evaluating association rules and setting selection thresholds are listed below. Given a rule \"A -> C\", *A* stands for antecedent and *C* stands for consequent.\n",
     "\n",
     "\n",
     "#### 'support':\n",
@@ -46,7 +46,7 @@
     "\n",
     "- introduced in [3]\n",
     "\n",
-    "The support metric is defined for itemsets, not assocication rules. The table produced by the association rule mining algorithm contains three different support metrics: 'antecedant support', 'consequent support', and 'support'. Here, 'antecedant support' computes the proportion of transactions that contain the antecedant A, and 'consequent support' computes the support for the itemset of the consequent C. The 'support' metric then computes the support of the combined itemset A $\\cup$ C -- note that 'support' depends on 'antecedant support' and 'consequent support' via min('antecedant support', 'consequent support').\n",
+    "The support metric is defined for itemsets, not assocication rules. The table produced by the association rule mining algorithm contains three different support metrics: 'antecedent support', 'consequent support', and 'support'. Here, 'antecedent support' computes the proportion of transactions that contain the antecedent A, and 'consequent support' computes the support for the itemset of the consequent C. The 'support' metric then computes the support of the combined itemset A $\\cup$ C -- note that 'support' depends on 'antecedent support' and 'consequent support' via min('antecedent support', 'consequent support').\n",
     "\n",
     "\n",
     "Typically, support is used to measure the abundance or frequency (often interpreted as significance or importance) of an itemset in a database. We refer to an itemset as a \"frequent itemset\" if you support is larger than a specified minimum-support threshold. Note that in general, due to the *downward closure* property, all subsets of a frequent itemset are also frequent.\n",
@@ -659,7 +659,7 @@
    "source": [
     "Pandas `DataFrames` make it easy to filter the results further. Let's say we are ony interested in rules that satisfy the following criteria:\n",
     "\n",
-    "1. at least 2 antecedants\n",
+    "1. at least 2 antecedents\n",
     "2. a confidence > 0.75\n",
     "3. a lift score > 1.2\n",
     "\n",
@@ -701,7 +701,7 @@
        "      <th>lift</th>\n",
        "      <th>leverage</th>\n",
        "      <th>conviction</th>\n",
-       "      <th>antecedant_len</th>\n",
+       "      <th>antecedent_len</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -804,7 +804,7 @@
        "4                 0.8      0.6        1.00  1.25      0.12         inf   \n",
        "5                 0.6      0.6        0.75  1.25      0.12    1.600000   \n",
        "\n",
-       "   antecedant_len  \n",
+       "   antecedent_len  \n",
        "0               1  \n",
        "1               1  \n",
        "2               2  \n",
@@ -819,7 +819,7 @@
     }
    ],
    "source": [
-    "rules[\"antecedant_len\"] = rules[\"antecedents\"].apply(lambda x: len(x))\n",
+    "rules[\"antecedent_len\"] = rules[\"antecedents\"].apply(lambda x: len(x))\n",
     "rules"
    ]
   },
@@ -865,7 +865,7 @@
        "      <th>lift</th>\n",
        "      <th>leverage</th>\n",
        "      <th>conviction</th>\n",
-       "      <th>antecedant_len</th>\n",
+       "      <th>antecedent_len</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -890,7 +890,7 @@
        "             antecedents consequents  antecedent support  consequent support  \\\n",
        "2  (Onion, Kidney Beans)      (Eggs)                 0.6                 0.8   \n",
        "\n",
-       "   support  confidence  lift  leverage  conviction  antecedant_len  \n",
+       "   support  confidence  lift  leverage  conviction  antecedent_len  \n",
        "2      0.6         1.0  1.25      0.12         inf               2  "
       ]
      },
@@ -900,7 +900,7 @@
     }
    ],
    "source": [
-    "rules[ (rules['antecedant_len'] >= 2) &\n",
+    "rules[ (rules['antecedent_len'] >= 2) &\n",
     "       (rules['confidence'] > 0.75) &\n",
     "       (rules['lift'] > 1.2) ]"
    ]
@@ -909,7 +909,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarly, using the Pandas API, we can select entries based on the \"antecedants\" or \"consequents\" columns:"
+    "Similarly, using the Pandas API, we can select entries based on the \"antecedents\" or \"consequents\" columns:"
    ]
   },
   {
@@ -947,7 +947,7 @@
        "      <th>lift</th>\n",
        "      <th>leverage</th>\n",
        "      <th>conviction</th>\n",
-       "      <th>antecedant_len</th>\n",
+       "      <th>antecedent_len</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -972,7 +972,7 @@
        "            antecedents consequents  antecedent support  consequent support  \\\n",
        "3  (Kidney Beans, Eggs)     (Onion)                 0.8                 0.6   \n",
        "\n",
-       "   support  confidence  lift  leverage  conviction  antecedant_len  \n",
+       "   support  confidence  lift  leverage  conviction  antecedent_len  \n",
        "3      0.6        0.75  1.25      0.12         1.6               2  "
       ]
      },
@@ -993,13 +993,13 @@
     "\n",
     "Note that the entries in the \"itemsets\" column are of type `frozenset`, which is built-in Python type that is similar to a Python `set` but immutable, which makes it more efficient for certain query or comparison operations (https://docs.python.org/3.6/library/stdtypes.html#frozenset). Since `frozenset`s are sets, the item order does not matter. I.e., the query\n",
     "\n",
-    "`rules[rules['antecedants'] == {'Eggs', 'Kidney Beans'}]`\n",
+    "`rules[rules['antecedents'] == {'Eggs', 'Kidney Beans'}]`\n",
     "    \n",
     "is equivalent to any of the following three\n",
     "\n",
-    "- `rules[rules['antecedants'] == {'Kidney Beans', 'Eggs'}]`\n",
-    "- `rules[rules['antecedants'] == frozenset(('Eggs', 'Kidney Beans'))]`\n",
-    "- `rules[rules['antecedants'] == frozenset(('Kidney Beans', 'Eggs'))]`\n",
+    "- `rules[rules['antecedents'] == {'Kidney Beans', 'Eggs'}]`\n",
+    "- `rules[rules['antecedents'] == frozenset(('Eggs', 'Kidney Beans'))]`\n",
+    "- `rules[rules['antecedents'] == frozenset(('Kidney Beans', 'Eggs'))]`\n",
     "\n",
     "\n"
    ]
@@ -1708,14 +1708,14 @@
       "\n",
       "**Returns**\n",
       "\n",
-      "pandas DataFrame with columns \"antecedants\" and \"consequents\"\n",
+      "pandas DataFrame with columns \"antecedents\" and \"consequents\"\n",
       "    that store itemsets, plus the scoring metric columns:\n",
       "    \"antecedent support\", \"consequent support\",\n",
       "    \"support\", \"confidence\", \"lift\",\n",
       "    \"leverage\", \"conviction\"\n",
       "    of all rules for which\n",
       "    metric(rule) >= min_threshold.\n",
-      "    Each entry in the \"antecedants\" and \"consequents\" columns are\n",
+      "    Each entry in the \"antecedents\" and \"consequents\" columns are\n",
       "    of type `frozenset`, which is a Python built-in type that\n",
       "    behaves similarly to sets except that it is immutable\n",
       "    (For more info, see\n",


### PR DESCRIPTION
### Description

Fixes a typo in the Jupyter docs, where antecedAnt was used instead of antecedEnt based on an older mlxtend version.


### Related issues or pull requests

#431 

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
