### PR TITLE
PredefinedHoldoutSplit

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,6 +72,7 @@ pages:
     - user_guide/evaluate/paired_ttest_kfold_cv.md
     - user_guide/evaluate/paired_ttest_resampled.md
     - user_guide/evaluate/permutation_test.md
+    - user_guide/evaluate/PredefinedHoldoutSplit.md
     - user_guide/evaluate/RandomHoldoutSplit.md
     - user_guide/evaluate/scoring.md
   - feature_extraction:

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -18,7 +18,8 @@ The CHANGELOG for the current development version is available at
 
 - Added a `scatterplotmatrix` function to the `plotting` module. ([#437](https://github.com/rasbt/mlxtend/pull/437))
 - Added `sample_weight` option to `StackingRegressor`, `StackingClassifier`, `StackingCVRegressor`, `StackingCVClassifier`, `EnsembleVoteClassifier`. ([#438](https://github.com/rasbt/mlxtend/issues/438))
-- Added a `RandomHoldoutSplit` class to perform a train/valid split without rotation in `SequentialFeatureSelector`, scikit-learn `GridSearchCV` etc. ([#442](https://github.com/rasbt/mlxtend/pull/442))
+- Added a `RandomHoldoutSplit` class to perform a random train/valid split without rotation in `SequentialFeatureSelector`, scikit-learn `GridSearchCV` etc. ([#442](https://github.com/rasbt/mlxtend/pull/442))
+- Added a `PredefinedHoldoutSplit` class to perform a train/valid split, based on user-specified indices, without rotation in `SequentialFeatureSelector`, scikit-learn `GridSearchCV` etc. ([#443](https://github.com/rasbt/mlxtend/pull/443))
 
 ##### Changes
 

--- a/docs/sources/USER_GUIDE_INDEX.md
+++ b/docs/sources/USER_GUIDE_INDEX.md
@@ -38,6 +38,7 @@
 - [paired_ttest_kfold_cv](user_guide/evaluate/paired_ttest_kfold_cv.md)
 - [paired_ttest_resampled](user_guide/evaluate/paired_ttest_resampled.md)
 - [permutation_test](user_guide/evaluate/permutation_test.md)
+- [PredefinedHoldoutSplit](user_guide/evaluate/PredefinedHoldoutSplit.md)
 - [RandomHoldoutSplit](user_guide/evaluate/RandomHoldoutSplit.md)
 - [scoring](user_guide/evaluate/scoring.md)
 

--- a/docs/sources/user_guide/classifier/EnsembleVoteClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/EnsembleVoteClassifier.ipynb
@@ -1071,7 +1071,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit(X, y)*\n",
+      "*fit(X, y, sample_weight=None)*\n",
       "\n",
       "Learn weight coefficients from training data for each classifier.\n",
       "\n",
@@ -1086,6 +1086,14 @@
       "- `y` : array-like, shape = [n_samples]\n",
       "\n",
       "    Target values.\n",
+      "\n",
+      "\n",
+      "- `sample_weight` : array-like, shape = [n_samples], optional\n",
+      "\n",
+      "    Sample weights passed as sample_weights to each regressor\n",
+      "    in the regressors list as well as the meta_regressor.\n",
+      "    Raises error if some regressor does not support\n",
+      "    sample_weight in the fit() method.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -1266,7 +1274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},

--- a/docs/sources/user_guide/classifier/StackingCVClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/StackingCVClassifier.ipynb
@@ -508,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -639,7 +639,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit(X, y, groups=None)*\n",
+      "*fit(X, y, groups=None, sample_weight=None)*\n",
       "\n",
       "Fit ensemble classifers and the meta-classifier.\n",
       "\n",
@@ -660,6 +660,14 @@
       "\n",
       "    The group that each sample belongs to. This is used by specific\n",
       "    folding strategies such as GroupKFold()\n",
+      "\n",
+      "\n",
+      "- `sample_weight` : array-like, shape = [n_samples], optional\n",
+      "\n",
+      "    Sample weights passed as sample_weights to each regressor\n",
+      "    in the regressors list as well as the meta_regressor.\n",
+      "    Raises error if some regressor does not support\n",
+      "    sample_weight in the fit() method.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -836,7 +844,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},

--- a/docs/sources/user_guide/classifier/StackingClassifier.ipynb
+++ b/docs/sources/user_guide/classifier/StackingClassifier.ipynb
@@ -582,7 +582,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit(X, y)*\n",
+      "*fit(X, y, sample_weight=None)*\n",
       "\n",
       "Fit ensemble classifers and the meta-classifier.\n",
       "\n",
@@ -596,6 +596,13 @@
       "- `y` : array-like, shape = [n_samples] or [n_samples, n_outputs]\n",
       "\n",
       "    Target values.\n",
+      "\n",
+      "- `sample_weight` : array-like, shape = [n_samples], optional\n",
+      "\n",
+      "    Sample weights passed as sample_weights to each regressor\n",
+      "    in the regressors list as well as the meta_regressor.\n",
+      "    Raises error if some regressor does not support\n",
+      "    sample_weight in the fit() method.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -774,7 +781,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},

--- a/docs/sources/user_guide/evaluate/PredefinedHoldoutSplit.ipynb
+++ b/docs/sources/user_guide/evaluate/PredefinedHoldoutSplit.ipynb
@@ -4,21 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# RandomHoldoutSplit"
+    "# PredefinedHoldoutSplit"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Randomly split a dataset into a train and validation subset for validation."
+    "Split a dataset into a train and validation subset for validation based on user-specified indices."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> `from mlxtend.evaluate import RandomHoldoutSplit`    "
+    "> `from mlxtend.evaluate import PredefinedHoldoutSplit`    "
    ]
   },
   {
@@ -32,16 +32,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `RandomHoldoutSplit` class serves as an alternative to scikit-learn's `KFold` class, where the `RandomHoldoutSplit` class splits a dataset into training and a validation subsets without rotation. The `RandomHoldoutSplit` can be used as argument for `cv` parameters in scikit-learn's `GridSearchCV` etc.\n",
+    "The `PredefinedHoldoutSplit` class serves as an alternative to scikit-learn's `KFold` class, where the `PredefinedHoldoutSplit` class splits a dataset into training and a validation subsets without rotation, based on validation indices specified by the user. The `PredefinedHoldoutSplit` can be used as argument for `cv` parameters in scikit-learn's `GridSearchCV` etc.\n",
     "\n",
-    "The term \"random\" in `RandomHoldoutSplit` comes from the fact that the split is specified by the `random_seed` rather than specifying the training and validation set indices manually as in the `PredefinedHoldoutSplit` class in mlxtend."
+    "For performing a random split, see the related `RandomHoldoutSplit` class."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1 -- Iterating Over a RandomHoldoutSplit"
+    "## Example 1 -- Iterating Over a PredefinedHoldoutSplit"
    ]
   },
   {
@@ -58,11 +58,11 @@
     }
    ],
    "source": [
-    "from mlxtend.evaluate import RandomHoldoutSplit\n",
+    "from mlxtend.evaluate import PredefinedHoldoutSplit\n",
     "from mlxtend.data import iris_data\n",
     "\n",
     "X, y = iris_data()\n",
-    "h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)\n",
+    "h_iter = PredefinedHoldoutSplit(valid_indices=[0, 1, 99])\n",
     "\n",
     "cnt = 0\n",
     "for train_ind, valid_ind in h_iter.split(X, y):\n",
@@ -79,8 +79,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 60  16  88 130   6]\n",
-      "[ 72 125  80  86 117]\n"
+      "[2 3 4 5 6]\n",
+      "[ 0  1 99]\n"
      ]
     }
    ],
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 2 -- RandomHoldoutSplit in GridSearch"
+    "## Example 2 -- PredefinedHoldoutSplit in GridSearch"
    ]
   },
   {
@@ -105,7 +105,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[mean: 0.95556, std: 0.00000, params: {'n_neighbors': 1}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 2}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 3}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 4}, mean: 0.95556, std: 0.00000, params: {'n_neighbors': 5}]\n"
+      "[mean: 1.00000, std: 0.00000, params: {'n_neighbors': 1}, mean: 1.00000, std: 0.00000, params: {'n_neighbors': 2}, mean: 1.00000, std: 0.00000, params: {'n_neighbors': 3}, mean: 1.00000, std: 0.00000, params: {'n_neighbors': 4}, mean: 1.00000, std: 0.00000, params: {'n_neighbors': 5}]\n"
      ]
     },
     {
@@ -120,16 +120,17 @@
    "source": [
     "from sklearn.model_selection import GridSearchCV\n",
     "from sklearn.neighbors import KNeighborsClassifier\n",
-    "from mlxtend.evaluate import RandomHoldoutSplit\n",
+    "from mlxtend.evaluate import PredefinedHoldoutSplit\n",
     "from mlxtend.data import iris_data\n",
     "\n",
     "X, y = iris_data()\n",
+    "\n",
     "\n",
     "params = {'n_neighbors': [1, 2, 3, 4, 5]}\n",
     "\n",
     "grid = GridSearchCV(KNeighborsClassifier(),\n",
     "                    param_grid=params,\n",
-    "                    cv=RandomHoldoutSplit(valid_size=0.3, random_seed=123))\n",
+    "                    cv=PredefinedHoldoutSplit(valid_indices=[0, 1, 99]))\n",
     "\n",
     "grid.fit(X, y)\n",
     "\n",
@@ -153,32 +154,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "## RandomHoldoutSplit\n",
+      "## PredefinedHoldoutSplit\n",
       "\n",
-      "*RandomHoldoutSplit(valid_size=0.5, random_seed=None, stratify=False)*\n",
+      "*PredefinedHoldoutSplit(valid_indices)*\n",
       "\n",
       "Train/Validation set splitter for sklearn's GridSearchCV etc.\n",
       "\n",
-      "Provides train/validation set indices to split a dataset\n",
-      "into train/validation sets using random indices.\n",
+      "Uses user-specified train/validation set indices to split a dataset\n",
+      "into train/validation sets using user-defined or random\n",
+      "indices.\n",
       "\n",
       "**Parameters**\n",
       "\n",
-      "- `valid_size` : float (default: 0.5)\n",
+      "- `valid_indices` : array-like, shape (num_examples,)\n",
       "\n",
-      "    Proportion of examples that being assigned as\n",
-      "    validation examples. 1-`valid_size` will then automatically\n",
-      "    be assigned as training set examples.\n",
-      "\n",
-      "- `random_seed` : int (default: None)\n",
-      "\n",
-      "    The random seed for splitting the data\n",
-      "    into training and validation set partitions.\n",
-      "\n",
-      "- `stratify` : bool (default: False)\n",
-      "\n",
-      "    True or False, whether to perform a stratified\n",
-      "    split or not\n",
+      "    Indices of the training examples in the training set\n",
+      "    to be used for validation. All other indices in the\n",
+      "    training set are used to for a training subset\n",
+      "    for model fitting.\n",
       "\n",
       "### Methods\n",
       "\n",
@@ -221,8 +214,8 @@
       "\n",
       "- `X` : array-like, shape (num_examples, num_features)\n",
       "\n",
-      "    Training data, where num_examples is the number of\n",
-      "    training examples and num_features is the number of features.\n",
+      "    Training data, where num_examples is the number of examples\n",
+      "    and num_features is the number of features.\n",
       "\n",
       "\n",
       "- `y` : array-like, shape (num_examples,)\n",
@@ -251,7 +244,7 @@
     }
    ],
    "source": [
-    "with open('../../api_modules/mlxtend.evaluate/RandomHoldoutSplit.md', 'r') as f:\n",
+    "with open('../../api_modules/mlxtend.evaluate/PredefinedHoldoutSplit.md', 'r') as f:\n",
     "    s = f.read() \n",
     "print(s)"
    ]

