### PR TITLE
minor correction and extension of doc on lift score calculation

### DIFF
--- a/docs/sources/user_guide/evaluate/lift_score.ipynb
+++ b/docs/sources/user_guide/evaluate/lift_score.ipynb
@@ -268,21 +268,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   },
   "toc": {
    "nav_menu": {},

--- a/docs/sources/user_guide/evaluate/lift_score.ipynb
+++ b/docs/sources/user_guide/evaluate/lift_score.ipynb
@@ -62,25 +62,25 @@
     "Based on the confusion matrix above, with \"1\" as positive label, we compute *lift* as follows:\n",
     "\n",
     "$$\n",
-    "\\text{lift} = \\frac{(TP/(TP+FN)}{(TP+FP)/(TP+TN+FP+FN)}\n",
+    "\\text{lift} = \\frac{(TP/(TP+FP)}{(TP+FN)/(TP+TN+FP+FN)}\n",
     "$$\n",
     "\n",
     "Plugging in the actual values from the example above, we arrive at the following lift value:\n",
     "\n",
     "$$\n",
-    "\\frac{2/(2+4)}{(2+1)/(2+3+1+4)} = 1.11.\n",
+    "\\frac{2/(2+1)}{(2+4)/(2+3+1+4)} = 1.1111111111111112\n",
     "$$\n",
     "\n",
     "An alternative way to computing lift is by using the *support* metric [3]:\n",
     "\n",
     "$$\n",
-    "\\text{lift} = \\frac{\\text{support}(\\text{true labels} \\cup \\text{prediction})/N}{\\text{support}(\\text{true labels})/N \\times \\text{support}(\\text{prediction})/N},\n",
+    "\\text{lift} = \\frac{\\text{support}(\\text{true labels} \\cap \\text{prediction})}{\\text{support}(\\text{true labels}) \\times \\text{support}(\\text{prediction})},\n",
     "$$\n",
     "\n",
-    "where $N$ is the number of samples in the datset. Plugging the values from our example into the equation above, we arrive at\n",
+    "Support is $x / N$, where $x$ is the number of incidences of an observation and $N$ is the total number of samples in the datset. $\\text{true labels} \\cap \\text{prediction}$ are the true positives, $true labels$ are true positives plus false negatives, and $prediction$ are true positives plus false positives. Plugging the values from our example into the equation above, we arrive at:\n",
     "\n",
     "$$\n",
-    "\\frac{2/10}{(6/10 \\times 3/10)} = 1.11.\n",
+    "\\frac{2/10}{(6/10 \\times 3/10)} = 1.1111111111111112\n",
     "$$\n",
     "\n"
    ]
@@ -268,21 +268,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/evaluate/lift_score.py
+++ b/mlxtend/evaluate/lift_score.py
@@ -16,7 +16,7 @@ def lift_score(y_target, y_predicted, binary=True, positive_label=1):
     The in terms of True Positives (TP), True Negatives (TN),
     False Positives (FP), and False Negatives (FN), the lift score is
     computed as:
-    [ TP/(TP+FN) ] / [ (TP+FP) / (TP+TN+FP+FN) ]
+    [ TP / (TP+FP) ] / [ (TP+FN) / (TP+TN+FP+FN) ]
 
 
     Parameters


### PR DESCRIPTION
### Description

I've noticed a minor error in the documentation for lift score calculation. The union in $support(true labels∪prediction)/N$ should actually be an intersect. This is correctly implemented in the code but also incorrect on the referenced Wikipedia article. I have changed it here and also modified a few other points in the doc:

- modified confusion matrix based lift formula. The numerator is now identical with model precision. Result remains identical.
- modified support based lift formula. This previously included N. However, with the way that support is implemented in the code, division by N is already part of the support calculation and should therefore not be listed separately in the equation.
- updated results so that number of decimal places shown matches up between the different examples.


### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`