### PR TITLE
Adds sample_weight option to estimators fit method

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -17,7 +17,7 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - Added a `scatterplotmatrix` function to the `plotting` module. ([#437](https://github.com/rasbt/mlxtend/pull/437))
-
+- Added `sample_weight` option to `StackingRegressor`. ([#438](https://github.com/rasbt/mlxtend/issues/438))
 
 ##### Changes
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -17,7 +17,7 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - Added a `scatterplotmatrix` function to the `plotting` module. ([#437](https://github.com/rasbt/mlxtend/pull/437))
-- Added `sample_weight` option to `StackingRegressor`. ([#438](https://github.com/rasbt/mlxtend/issues/438))
+- Added `sample_weight` option to `StackingRegressor`, `StackingClassifier`, `StackingCVRegressor`, `StackingCVClassifier`, `EnsembleVoteClassifier`. ([#438](https://github.com/rasbt/mlxtend/issues/438))
 
 ##### Changes
 

--- a/mlxtend/classifier/ensemble_vote.py
+++ b/mlxtend/classifier/ensemble_vote.py
@@ -106,7 +106,7 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         self.verbose = verbose
         self.refit = refit
 
-    def fit(self, X, y):
+    def fit(self, X, y, sample_weight=None):
         """Learn weight coefficients from training data for each classifier.
 
         Parameters
@@ -117,6 +117,12 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         y : array-like, shape = [n_samples]
             Target values.
+
+        sample_weight : array-like, shape = [n_samples], optional
+            Sample weights passed as sample_weights to each regressor
+            in the regressors list as well as the meta_regressor.
+            Raises error if some regressor does not support
+            sample_weight in the fit() method.
 
         Returns
         -------
@@ -164,7 +170,11 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
                 if self.verbose > 1:
                     print(_name_estimators((clf,))[0][1])
 
-                clf.fit(X, self.le_.transform(y))
+                if sample_weight is None:
+                    clf.fit(X, self.le_.transform(y))
+                else:
+                    clf.fit(X, self.le_.transform(y), 
+                            sample_weight=sample_weight)
         return self
 
     def predict(self, X):

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -133,9 +133,9 @@ class StackingCVRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             folding strategies such as GroupKFold()
 
         sample_weight : array-like, shape = [n_samples], optional
-            Sample weights passed as sample_weights to 
-            each regressor in the regressors list as well as the meta_regressor.
-            Raises error if some regressor does not support 
+            Sample weights passed as sample_weights to each regressor
+            in the regressors list as well as the meta_regressor.
+            Raises error if some regressor does not support
             sample_weight in the fit() method.
 
         Returns

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -133,8 +133,10 @@ class StackingCVRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             folding strategies such as GroupKFold()
 
         sample_weight : array-like, shape = [n_samples], optional
-            Sample weights. Required that all regressors and 
-            meta_regressors has fit() method with sample_weight option.
+            Sample weights passed as sample_weights to 
+            each regressor in the regressors list as well as the meta_regressor.
+            Raises error if some regressor does not support 
+            sample_weight in the fit() method.
 
         Returns
         -------

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -195,11 +195,18 @@ class StackingCVRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             meta_features = sparse.hstack((X, meta_features))
         else:
             meta_features = np.hstack((X, meta_features))
-        self.meta_regr_.fit(meta_features, y, sample_weight=sample_weight)
+
+        if sample_weight is None:
+            self.meta_regr_.fit(meta_features, y)
+        else:
+            self.meta_regr_.fit(meta_features, y, sample_weight=sample_weight)
 
         # Retrain base models on all data
         for regr in self.regr_:
-            regr.fit(X, y, sample_weight=sample_weight)
+            if sample_weight is None:
+                regr.fit(X, y)
+            else:
+                regr.fit(X, y, sample_weight=sample_weight)
 
         return self
 

--- a/mlxtend/regressor/stacking_regression.py
+++ b/mlxtend/regressor/stacking_regression.py
@@ -112,7 +112,10 @@ class StackingRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
         y : array-like, shape = [n_samples] or [n_samples, n_targets]
             Target values.
         sample_weight : array-like, shape = [n_samples], optional
-            Sample weights.
+            Sample weights passed as sample_weights to each regressor
+            in the regressors list as well as the meta_regressor.
+            Raises error if some regressor does not support
+            sample_weight in the fit() method.
 
         Returns
         -------

--- a/mlxtend/regressor/stacking_regression.py
+++ b/mlxtend/regressor/stacking_regression.py
@@ -146,7 +146,10 @@ class StackingRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             if self.verbose > 1:
                 print(_name_estimators((regr,))[0][1])
 
-            regr.fit(X, y, sample_weight=sample_weight)
+            if sample_weight is None:
+                regr.fit(X, y)
+            else:
+                regr.fit(X, y, sample_weight=sample_weight)
 
         meta_features = self.predict_meta_features(X)
 
@@ -157,7 +160,11 @@ class StackingRegressor(BaseEstimator, RegressorMixin, TransformerMixin):
             meta_features = sparse.hstack((X, meta_features))
         else:
             meta_features = np.hstack((X, meta_features))
-        self.meta_regr_.fit(meta_features, y, sample_weight=sample_weight)
+
+        if sample_weight is None:
+            self.meta_regr_.fit(meta_features, y)
+        else:
+            self.meta_regr_.fit(meta_features, y, sample_weight=sample_weight)
 
         # save meta-features for training data
         if self.store_train_meta_features:

--- a/mlxtend/regressor/tests/test_stacking_cv_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_cv_regression.py
@@ -15,7 +15,6 @@ from mlxtend.regressor import StackingCVRegressor
 from mlxtend.utils import assert_raises
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import Ridge, Lasso
-from sklearn.neural_network import MLPRegressor
 from sklearn.svm import SVR
 from sklearn.model_selection import GridSearchCV, train_test_split, KFold
 from sklearn.base import clone
@@ -268,10 +267,13 @@ def test_sample_weight():
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf,
                                 cv=KFold(4, shuffle=True, random_state=7))
-    stack.fit(X1, y, sample_weight=w).predict(X1)
+    pred1 = stack.fit(X1, y, sample_weight=w).predict(X1)
     mse = 0.21  # 0.20770
     got = np.mean((stack.predict(X1) - y) ** 2)
     assert round(got, 2) == mse, "Expected %.2f, but got %.5f" % (mse, got)
+    pred2 = stack.fit(X1, y).predict(X1)
+    maxdiff = np.max(np.abs(pred1 - pred2))
+    assert maxdiff > 1e-3, "max diff is %.4f" % maxdiff
 
 
 def test_weight_ones():
@@ -299,7 +301,7 @@ def test_unsupported_regressor():
     svr_rbf = SVR(kernel='rbf')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge, lasso],
                                 meta_regressor=svr_rbf)
-    stack.fit(X1, y).predict(X1)
+    stack.fit(X1, y, sample_weight=w).predict(X1)
 
 
 @raises(TypeError)
@@ -307,7 +309,22 @@ def test_unsupported_meta_regressor():
     lr = LinearRegression()
     svr_lin = SVR(kernel='linear')
     ridge = Ridge(random_state=1)
-    mlp = MLPRegressor()
+    lasso = Lasso()
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
-                                meta_regressor=mlp)
+                                meta_regressor=lasso)
+    stack.fit(X1, y, sample_weight=w).predict(X1)
+
+
+def test_weight_unsupported_with_no_weight():
+    # should be okay since we do not pass weight
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    lasso = Lasso()
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, lasso],
+                                meta_regressor=ridge)
+    stack.fit(X1, y).predict(X1)
+
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
+                                meta_regressor=lasso)
     stack.fit(X1, y).predict(X1)

--- a/mlxtend/regressor/tests/test_stacking_cv_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_cv_regression.py
@@ -253,11 +253,12 @@ def test_sparse_matrix_inputs_with_features_in_secondary():
 
 
 # Calling for np.random will break the existing tests by changing the
-# seed for CV. 
+# seed for CV.
 # As a temporary workaround, we use random package to generate random w.
 random.seed(8)
 w = np.array([random.random() for _ in range(40)])
 # w  = np.random.random(40)
+
 
 def test_sample_weight():
     lr = LinearRegression()
@@ -274,8 +275,8 @@ def test_sample_weight():
 
 
 def test_weight_ones():
-    # sample_weight = None and sample_weight = ones 
-    # should give the same result, provided that the 
+    # sample_weight = None and sample_weight = ones
+    # should give the same result, provided that the
     # randomness of the models is controled
     lr = LinearRegression()
     svr_lin = SVR(kernel='linear')

--- a/mlxtend/regressor/tests/test_stacking_cv_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_cv_regression.py
@@ -7,16 +7,19 @@
 #
 # License: BSD 3 clause
 
+import random
 import numpy as np
 from scipy import sparse
 from mlxtend.externals.estimator_checks import NotFittedError
 from mlxtend.regressor import StackingCVRegressor
 from mlxtend.utils import assert_raises
 from sklearn.linear_model import LinearRegression
-from sklearn.linear_model import Ridge
+from sklearn.linear_model import Ridge, Lasso
+from sklearn.neural_network import MLPRegressor
 from sklearn.svm import SVR
-from sklearn.model_selection import GridSearchCV, train_test_split
+from sklearn.model_selection import GridSearchCV, train_test_split, KFold
 from sklearn.base import clone
+from nose.tools import raises
 
 
 # Some test data
@@ -247,3 +250,63 @@ def test_sparse_matrix_inputs_with_features_in_secondary():
     mse = 0.20
     got = np.mean((stack.predict(sparse.csr_matrix(X1)) - y) ** 2)
     assert round(got, 2) == mse
+
+
+# Calling for np.random will break the existing tests by changing the
+# seed for CV. 
+# As a temporary workaround, we use random package to generate random w.
+random.seed(8)
+w = np.array([random.random() for _ in range(40)])
+# w  = np.random.random(40)
+
+def test_sample_weight():
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    svr_rbf = SVR(kernel='rbf')
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
+                                meta_regressor=svr_rbf,
+                                cv=KFold(4, shuffle=True, random_state=7))
+    stack.fit(X1, y, sample_weight=w).predict(X1)
+    mse = 0.21  # 0.20770
+    got = np.mean((stack.predict(X1) - y) ** 2)
+    assert round(got, 2) == mse, "Expected %.2f, but got %.5f" % (mse, got)
+
+
+def test_weight_ones():
+    # sample_weight = None and sample_weight = ones 
+    # should give the same result, provided that the 
+    # randomness of the models is controled
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    svr_rbf = SVR(kernel='rbf')
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
+                                meta_regressor=svr_rbf,
+                                cv=KFold(5, shuffle=True, random_state=5))
+    pred1 = stack.fit(X1, y).predict(X1)
+    pred2 = stack.fit(X1, y, sample_weight=np.ones(40)).predict(X1)
+    assert np.max(np.abs(pred1 - pred2)) < 1e-3
+
+
+@raises(TypeError)
+def test_unsupported_regressor():
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    lasso = Lasso(random_state=1)
+    svr_rbf = SVR(kernel='rbf')
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge, lasso],
+                                meta_regressor=svr_rbf)
+    stack.fit(X1, y).predict(X1)
+
+
+@raises(TypeError)
+def test_unsupported_meta_regressor():
+    lr = LinearRegression()
+    svr_lin = SVR(kernel='linear')
+    ridge = Ridge(random_state=1)
+    mlp = MLPRegressor()
+    stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
+                                meta_regressor=mlp)
+    stack.fit(X1, y).predict(X1)


### PR DESCRIPTION
### Description

Adds `sample_weight` option to the `fit` method of estimators.
Aims to cover the followings:

- [x] StackingClassifier
- [x] StackingCVClassifier
- [x] EnsembleVoteClassifier
- [x] StackingRegressor
- [x] StackingCVRegressor



### Related issues or pull requests

Fixes #438 

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