--- a/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
+++ b/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
@@ -1074,12 +1074,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you do not wish to use cross-validation (here: k-fold cross-validation, i.e., rotating training and validation folds), you can use the `PredefinedSplit` class from scikit-learn to specify your own, fixed training and validation split. I.e., suppo"
+    "If you do not wish to use cross-validation (here: k-fold cross-validation, i.e., rotating training and validation folds), you can use the `PredefinedHoldoutSplit` class to specify your own, fixed training and validation split."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -1093,11 +1093,8 @@
    ],
    "source": [
     "from sklearn.datasets import load_iris\n",
-    "from sklearn.model_selection import PredefinedSplit\n",
+    "from mlxtend.evaluate import PredefinedHoldoutSplit\n",
     "import numpy as np\n",
-    "\n",
-    "piter = PredefinedSplit(np.arange(20))\n",
-    "piter\n",
     "\n",
     "\n",
     "iris = load_iris()\n",
@@ -1111,7 +1108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -1119,15 +1116,15 @@
      "output_type": "stream",
      "text": [
       "[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
-      "[Parallel(n_jobs=1)]: Done   4 out of   4 | elapsed:    0.2s finished\n",
+      "[Parallel(n_jobs=1)]: Done   4 out of   4 | elapsed:    0.0s finished\n",
       "\n",
-      "[2018-09-23 11:49:06] Features: 1/3 -- score: 1.0[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
-      "[Parallel(n_jobs=1)]: Done   3 out of   3 | elapsed:    0.1s finished\n",
+      "[2018-09-24 02:31:21] Features: 1/3 -- score: 0.9666666666666667[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
+      "[Parallel(n_jobs=1)]: Done   3 out of   3 | elapsed:    0.0s finished\n",
       "\n",
-      "[2018-09-23 11:49:06] Features: 2/3 -- score: 1.0[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
-      "[Parallel(n_jobs=1)]: Done   2 out of   2 | elapsed:    0.1s finished\n",
+      "[2018-09-24 02:31:21] Features: 2/3 -- score: 0.9666666666666667[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:    0.0s remaining:    0.0s\n",
+      "[Parallel(n_jobs=1)]: Done   2 out of   2 | elapsed:    0.0s finished\n",
       "\n",
-      "[2018-09-23 11:49:06] Features: 3/3 -- score: 1.0"
+      "[2018-09-24 02:31:21] Features: 3/3 -- score: 0.9666666666666667"
      ]
     }
    ],
