### PR TITLE
Add PredefinedSplit example to SFS docs

### DIFF
--- a/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
+++ b/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
@@ -1012,224 +1012,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 6 - Using Pandas DataFrames"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "from sklearn.neighbors import KNeighborsClassifier\n",
-    "from sklearn.datasets import load_iris\n",
-    "from mlxtend.feature_selection import SequentialFeatureSelector as SFS\n",
-    "\n",
-    "\n",
-    "iris = load_iris()\n",
-    "X = iris.data\n",
-    "y = iris.target\n",
-    "knn = KNeighborsClassifier(n_neighbors=4)\n",
-    "\n",
-    "sfs1 = SFS(knn, \n",
-    "           k_features=3, \n",
-    "           forward=True, \n",
-    "           floating=False, \n",
-    "           scoring='accuracy',\n",
-    "           cv=0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>sepal len</th>\n",
-       "      <th>petal len</th>\n",
-       "      <th>sepal width</th>\n",
-       "      <th>petal width</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5.1</td>\n",
-       "      <td>3.5</td>\n",
-       "      <td>1.4</td>\n",
-       "      <td>0.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>4.9</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>1.4</td>\n",
-       "      <td>0.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>4.7</td>\n",
-       "      <td>3.2</td>\n",
-       "      <td>1.3</td>\n",
-       "      <td>0.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4.6</td>\n",
-       "      <td>3.1</td>\n",
-       "      <td>1.5</td>\n",
-       "      <td>0.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5.0</td>\n",
-       "      <td>3.6</td>\n",
-       "      <td>1.4</td>\n",
-       "      <td>0.2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   sepal len  petal len  sepal width  petal width\n",
-       "0        5.1        3.5          1.4          0.2\n",
-       "1        4.9        3.0          1.4          0.2\n",
-       "2        4.7        3.2          1.3          0.2\n",
-       "3        4.6        3.1          1.5          0.2\n",
-       "4        5.0        3.6          1.4          0.2"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_df = pd.DataFrame(X, columns=['sepal len', 'petal len',\n",
-    "                                  'sepal width', 'petal width'])\n",
-    "X_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Also, the target array, `y`, can be optionally be cast as a Series:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    0\n",
-       "1    0\n",
-       "2    0\n",
-       "3    0\n",
-       "4    0\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "y_series = pd.Series(y)\n",
-    "y_series.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sfs1 = sfs1.fit(X_df, y_series)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the only difference of passing a pandas DataFrame as input is that the sfs1.subsets_ array will now contain a new column, "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{1: {'avg_score': 0.95999999999999996,\n",
-       "  'cv_scores': array([ 0.96]),\n",
-       "  'feature_idx': (3,),\n",
-       "  'feature_names': ('petal width',)},\n",
-       " 2: {'avg_score': 0.97333333333333338,\n",
-       "  'cv_scores': array([ 0.97333333]),\n",
-       "  'feature_idx': (2, 3),\n",
-       "  'feature_names': ('sepal width', 'petal width')},\n",
-       " 3: {'avg_score': 0.97333333333333338,\n",
-       "  'cv_scores': array([ 0.97333333]),\n",
-       "  'feature_idx': (1, 2, 3),\n",
-       "  'feature_names': ('petal len', 'sepal width', 'petal width')}}"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sfs1.subsets_"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In mlxtend version >= 0.13 pandas DataFrames are supported as feature inputs to the `SequentianFeatureSelector` instead of NumPy arrays or other NumPy-like array types."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Example 5 - Sequential Feature Selection for Regression"
    ]
   },
@@ -1283,11 +1065,99 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 6 -- Feature Selection with Fixed Train/Validation Splits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you do not wish to use cross-validation (here: k-fold cross-validation, i.e., rotating training and validation folds), you can use the `PredefinedSplit` class from scikit-learn to specify your own, fixed training and validation split. I.e., suppo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 72 112 132  88  37 138  87  42   8  90 141  33  59 116 135 104  36  13\n",
+      "  63  45  28 133  24 127  46  20  31 121 117   4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.model_selection import PredefinedSplit\n",
+    "import numpy as np\n",
+    "\n",
+    "piter = PredefinedSplit(np.arange(20))\n",
+    "piter\n",
+    "\n",
+    "\n",
+    "iris = load_iris()\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "\n",
+    "rng = np.random.RandomState(123)\n",
+    "my_validation_indices = rng.permutation(np.arange(150))[:30]\n",
+    "print(my_validation_indices)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
+      "[Parallel(n_jobs=1)]: Done   4 out of   4 | elapsed:    0.2s finished\n",
+      "\n",
+      "[2018-09-23 11:49:06] Features: 1/3 -- score: 1.0[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
+      "[Parallel(n_jobs=1)]: Done   3 out of   3 | elapsed:    0.1s finished\n",
+      "\n",
+      "[2018-09-23 11:49:06] Features: 2/3 -- score: 1.0[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
+      "[Parallel(n_jobs=1)]: Done   2 out of   2 | elapsed:    0.1s finished\n",
+      "\n",
+      "[2018-09-23 11:49:06] Features: 3/3 -- score: 1.0"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "from mlxtend.feature_selection import SequentialFeatureSelector as SFS\n",
+    "\n",
+    "\n",
+    "\n",
+    "knn = KNeighborsClassifier(n_neighbors=4)\n",
+    "piter = PredefinedSplit(my_validation_indices)\n",
+    "\n",
+    "sfs1 = SFS(knn, \n",
+    "           k_features=3, \n",
+    "           forward=True, \n",
+    "           floating=False, \n",
+    "           verbose=2,\n",
+    "           scoring='accuracy',\n",
+    "           cv=piter)\n",
+    "\n",
+    "sfs1 = sfs1.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
    "source": [
-    "## Example 6 -- Using the Selected Feature Subset For Making New Predictions"
+    "## Example 7 -- Using the Selected Feature Subset For Making New Predictions"
    ]
   },
   {
@@ -1382,7 +1252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 7 -- Sequential Feature Selection and GridSearch"
+    "## Example 8 -- Sequential Feature Selection and GridSearch"
    ]
   },
   {
@@ -1635,7 +1505,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 8 -- Selecting the \"best\"  feature combination in a k-range"
+    "## Example 9 -- Selecting the \"best\"  feature combination in a k-range"
    ]
   },
   {
@@ -1728,7 +1598,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 9 -- Using other cross-validation schemes"
+    "## Example 10 -- Using other cross-validation schemes"
    ]
   },
   {
@@ -1849,7 +1719,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 10 - Working with pandas DataFrames"
+    "## Example 11 - Working with pandas DataFrames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 12 - Using Pandas DataFrames"
    ]
   },
   {
@@ -1861,76 +1738,206 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
     "from sklearn.neighbors import KNeighborsClassifier\n",
     "from sklearn.datasets import load_iris\n",
+    "from mlxtend.feature_selection import SequentialFeatureSelector as SFS\n",
+    "\n",
     "\n",
     "iris = load_iris()\n",
-    "col_names = ('sepal length', 'sepal width',\n",
-    "             'petal length', 'petal width')\n",
-    "X_df = pd.DataFrame(iris.data, columns=col_names)\n",
-    "y_series = pd.Series(iris.target)\n",
-    "knn = KNeighborsClassifier(n_neighbors=4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
-      "[Parallel(n_jobs=1)]: Done   4 out of   4 | elapsed:    0.0s finished\n",
-      "\n",
-      "[2018-05-06 12:49:29] Features: 1/3 -- score: 0.96[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
-      "[Parallel(n_jobs=1)]: Done   3 out of   3 | elapsed:    0.0s finished\n",
-      "\n",
-      "[2018-05-06 12:49:29] Features: 2/3 -- score: 0.973333333333[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
-      "[Parallel(n_jobs=1)]: Done   2 out of   2 | elapsed:    0.0s finished\n",
-      "\n",
-      "[2018-05-06 12:49:29] Features: 3/3 -- score: 0.973333333333"
-     ]
-    }
-   ],
-   "source": [
-    "from mlxtend.feature_selection import SequentialFeatureSelector as SFS\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "knn = KNeighborsClassifier(n_neighbors=4)\n",
     "\n",
     "sfs1 = SFS(knn, \n",
     "           k_features=3, \n",
     "           forward=True, \n",
     "           floating=False, \n",
-    "           verbose=2,\n",
     "           scoring='accuracy',\n",
-    "           cv=0)\n",
-    "\n",
-    "sfs1 = sfs1.fit(X_df, y_series)"
+    "           cv=0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sepal len</th>\n",
+       "      <th>petal len</th>\n",
+       "      <th>sepal width</th>\n",
+       "      <th>petal width</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.1</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4.9</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>4.7</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>1.3</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4.6</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>3.6</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "('sepal width', 'petal length', 'petal width')"
+       "   sepal len  petal len  sepal width  petal width\n",
+       "0        5.1        3.5          1.4          0.2\n",
+       "1        4.9        3.0          1.4          0.2\n",
+       "2        4.7        3.2          1.3          0.2\n",
+       "3        4.6        3.1          1.5          0.2\n",
+       "4        5.0        3.6          1.4          0.2"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "sfs1.k_feature_names_"
+    "X_df = pd.DataFrame(X, columns=['sepal len', 'petal len',\n",
+    "                                'sepal width', 'petal width'])\n",
+    "X_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, the target array, `y`, can be optionally be cast as a Series:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    0\n",
+       "1    0\n",
+       "2    0\n",
+       "3    0\n",
+       "4    0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_series = pd.Series(y)\n",
+    "y_series.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sfs1 = sfs1.fit(X_df, y_series)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the only difference of passing a pandas DataFrame as input is that the sfs1.subsets_ array will now contain a new column, "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1: {'avg_score': 0.95999999999999996,\n",
+       "  'cv_scores': array([ 0.96]),\n",
+       "  'feature_idx': (3,),\n",
+       "  'feature_names': ('petal width',)},\n",
+       " 2: {'avg_score': 0.97333333333333338,\n",
+       "  'cv_scores': array([ 0.97333333]),\n",
+       "  'feature_idx': (2, 3),\n",
+       "  'feature_names': ('sepal width', 'petal width')},\n",
+       " 3: {'avg_score': 0.97333333333333338,\n",
+       "  'cv_scores': array([ 0.97333333]),\n",
+       "  'feature_idx': (1, 2, 3),\n",
+       "  'feature_names': ('petal len', 'sepal width', 'petal width')}}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sfs1.subsets_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In mlxtend version >= 0.13 pandas DataFrames are supported as feature inputs to the `SequentianFeatureSelector` instead of NumPy arrays or other NumPy-like array types."
    ]
   },
   {
@@ -2250,7 +2257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
### Description

Adds a documentation example for showing how to use pre-defined training/validation splits in the SequentialFeatureSelector



### Related issues or pull requests

Fixes #436 



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
