### PR TITLE
randomholdoutsplit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: required
 language: python
 matrix:
     include:
-        - python: 3.5
-          env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.18" PANDAS_VERSION="0.19.1"
         - python: 3.6
+          env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"
+        - python: 3.7
           env: LATEST="true" COVERAGE="true" NOTEBOOKS="true"
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: python
 matrix:
     include:
         - python: 3.6
-          env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"
-        - python: 3.7
-          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true"
+          env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
+        - python: 3.6
+          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
-          env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"
+          env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7
 install:
     - sudo apt-get update
     - source ci/.travis_install.sh

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -15,7 +15,7 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
 
-conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+conda create -q -n test-environment python=$MINICONDA_PYTHON_VERSION
 source activate test-environment
 
 if [ "${LATEST}" = "true" ]; then

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,6 +72,7 @@ pages:
     - user_guide/evaluate/paired_ttest_kfold_cv.md
     - user_guide/evaluate/paired_ttest_resampled.md
     - user_guide/evaluate/permutation_test.md
+    - user_guide/evaluate/RandomHoldoutSplit.md
     - user_guide/evaluate/scoring.md
   - feature_extraction:
     - user_guide/feature_extraction/LinearDiscriminantAnalysis.md

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -17,7 +17,7 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - Added a `scatterplotmatrix` function to the `plotting` module. ([#437](https://github.com/rasbt/mlxtend/pull/437))
-
+- Added a `RandomHoldoutSplit` class to perform a train/valid split without rotation in `SequentialFeatureSelector`, scikit-learn `GridSearchCV` etc. ([#442](https://github.com/rasbt/mlxtend/pull/442))
 
 ##### Changes
 

--- a/docs/sources/USER_GUIDE_INDEX.md
+++ b/docs/sources/USER_GUIDE_INDEX.md
@@ -38,6 +38,7 @@
 - [paired_ttest_kfold_cv](user_guide/evaluate/paired_ttest_kfold_cv.md)
 - [paired_ttest_resampled](user_guide/evaluate/paired_ttest_resampled.md)
 - [permutation_test](user_guide/evaluate/permutation_test.md)
+- [RandomHoldoutSplit](user_guide/evaluate/RandomHoldoutSplit.md)
 - [scoring](user_guide/evaluate/scoring.md)
 
 ## `feature_extraction`

--- a/docs/sources/user_guide/evaluate/RandomHoldoutSplit.ipynb
+++ b/docs/sources/user_guide/evaluate/RandomHoldoutSplit.ipynb
@@ -1,0 +1,303 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BootstrapOutOfBag"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Randomly split a dataset into a train and validation subset for validation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> `from mlxtend.evaluate import RandomHoldoutSplit`    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `RandomHoldoutSplit` class serves as an alternative to scikit-learn's `KFold class`, where the `RandomHoldoutSplit` class splits a dataset into training and a validation subsets without rotation. The `RandomHoldoutSplit` can be used as argument for `cv` parameters in scikit-learn's `GridSearchCV` etc.\n",
+    "\n",
+    "The term \"random\" in `RandomHoldoutSplit` comes from the fact that the split is specified by the `random_seed` rather than specifying the training and validation set indices manually as in the `PredefinedHoldoutSplit` class in mlxtend."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1 -- Iterating Over a RandomHoldoutSplit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from mlxtend.evaluate import RandomHoldoutSplit\n",
+    "from mlxtend.data import iris_data\n",
+    "\n",
+    "X, y = iris_data()\n",
+    "h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)\n",
+    "\n",
+    "cnt = 0\n",
+    "for train_ind, valid_ind in h_iter.split(X, y):\n",
+    "    cnt += 1\n",
+    "    print(cnt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 60  16  88 130   6]\n",
+      "[ 72 125  80  86 117]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(train_ind[:5])\n",
+    "print(valid_ind[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1 -- RandomHoldoutSplit in GridSearch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[mean: 0.95556, std: 0.00000, params: {'n_neighbors': 1}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 2}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 3}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 4}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 5}]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sebastian/miniconda3/lib/python3.6/site-packages/sklearn/model_selection/_search.py:761: DeprecationWarning: The grid_scores_ attribute was deprecated in version 0.18 in favor of the more elaborate cv_results_ attribute. The grid_scores_ attribute will not be available from 0.20\n",
+      "  DeprecationWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "from mlxtend.evaluate import RandomHoldoutSplit\n",
+    "from mlxtend.data import iris_data\n",
+    "\n",
+    "X, y = iris_data()\n",
+    "h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)\n",
+    "\n",
+    "\n",
+    "params = {'n_neighbors': [1, 2, 3, 4, 5]}\n",
+    "\n",
+    "grid = GridSearchCV(KNeighborsClassifier(),\n",
+    "                    param_grid=params,\n",
+    "                    cv=RandomHoldoutSplit(valid_size=0.3, random_seed=123))\n",
+    "\n",
+    "grid.fit(X, y)\n",
+    "\n",
+    "assert grid.n_splits_ == 1\n",
+    "print(grid.grid_scores_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## RandomHoldoutSplit\n",
+      "\n",
+      "*RandomHoldoutSplit(valid_size=0.5, random_seed=None, stratify=False)*\n",
+      "\n",
+      "Train/Validation set splitter for sklearn's GridSearchCV etc.\n",
+      "\n",
+      "Provides train/validation set indices to split a dataset\n",
+      "into train/validation sets using random indices.\n",
+      "\n",
+      "**Parameters**\n",
+      "\n",
+      "- `valid_size` : float (default: 0.5)\n",
+      "\n",
+      "    Proportion of examples that being assigned as\n",
+      "    validation examples. 1-`valid_size` will then automatically\n",
+      "    be assigned as training set examples.\n",
+      "\n",
+      "- `random_seed` : int (default: None)\n",
+      "\n",
+      "    The random seed for splitting the data\n",
+      "    into training and validation set partitions.\n",
+      "\n",
+      "- `stratify` : bool (default: False)\n",
+      "\n",
+      "    True or False, whether to perform a stratified\n",
+      "    split or not\n",
+      "\n",
+      "### Methods\n",
+      "\n",
+      "<hr>\n",
+      "\n",
+      "*get_n_splits(X=None, y=None, groups=None)*\n",
+      "\n",
+      "Returns the number of splitting iterations in the cross-validator\n",
+      "\n",
+      "**Parameters**\n",
+      "\n",
+      "- `X` : object\n",
+      "\n",
+      "    Always ignored, exists for compatibility.\n",
+      "\n",
+      "\n",
+      "- `y` : object\n",
+      "\n",
+      "    Always ignored, exists for compatibility.\n",
+      "\n",
+      "\n",
+      "- `groups` : object\n",
+      "\n",
+      "    Always ignored, exists for compatibility.\n",
+      "\n",
+      "**Returns**\n",
+      "\n",
+      "- `n_splits` : 1\n",
+      "\n",
+      "    Returns the number of splitting iterations in the cross-validator.\n",
+      "    Always returns 1.\n",
+      "\n",
+      "<hr>\n",
+      "\n",
+      "*split(X, y, groups=None)*\n",
+      "\n",
+      "Generate indices to split data into training and test set.\n",
+      "\n",
+      "**Parameters**\n",
+      "\n",
+      "- `X` : array-like, shape (num_examples, num_features)\n",
+      "\n",
+      "    Training data, where n_samples is the number of samples\n",
+      "    and n_features is the number of features.\n",
+      "\n",
+      "\n",
+      "- `y` : array-like, shape (num_examples,)\n",
+      "\n",
+      "    The target variable for supervised learning problems.\n",
+      "    Stratification is done based on the y labels.\n",
+      "\n",
+      "\n",
+      "- `groups` : object\n",
+      "\n",
+      "    Always ignored, exists for compatibility.\n",
+      "\n",
+      "**Yields**\n",
+      "\n",
+      "- `train_index` : ndarray\n",
+      "\n",
+      "    The training set indices for that split.\n",
+      "\n",
+      "\n",
+      "- `valid_index` : ndarray\n",
+      "\n",
+      "    The validation set indices for that split.\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open('../../api_modules/mlxtend.evaluate/RandomHoldoutSplit.md', 'r') as f:\n",
+    "    s = f.read() \n",
+    "print(s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/mlxtend/evaluate/__init__.py
+++ b/mlxtend/evaluate/__init__.py
@@ -20,6 +20,7 @@ from .scoring import scoring
 from .ttest import paired_ttest_resampled
 from .ttest import paired_ttest_kfold_cv
 from .ttest import paired_ttest_5x2cv
+from .holdout import RandomHoldoutSplit
 
 
 __all__ = ["scoring", "confusion_matrix",
@@ -29,4 +30,5 @@ __all__ = ["scoring", "confusion_matrix",
            "BootstrapOutOfBag", "bootstrap_point632_score",
            "cochrans_q", "paired_ttest_resampled",
            "paired_ttest_kfold_cv", "paired_ttest_5x2cv",
-           "feature_importance_permutation"]
+           "feature_importance_permutation",
+           "RandomHoldoutSplit"]

--- a/mlxtend/evaluate/holdout.py
+++ b/mlxtend/evaluate/holdout.py
@@ -1,0 +1,103 @@
+# Sebastian Raschka 2014-2018
+# mlxtend Machine Learning Library Extensions
+#
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+
+class RandomHoldoutSplit(object):
+    """Train/Validation set splitter for sklearn's GridSearchCV etc.
+
+    Provides train/validation set indices to split a dataset
+    into train/validation sets using random indices.
+
+    Parameters
+    ----------
+    valid_size : float (default: 0.5)
+        Proportion of examples that being assigned as
+        validation examples. 1-`valid_size` will then automatically
+        be assigned as training set examples.
+    random_seed : int (default: None)
+        The random seed for splitting the data
+        into training and validation set partitions.
+    stratify : bool (default: False)
+        True or False, whether to perform a stratified
+        split or not
+
+    """
+
+    def __init__(self, valid_size=0.5, random_seed=None, stratify=False):
+        self.valid_size = valid_size
+        self.random_seed = random_seed
+        self.stratify = stratify
+
+    def split(self, X, y, groups=None):
+        """Generate indices to split data into training and test set.
+
+        Parameters
+        ----------
+        X : array-like, shape (num_examples, num_features)
+            Training data, where n_samples is the number of samples
+            and n_features is the number of features.
+
+        y : array-like, shape (num_examples,)
+            The target variable for supervised learning problems.
+            Stratification is done based on the y labels.
+
+        groups : object
+            Always ignored, exists for compatibility.
+
+        Yields
+        ------
+        train_index : ndarray
+            The training set indices for that split.
+
+        valid_index : ndarray
+            The validation set indices for that split.
+        """
+        ind = np.arange(X.shape[0])
+        if self.stratify:
+            train_index, valid_index, _, _ = \
+                    train_test_split(ind, y,
+                                     test_size=self.valid_size,
+                                     shuffle=True,
+                                     stratify=y,
+                                     random_state=self.random_seed)
+
+        else:
+            train_index, valid_index, _, _ = \
+                    train_test_split(ind, y,
+                                     test_size=self.valid_size,
+                                     shuffle=True,
+                                     stratify=y,
+                                     random_state=self.random_seed)
+
+        for i in range(1):
+            yield train_index, valid_index
+
+    def get_n_splits(self, X=None, y=None, groups=None):
+        """Returns the number of splitting iterations in the cross-validator
+
+        Parameters
+        ----------
+        X : object
+            Always ignored, exists for compatibility.
+
+        y : object
+            Always ignored, exists for compatibility.
+
+        groups : object
+            Always ignored, exists for compatibility.
+
+        Returns
+        -------
+        n_splits : 1
+            Returns the number of splitting iterations in the cross-validator.
+            Always returns 1.
+        """
+        return 1

--- a/mlxtend/evaluate/tests/test_holdout.py
+++ b/mlxtend/evaluate/tests/test_holdout.py
@@ -1,0 +1,71 @@
+# Sebastian Raschka 2014-2018
+# mlxtend Machine Learning Library Extensions
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+import numpy as np
+from sklearn.model_selection import GridSearchCV
+from sklearn.neighbors import KNeighborsClassifier
+from mlxtend.feature_selection import SequentialFeatureSelector as SFS
+from mlxtend.evaluate import RandomHoldoutSplit
+from mlxtend.data import iris_data
+
+
+X, y = iris_data()
+
+
+def test_default_iter():
+    h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)
+
+    cnt = 0
+    for train_ind, valid_ind in h_iter.split(X, y):
+        cnt += 1
+
+    assert cnt == 1
+
+    expect_train_ind = np.array([60, 16, 88, 130, 6, 149, 7, 139, 83, 4,
+                                 147, 111, 108, 11, 44, 36, 31, 35, 40, 119,
+                                 107, 24, 103, 87, 10, 82, 29, 106, 104,
+                                 90, 118, 132, 129, 84, 85, 43, 74, 94,
+                                 73, 62, 69, 133, 52, 23, 1, 134, 96, 14, 50,
+                                 128, 8, 140, 0, 18, 55, 67, 75, 120, 78,
+                                 141, 126, 15, 5, 109, 102, 114, 3, 142, 26,
+                                 79, 71, 136, 137, 21, 48, 47, 70, 92,
+                                 124, 53, 121, 131, 54, 59, 81, 98, 49, 30,
+                                 99, 51, 112, 113, 27, 46, 97, 123, 89, 145,
+                                 95, 13, 58, 41, 12, 20, 148])
+    expect_valid_ind = np.array([72, 125, 80, 86, 117, 17, 33, 68, 2, 28, 122,
+                                 19, 116, 22, 91, 9, 146, 101, 38, 39, 37, 42,
+                                 25, 65, 32, 56, 115, 34, 76, 143, 144, 100,
+                                 138, 57, 93, 61, 127, 77, 110, 45, 135,
+                                 64, 66, 105, 63])
+    assert (train_ind == expect_train_ind).all()
+    assert (valid_ind == expect_valid_ind).all()
+
+
+def test_in_sfs():
+    h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)
+    knn = KNeighborsClassifier(n_neighbors=4)
+
+    sfs1 = SFS(knn,
+               k_features=3,
+               forward=True,
+               floating=False,
+               verbose=2,
+               scoring='accuracy',
+               cv=h_iter)
+
+    sfs1 = sfs1.fit(X, y)
+    d = sfs1.get_metric_dict()
+    assert d[1]['cv_scores'].shape[0] == 1
+
+
+def test_in_grid():
+    params = {'n_neighbors': [1, 2, 3, 4, 5]}
+
+    grid = GridSearchCV(KNeighborsClassifier(),
+                        param_grid=params,
+                        cv=RandomHoldoutSplit(valid_size=0.3, random_seed=123))
+    grid.fit(X, y)
+    assert grid.n_splits_ == 1


### PR DESCRIPTION
### Description

Adds a `RandomHoldoutSplit` class to perform a train/valid split without rotation in `SequentialFeatureSelector`, scikit-learn `GridSearchCV` etc.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