@@ -1138,7 +1135,7 @@
     "\n",
     "\n",
     "knn = KNeighborsClassifier(n_neighbors=4)\n",
-    "piter = PredefinedSplit(my_validation_indices)\n",
+    "piter = PredefinedHoldoutSplit(my_validation_indices)\n",
     "\n",
     "sfs1 = SFS(knn, \n",
     "           k_features=3, \n",

--- a/docs/sources/user_guide/regressor/StackingCVRegressor.ipynb
+++ b/docs/sources/user_guide/regressor/StackingCVRegressor.ipynb
@@ -398,7 +398,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit(X, y, groups=None)*\n",
+      "*fit(X, y, groups=None, sample_weight=None)*\n",
       "\n",
       "Fit ensemble regressors and the meta-regressor.\n",
       "\n",
@@ -419,6 +419,14 @@
       "\n",
       "    The group that each sample belongs to. This is used by specific\n",
       "    folding strategies such as GroupKFold()\n",
+      "\n",
+      "\n",
+      "- `sample_weight` : array-like, shape = [n_samples], optional\n",
+      "\n",
+      "    Sample weights passed as sample_weights to each regressor\n",
+      "    in the regressors list as well as the meta_regressor.\n",
+      "    Raises error if some regressor does not support\n",
+      "    sample_weight in the fit() method.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -571,6 +579,13 @@
     "with open('../../api_modules/mlxtend.regressor/StackingCVRegressor.md', 'r') as f:\n",
     "    print(f.read())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -590,7 +605,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},

--- a/docs/sources/user_guide/regressor/StackingRegressor.ipynb
+++ b/docs/sources/user_guide/regressor/StackingRegressor.ipynb
@@ -722,7 +722,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit(X, y)*\n",
+      "*fit(X, y, sample_weight=None)*\n",
       "\n",
       "Learn weight coefficients from training data for each regressor.\n",
       "\n",
@@ -736,6 +736,13 @@
       "- `y` : array-like, shape = [n_samples] or [n_samples, n_targets]\n",
       "\n",
       "    Target values.\n",
+      "\n",
+      "- `sample_weight` : array-like, shape = [n_samples], optional\n",
+      "\n",
+      "    Sample weights passed as sample_weights to each regressor\n",
+      "    in the regressors list as well as the meta_regressor.\n",
+      "    Raises error if some regressor does not support\n",
+      "    sample_weight in the fit() method.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -915,7 +922,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/evaluate/__init__.py
+++ b/mlxtend/evaluate/__init__.py
@@ -21,6 +21,7 @@ from .ttest import paired_ttest_resampled
 from .ttest import paired_ttest_kfold_cv
 from .ttest import paired_ttest_5x2cv
 from .holdout import RandomHoldoutSplit
+from .holdout import PredefinedHoldoutSplit
 
 
 __all__ = ["scoring", "confusion_matrix",

--- a/mlxtend/evaluate/holdout.py
+++ b/mlxtend/evaluate/holdout.py
@@ -151,7 +151,7 @@ class PredefinedHoldoutSplit(object):
         ind = np.arange(X.shape[0])
         train_mask = np.ones(X.shape[0], dtype=np.bool)
         train_mask[self.valid_indices] = False
-        valid_mask = np.where(train_mask is True, False, True)
+        valid_mask = np.where(train_mask, False, True)
 
         for i in range(1):
             yield ind[train_mask], ind[valid_mask]

--- a/mlxtend/evaluate/holdout.py
+++ b/mlxtend/evaluate/holdout.py
@@ -151,8 +151,8 @@ class PredefinedHoldoutSplit(object):
         ind = np.arange(X.shape[0])
         train_mask = np.ones(X.shape[0], dtype=np.bool)
         train_mask[self.valid_indices] = False
-        valid_mask = np.where(train_mask==True, False, True)
-        
+        valid_mask = np.where(train_mask is True, False, True)
+
         for i in range(1):
             yield ind[train_mask], ind[valid_mask]
 
@@ -177,4 +177,3 @@ class PredefinedHoldoutSplit(object):
             Always returns 1.
         """
         return 1
-

--- a/mlxtend/evaluate/holdout.py
+++ b/mlxtend/evaluate/holdout.py
@@ -42,8 +42,8 @@ class RandomHoldoutSplit(object):
         Parameters
         ----------
         X : array-like, shape (num_examples, num_features)
-            Training data, where n_samples is the number of samples
-            and n_features is the number of features.
+            Training data, where num_examples is the number of
+            training examples and num_features is the number of features.
 
         y : array-like, shape (num_examples,)
             The target variable for supervised learning problems.
@@ -101,3 +101,80 @@ class RandomHoldoutSplit(object):
             Always returns 1.
         """
         return 1
+
+
+class PredefinedHoldoutSplit(object):
+    """Train/Validation set splitter for sklearn's GridSearchCV etc.
+
+    Uses user-specified train/validation set indices to split a dataset
+    into train/validation sets using user-defined or random
+    indices.
+
+    Parameters
+    ----------
+    valid_indices : array-like, shape (num_examples,)
+        Indices of the training examples in the training set
+        to be used for validation. All other indices in the
+        training set are used to for a training subset
+        for model fitting.
+
+    """
+
+    def __init__(self, valid_indices):
+        self.valid_indices = valid_indices
+
+    def split(self, X, y, groups=None):
+        """Generate indices to split data into training and test set.
+
+        Parameters
+        ----------
+        X : array-like, shape (num_examples, num_features)
+            Training data, where num_examples is the number of examples
+            and num_features is the number of features.
+
+        y : array-like, shape (num_examples,)
+            The target variable for supervised learning problems.
+            Stratification is done based on the y labels.
+
+        groups : object
+            Always ignored, exists for compatibility.
+
+        Yields
+        ------
+        train_index : ndarray
+            The training set indices for that split.
+
+        valid_index : ndarray
+            The validation set indices for that split.
+        """
+
+        ind = np.arange(X.shape[0])
+        train_mask = np.ones(X.shape[0], dtype=np.bool)
+        train_mask[self.valid_indices] = False
+        valid_mask = np.where(train_mask==True, False, True)
+        
+        for i in range(1):
+            yield ind[train_mask], ind[valid_mask]
+
+    def get_n_splits(self, X=None, y=None, groups=None):
+        """Returns the number of splitting iterations in the cross-validator
+
+        Parameters
+        ----------
+        X : object
+            Always ignored, exists for compatibility.
+
+        y : object
+            Always ignored, exists for compatibility.
+
+        groups : object
+            Always ignored, exists for compatibility.
+
+        Returns
+        -------
+        n_splits : 1
+            Returns the number of splitting iterations in the cross-validator.
+            Always returns 1.
+        """
+        return 1
+

--- a/mlxtend/evaluate/tests/test_holdout.py
+++ b/mlxtend/evaluate/tests/test_holdout.py
@@ -9,13 +9,14 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KNeighborsClassifier
 from mlxtend.feature_selection import SequentialFeatureSelector as SFS
 from mlxtend.evaluate import RandomHoldoutSplit
+from mlxtend.evaluate import PredefinedHoldoutSplit
 from mlxtend.data import iris_data
 
 
 X, y = iris_data()
 
 
-def test_default_iter():
+def test_randomholdoutsplit_default_iter():
     h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)
 
     cnt = 0
@@ -44,7 +45,7 @@ def test_default_iter():
     assert (valid_ind == expect_valid_ind).all()
 
 
-def test_in_sfs():
+def test_randomholdoutsplit_in_sfs():
     h_iter = RandomHoldoutSplit(valid_size=0.3, random_seed=123)
     knn = KNeighborsClassifier(n_neighbors=4)
 
@@ -61,11 +62,69 @@ def test_in_sfs():
     assert d[1]['cv_scores'].shape[0] == 1
 
 
-def test_in_grid():
+def test_randomholdoutsplit_in_grid():
     params = {'n_neighbors': [1, 2, 3, 4, 5]}
 
     grid = GridSearchCV(KNeighborsClassifier(),
                         param_grid=params,
                         cv=RandomHoldoutSplit(valid_size=0.3, random_seed=123))
+    grid.fit(X, y)
+    assert grid.n_splits_ == 1
+
+
+
+def test_predefinedholdoutsplit_default_iter():
+    h_iter = PredefinedHoldoutSplit(valid_indices=[0, 1, 99])
+
+    cnt = 0
+    for train_ind, valid_ind in h_iter.split(X, y):
+        cnt += 1
+
+    assert cnt == 1
+
+    expect_train_ind = np.array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+                                 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+                                 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+                                 44, 45, 46, 47, 48, 49, 50, 51, 52, 53,
+                                 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+                                 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+                                 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,
+                                 84, 85, 86, 87, 88, 89, 90, 91, 92, 93,
+                                 94, 95, 96, 97, 98, 100, 101, 102, 103,
+                                 104, 105, 106, 107, 108, 109, 110, 111,
+                                 112, 113, 114, 115, 116, 117, 118, 119,
+                                 120, 121, 122, 123, 124, 125, 126, 127,
+                                 128, 129, 130, 131, 132, 133, 134, 135,
+                                 136, 137, 138, 139, 140, 141, 142, 143,
+                                 144, 145, 146, 147, 148, 149])
+    expect_valid_ind = np.array([0, 1, 99])
+    assert (train_ind == expect_train_ind).all()
+    assert (valid_ind == expect_valid_ind).all()
+
+
+def test_predefinedholdoutsplit_in_sfs():
+    h_iter = PredefinedHoldoutSplit(valid_indices=[0, 1, 99])
+    knn = KNeighborsClassifier(n_neighbors=4)
+
+    sfs1 = SFS(knn,
+               k_features=3,
+               forward=True,
+               floating=False,
+               verbose=2,
+               scoring='accuracy',
+               cv=h_iter)
+
+    sfs1 = sfs1.fit(X, y)
+    d = sfs1.get_metric_dict()
+    assert d[1]['cv_scores'].shape[0] == 1
+
+
+def test_predefinedholdoutsplit_in_grid():
+    params = {'n_neighbors': [1, 3, 5]}
+
+    grid = GridSearchCV(KNeighborsClassifier(),
+                        param_grid=params,
+                        cv=PredefinedHoldoutSplit(valid_indices=[0, 1, 99]))
     grid.fit(X, y)
     assert grid.n_splits_ == 1

--- a/mlxtend/evaluate/tests/test_holdout.py
+++ b/mlxtend/evaluate/tests/test_holdout.py
@@ -72,7 +72,6 @@ def test_randomholdoutsplit_in_grid():
     assert grid.n_splits_ == 1
 
 
-
 def test_predefinedholdoutsplit_default_iter():
     h_iter = PredefinedHoldoutSplit(valid_indices=[0, 1, 99])
 
@@ -99,7 +98,8 @@ def test_predefinedholdoutsplit_default_iter():
                                  136, 137, 138, 139, 140, 141, 142, 143,
                                  144, 145, 146, 147, 148, 149])
     expect_valid_ind = np.array([0, 1, 99])
-    assert (train_ind == expect_train_ind).all()
+
+    np.testing.assert_equal(train_ind, expect_train_ind)
     assert (valid_ind == expect_valid_ind).all()
 
 


### PR DESCRIPTION
### Description

Adds a `PredefinedHoldoutSplit` class to perform a train/valid split, based on user-specified indices, without rotation in `SequentialFeatureSelector`, `GridSearchCV`, etc.




### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->