### PR TITLE
Support both scikit-learn 0.19 and 0.20 in unit tests

### DIFF
--- a/mlxtend/classifier/tests/test_ensemble_vote_classifier.py
+++ b/mlxtend/classifier/tests/test_ensemble_vote_classifier.py
@@ -142,7 +142,9 @@ def test_EnsembleVoteClassifier_weights():
 
 def test_EnsembleVoteClassifier_gridsearch():
 
-    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr', random_state=1)
+    clf1 = LogisticRegression(solver='liblinear',
+                              multi_class='ovr',
+                              random_state=1)
     clf2 = RandomForestClassifier(random_state=1)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='soft')
@@ -163,7 +165,9 @@ def test_EnsembleVoteClassifier_gridsearch():
 
 def test_EnsembleVoteClassifier_gridsearch_enumerate_names():
 
-    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr', random_state=1)
+    clf1 = LogisticRegression(solver='liblinear',
+                              multi_class='ovr',
+                              random_state=1)
     clf2 = RandomForestClassifier(random_state=1)
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf1, clf2])
 

--- a/mlxtend/classifier/tests/test_ensemble_vote_classifier.py
+++ b/mlxtend/classifier/tests/test_ensemble_vote_classifier.py
@@ -11,22 +11,21 @@ from sklearn.naive_bayes import GaussianNB
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.neighbors import KNeighborsClassifier
 import numpy as np
-from sklearn import datasets
+from mlxtend.data import iris_data
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import cross_val_score
 from sklearn.base import clone
 from nose.tools import raises
 
-
-iris = datasets.load_iris()
-X, y = iris.data[:, 1:3], iris.target
+X, y = iris_data()
+X = X[:, 1:3]
 
 
 def test_EnsembleVoteClassifier():
 
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='hard')
 
@@ -42,8 +41,8 @@ def test_EnsembleVoteClassifier():
 def test_sample_weight():
     # with no weight
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='hard')
     prob1 = eclf.fit(X, y).predict_proba(X)
@@ -51,8 +50,8 @@ def test_sample_weight():
     # with weight = 1
     w = np.ones(len(y))
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='hard')
     prob2 = eclf.fit(X, y, sample_weight=w).predict_proba(X)
@@ -61,8 +60,8 @@ def test_sample_weight():
     random.seed(87)
     w = np.array([random.random() for _ in range(len(y))])
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='hard')
     prob3 = eclf.fit(X, y, sample_weight=w).predict_proba(X)
@@ -77,8 +76,8 @@ def test_sample_weight():
 def test_no_weight_support():
     random.seed(87)
     w = np.array([random.random() for _ in range(len(y))])
-    logi = LogisticRegression()
-    rf = RandomForestClassifier()
+    logi = LogisticRegression(solver='liblinear', multi_class='ovr')
+    rf = RandomForestClassifier(n_estimators=10)
     gnb = GaussianNB()
     knn = KNeighborsClassifier()
     eclf = EnsembleVoteClassifier(clfs=[logi, rf, gnb, knn], voting='hard')
@@ -86,8 +85,8 @@ def test_no_weight_support():
 
 
 def test_no_weight_support_with_no_weight():
-    logi = LogisticRegression()
-    rf = RandomForestClassifier()
+    logi = LogisticRegression(solver='liblinear', multi_class='ovr')
+    rf = RandomForestClassifier(n_estimators=10)
     gnb = GaussianNB()
     knn = KNeighborsClassifier()
     eclf = EnsembleVoteClassifier(clfs=[logi, rf, gnb, knn], voting='hard')
@@ -125,8 +124,8 @@ def test_1model_probas():
 def test_EnsembleVoteClassifier_weights():
 
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3],
                                   voting='soft',
@@ -143,7 +142,7 @@ def test_EnsembleVoteClassifier_weights():
 
 def test_EnsembleVoteClassifier_gridsearch():
 
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr', random_state=1)
     clf2 = RandomForestClassifier(random_state=1)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='soft')
@@ -151,8 +150,10 @@ def test_EnsembleVoteClassifier_gridsearch():
     params = {'logisticregression__C': [1.0, 100.0],
               'randomforestclassifier__n_estimators': [20, 200]}
 
-    grid = GridSearchCV(estimator=eclf, param_grid=params, cv=5)
-    grid.fit(iris.data, iris.target)
+    grid = GridSearchCV(estimator=eclf, param_grid=params, cv=5, iid=False)
+
+    X, y = iris_data()
+    grid.fit(X, y)
 
     mean_scores = [round(s, 2) for s
                    in grid.cv_results_['mean_test_score']]
@@ -162,7 +163,7 @@ def test_EnsembleVoteClassifier_gridsearch():
 
 def test_EnsembleVoteClassifier_gridsearch_enumerate_names():
 
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr', random_state=1)
     clf2 = RandomForestClassifier(random_state=1)
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf1, clf2])
 
@@ -171,13 +172,15 @@ def test_EnsembleVoteClassifier_gridsearch_enumerate_names():
               'randomforestclassifier__n_estimators': [5, 20],
               'voting': ['hard', 'soft']}
 
-    grid = GridSearchCV(estimator=eclf, param_grid=params, cv=5)
-    grid = grid.fit(iris.data, iris.target)
+    grid = GridSearchCV(estimator=eclf, param_grid=params, cv=5, iid=False)
+
+    X, y = iris_data()
+    grid = grid.fit(X, y)
 
 
 def test_get_params():
     clf1 = KNeighborsClassifier(n_neighbors=1)
-    clf2 = RandomForestClassifier(random_state=1)
+    clf2 = RandomForestClassifier(random_state=1, n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3])
 
@@ -195,7 +198,7 @@ def test_get_params():
 
 def test_classifier_gridsearch():
     clf1 = KNeighborsClassifier(n_neighbors=1)
-    clf2 = RandomForestClassifier(random_state=1)
+    clf2 = RandomForestClassifier(random_state=1, n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1])
 
@@ -203,6 +206,7 @@ def test_classifier_gridsearch():
 
     grid = GridSearchCV(estimator=eclf,
                         param_grid=params,
+                        iid=False,
                         cv=5,
                         refit=True)
     grid.fit(X, y)
@@ -212,8 +216,8 @@ def test_classifier_gridsearch():
 
 def test_string_labels_numpy_array():
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='hard')
 
@@ -234,8 +238,8 @@ def test_string_labels_numpy_array():
 
 def test_string_labels_python_list():
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3], voting='hard')
 
@@ -254,8 +258,8 @@ def test_string_labels_python_list():
 
 def test_string_labels_refit_false():
     np.random.seed(123)
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
 
     y_str = y.copy()
@@ -285,8 +289,8 @@ def test_string_labels_refit_false():
 
 def test_clone():
 
-    clf1 = LogisticRegression()
-    clf2 = RandomForestClassifier()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf2, clf3],
                                   voting='hard',

--- a/mlxtend/classifier/tests/test_stacking_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_classifier.py
@@ -15,23 +15,28 @@ from sklearn.neighbors import KNeighborsClassifier
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import cross_val_score
 import numpy as np
-from sklearn import datasets
+from mlxtend.data import iris_data
 from mlxtend.utils import assert_raises
 from nose.tools import assert_almost_equal
 from sklearn.model_selection import train_test_split
 from sklearn.base import clone
 from nose.tools import raises
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
 
 
-iris = datasets.load_iris()
-X, y = iris.data[:, 1:3], iris.target
+X, y = iris_data()
+X = X[:, 1:3]
+
+
 y2 = np.c_[y, y]
 
 
 def test_StackingClassifier():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr',)
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               meta_classifier=meta)
@@ -42,7 +47,11 @@ def test_StackingClassifier():
                              cv=5,
                              scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
-    assert scores_mean == 0.95
+
+    if Version(sklearn_version) < Version("0.20"):
+        assert scores_mean == 0.95, scores_mean
+    else:
+        assert scores_mean == 0.95, scores_mean
 
 
 def test_sample_weight():
@@ -54,16 +63,18 @@ def test_sample_weight():
     w = np.array([random.random() for _ in range(len(y))])
 
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               meta_classifier=meta)
     prob1 = sclf.fit(X, y, sample_weight=w).predict_proba(X)
 
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               meta_classifier=meta)
@@ -73,8 +84,9 @@ def test_sample_weight():
     assert maxdiff > 1e-3, "max diff is %.4f" % maxdiff
 
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               meta_classifier=meta)
@@ -87,8 +99,10 @@ def test_sample_weight():
 @raises(TypeError)
 def test_weight_unsupported():
     # Error since KNN does not support sample_weight
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    np.random.seed(123)
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     clf3 = KNeighborsClassifier()
     sclf = StackingClassifier(classifiers=[clf1, clf2, clf3],
@@ -100,8 +114,10 @@ def test_weight_unsupported():
 
 def test_weight_unsupported_no_weight():
     # This is okay since we do not pass sample weight
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    np.random.seed(123)
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     clf3 = KNeighborsClassifier()
     sclf = StackingClassifier(classifiers=[clf1, clf2, clf3],
@@ -112,8 +128,10 @@ def test_weight_unsupported_no_weight():
 def test_StackingClassifier_proba_avg_1():
 
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr',
+                              random_state=1)
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_probas=True,
@@ -131,8 +149,9 @@ def test_StackingClassifier_proba_avg_1():
 def test_StackingClassifier_proba_concat_1():
 
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_probas=True,
@@ -150,7 +169,8 @@ def test_StackingClassifier_proba_concat_1():
 
 def test_StackingClassifier_avg_vs_concat():
     np.random.seed(123)
-    lr1 = LogisticRegression()
+    lr1 = LogisticRegression(solver='liblinear',
+                             multi_class='ovr')
     sclf1 = StackingClassifier(classifiers=[lr1, lr1],
                                use_probas=True,
                                average_probas=True,
@@ -178,7 +198,7 @@ def test_StackingClassifier_avg_vs_concat():
 def test_multivariate_class():
     np.random.seed(123)
     meta = KNeighborsClassifier()
-    clf1 = RandomForestClassifier()
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = KNeighborsClassifier()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               meta_classifier=meta)
@@ -189,8 +209,9 @@ def test_multivariate_class():
 
 def test_gridsearch():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               meta_classifier=meta)
@@ -198,19 +219,21 @@ def test_gridsearch():
     params = {'meta-logisticregression__C': [1.0, 100.0],
               'randomforestclassifier__n_estimators': [20, 200]}
 
-    grid = GridSearchCV(estimator=sclf, param_grid=params, cv=5)
-    grid.fit(iris.data, iris.target)
+    grid = GridSearchCV(estimator=sclf, param_grid=params, cv=5, iid=False)
+    X, y = iris_data()
+    grid.fit(X, y)
 
     mean_scores = [round(s, 2) for s
                    in grid.cv_results_['mean_test_score']]
 
-    assert mean_scores == [0.95, 0.97, 0.96, 0.96]
+    assert mean_scores == [0.95, 0.97, 0.96, 0.96], mean_scores
 
 
 def test_gridsearch_enumerate_names():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf1, clf2],
                               meta_classifier=meta)
@@ -220,14 +243,16 @@ def test_gridsearch_enumerate_names():
               'randomforestclassifier-2__n_estimators': [5, 20],
               'use_probas': [True, False]}
 
-    grid = GridSearchCV(estimator=sclf, param_grid=params, cv=5)
-    grid = grid.fit(iris.data, iris.target)
+    grid = GridSearchCV(estimator=sclf, param_grid=params, cv=5, iid=False)
+    X, y = iris_data()
+    grid = grid.fit(X, y)
 
 
 def test_use_probas():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_probas=True,
@@ -244,51 +269,58 @@ def test_use_probas():
 
 def test_not_fitted():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_probas=True,
                               meta_classifier=meta)
+
+    X, y = iris_data()
 
     assert_raises(NotFittedError,
                   "This StackingClassifier instance is not fitted yet."
                   " Call 'fit' with appropriate arguments"
                   " before using this method.",
                   sclf.predict,
-                  iris.data)
+                  X)
 
     assert_raises(NotFittedError,
                   "This StackingClassifier instance is not fitted yet."
                   " Call 'fit' with appropriate arguments"
                   " before using this method.",
                   sclf.predict_proba,
-                  iris.data)
+                  X)
 
     assert_raises(NotFittedError,
                   "This StackingClassifier instance is not fitted yet."
                   " Call 'fit' with appropriate arguments"
                   " before using this method.",
                   sclf.predict_meta_features,
-                  iris.data)
+                  X)
 
 
 def test_verbose():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_probas=True,
                               meta_classifier=meta,
                               verbose=3)
-    sclf.fit(iris.data, iris.target)
+    X, y = iris_data()
+    sclf.fit(X, y)
 
 
 def test_use_features_in_secondary_predict():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    X, y = iris_data()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_features_in_secondary=True,
@@ -305,8 +337,11 @@ def test_use_features_in_secondary_predict():
 
 def test_use_features_in_secondary_predict_proba():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    X, y = iris_data()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr',
+                              random_state=1)
+    clf1 = RandomForestClassifier(n_estimators=10, random_state=1)
     clf2 = GaussianNB()
     sclf = StackingClassifier(classifiers=[clf1, clf2],
                               use_features_in_secondary=True,
@@ -315,14 +350,17 @@ def test_use_features_in_secondary_predict_proba():
     sclf.fit(X, y)
     idx = [0, 1, 2]
     y_pred = sclf.predict_proba(X[idx])[:, 0]
-    expect = np.array([0.911, 0.829, 0.885])
+    expect = np.array([0.916, 0.828, 0.889])
     np.testing.assert_almost_equal(y_pred, expect, 3)
 
 
 def test_use_features_in_secondary_sparse_input_predict():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    X, y = iris_data()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr',
+                              random_state=1)
+    clf1 = RandomForestClassifier(n_estimators=10, random_state=1)
     sclf = StackingClassifier(classifiers=[clf1],
                               use_features_in_secondary=True,
                               meta_classifier=meta)
@@ -333,13 +371,14 @@ def test_use_features_in_secondary_sparse_input_predict():
                              cv=5,
                              scoring='accuracy')
     scores_mean = (round(scores.mean(), 2))
-    assert scores_mean == 0.95, scores_mean
+    assert scores_mean == 0.97, scores_mean
 
 
 def test_use_features_in_secondary_sparse_input_predict_proba():
     np.random.seed(123)
-    meta = LogisticRegression()
-    clf1 = RandomForestClassifier()
+    meta = LogisticRegression(solver='liblinear',
+                              multi_class='ovr')
+    clf1 = RandomForestClassifier(n_estimators=10)
     sclf = StackingClassifier(classifiers=[clf1],
                               use_features_in_secondary=True,
                               meta_classifier=meta)
@@ -354,10 +393,12 @@ def test_use_features_in_secondary_sparse_input_predict_proba():
 
 
 def test_get_params():
+    np.random.seed(123)
     clf1 = KNeighborsClassifier(n_neighbors=1)
-    clf2 = RandomForestClassifier(random_state=1)
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear',
+                            multi_class='ovr')
     sclf = StackingClassifier(classifiers=[clf1, clf2, clf3],
                               meta_classifier=lr)
 
@@ -378,10 +419,12 @@ def test_get_params():
 
 
 def test_classifier_gridsearch():
+    np.random.seed(123)
     clf1 = KNeighborsClassifier(n_neighbors=1)
-    clf2 = RandomForestClassifier(random_state=1)
+    clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear',
+                            multi_class='ovr')
     sclf = StackingClassifier(classifiers=[clf1, clf2, clf3],
                               meta_classifier=lr)
 
@@ -390,6 +433,7 @@ def test_classifier_gridsearch():
     grid = GridSearchCV(estimator=sclf,
                         param_grid=params,
                         cv=5,
+                        iid=False,
                         refit=True)
     grid.fit(X, y)
 
@@ -397,8 +441,10 @@ def test_classifier_gridsearch():
 
 
 def test_train_meta_features_():
+    np.random.seed(123)
     knn = KNeighborsClassifier()
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear',
+                            multi_class='ovr')
     gnb = GaussianNB()
     stclf = StackingClassifier(classifiers=[knn, gnb],
                                meta_classifier=lr,
@@ -411,7 +457,9 @@ def test_train_meta_features_():
 
 def test_predict_meta_features():
     knn = KNeighborsClassifier()
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear',
+                            multi_class='ovr',
+                            random_state=1)
     gnb = GaussianNB()
     X_train, X_test, y_train,  y_test = train_test_split(X, y, test_size=0.3)
 
@@ -425,9 +473,10 @@ def test_predict_meta_features():
 
 
 def test_clone():
-
+    np.random.seed(1)
     knn = KNeighborsClassifier()
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear',
+                            multi_class='ovr')
     gnb = GaussianNB()
     stclf = StackingClassifier(classifiers=[knn, gnb],
                                meta_classifier=lr,

--- a/mlxtend/evaluate/tests/test_bootstrap_point632.py
+++ b/mlxtend/evaluate/tests/test_bootstrap_point632.py
@@ -14,7 +14,7 @@ X, y = iris_data()
 
 
 def test_defaults():
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     scores = bootstrap_point632_score(lr, X, y, random_seed=123)
     acc = np.mean(scores)
     assert len(scores == 200)
@@ -23,7 +23,7 @@ def test_defaults():
 
 def test_invalid_splits():
     msg = 'Number of splits must be greater than 1. Got -1.'
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     assert_raises(ValueError,
                   msg,
                   bootstrap_point632_score,
@@ -35,7 +35,7 @@ def test_invalid_splits():
 
 def test_allowed_methods():
     msg = "The `method` must be in ('.632', '.632+'). Got 1."
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     assert_raises(ValueError,
                   msg,
                   bootstrap_point632_score,
@@ -46,7 +46,7 @@ def test_allowed_methods():
                   1)
 
     msg = "The `method` must be in ('.632', '.632+'). Got test."
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     assert_raises(ValueError,
                   msg,
                   bootstrap_point632_score,
@@ -56,9 +56,8 @@ def test_allowed_methods():
                   200,
                   'test')
 
-
     msg = "The .632+ method is not implemented, yet."
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     assert_raises(NotImplementedError,
                   msg,
                   bootstrap_point632_score,
@@ -70,7 +69,7 @@ def test_allowed_methods():
 
 
 def test_scoring():
-    lr = LogisticRegression()
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     scores = bootstrap_point632_score(lr, X[:100], y[:100],
                                       scoring='f1',
                                       random_seed=123)

--- a/mlxtend/evaluate/tests/test_feature_importance.py
+++ b/mlxtend/evaluate/tests/test_feature_importance.py
@@ -64,7 +64,7 @@ def test_classification():
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=0, stratify=y)
 
-    svm = SVC(C=1.0, kernel='rbf', random_state=0)
+    svm = SVC(C=1.0, kernel='rbf', random_state=0, gamma='auto')
     svm.fit(X_train, y_train)
 
     imp_vals, imp_all = feature_importance_permutation(
@@ -95,7 +95,7 @@ def test_regression():
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123)
 
-    svm = SVR(kernel='rbf')
+    svm = SVR(kernel='rbf', gamma='auto')
     svm.fit(X_train, y_train)
 
     imp_vals, imp_all = feature_importance_permutation(
@@ -127,7 +127,7 @@ def test_n_rounds():
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=0, stratify=y)
 
-    svm = SVC(C=1.0, kernel='rbf', random_state=0)
+    svm = SVC(C=1.0, kernel='rbf', random_state=0, gamma='auto')
     svm.fit(X_train, y_train)
 
     imp_vals, imp_all = feature_importance_permutation(

--- a/mlxtend/evaluate/tests/test_holdout.py
+++ b/mlxtend/evaluate/tests/test_holdout.py
@@ -66,6 +66,7 @@ def test_randomholdoutsplit_in_grid():
     params = {'n_neighbors': [1, 2, 3, 4, 5]}
 
     grid = GridSearchCV(KNeighborsClassifier(),
+                        iid=False,
                         param_grid=params,
                         cv=RandomHoldoutSplit(valid_size=0.3, random_seed=123))
     grid.fit(X, y)
@@ -125,6 +126,7 @@ def test_predefinedholdoutsplit_in_grid():
 
     grid = GridSearchCV(KNeighborsClassifier(),
                         param_grid=params,
+                        iid=False,
                         cv=PredefinedHoldoutSplit(valid_indices=[0, 1, 99]))
     grid.fit(X, y)
     assert grid.n_splits_ == 1

--- a/mlxtend/evaluate/tests/test_paired_ttest_5x2cv.py
+++ b/mlxtend/evaluate/tests/test_paired_ttest_5x2cv.py
@@ -12,11 +12,15 @@ from sklearn.linear_model import Lasso
 from sklearn.linear_model import Ridge
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import train_test_split
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
 
 
 def test_classifier_defaults():
     X, y = iris_data()
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(random_state=1,
+                              multi_class='ovr',
+                              solver='liblinear')
     clf2 = DecisionTreeClassifier(random_state=1)
 
     X_train, X_test, y_train, y_test = \
@@ -56,7 +60,8 @@ def test_classifier_defaults():
 
 def test_scoring():
     X, y = iris_data()
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(random_state=1, solver='liblinear',
+                              multi_class='ovr')
     clf2 = DecisionTreeClassifier(random_state=1)
 
     X_train, X_test, y_train, y_test = \
@@ -84,9 +89,12 @@ def test_scoring():
                               scoring='f1_macro',
                               random_seed=1)
 
-    assert round(t, 3) == -1.510, t
-    assert round(p, 3) == 0.191, p
-
+    if Version(sklearn_version) < Version('0.20'):
+        assert round(t, 3) == -1.510, t
+        assert round(p, 3) == 0.191, p
+    else:
+        assert round(t, 3) == -1.506, t
+        assert round(p, 3) == 0.192, p
 
 def test_regressor():
     X, y = boston_housing_data()

--- a/mlxtend/evaluate/tests/test_paired_ttest_5x2cv.py
+++ b/mlxtend/evaluate/tests/test_paired_ttest_5x2cv.py
@@ -96,6 +96,7 @@ def test_scoring():
         assert round(t, 3) == -1.506, t
         assert round(p, 3) == 0.192, p
 
+
 def test_regressor():
     X, y = boston_housing_data()
     reg1 = Lasso(random_state=1)

--- a/mlxtend/evaluate/tests/test_paired_ttest_kfold.py
+++ b/mlxtend/evaluate/tests/test_paired_ttest_kfold.py
@@ -16,7 +16,9 @@ from sklearn.model_selection import train_test_split
 
 def test_classifier_defaults():
     X, y = iris_data()
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(random_state=1,
+                              multi_class='ovr',
+                              solver='liblinear')
     clf2 = DecisionTreeClassifier(random_state=1)
 
     X_train, X_test, y_train, y_test = \
@@ -56,18 +58,20 @@ def test_classifier_defaults():
 
 def test_scoring():
     X, y = iris_data()
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(random_state=1,
+                              solver='liblinear',
+                              multi_class='ovr')
     clf2 = DecisionTreeClassifier(random_state=1)
 
     X_train, X_test, y_train, y_test = \
-        train_test_split(X, y, test_size=0.25,
+        train_test_split(X, y, test_size=0.5,
                          random_state=123)
 
     score1 = clf1.fit(X_train, y_train).score(X_test, y_test)
     score2 = clf2.fit(X_train, y_train).score(X_test, y_test)
 
-    assert round(score1, 2) == 0.97
-    assert round(score2, 2) == 0.95
+    assert round(score1, 2) == 0.96, round(score1, 2)
+    assert round(score2, 2) == 0.91, round(score2, 2)
 
     t, p = paired_ttest_kfold_cv(estimator1=clf1,
                                  estimator2=clf2,
@@ -81,11 +85,11 @@ def test_scoring():
     t, p = paired_ttest_kfold_cv(estimator1=clf1,
                                  estimator2=clf2,
                                  X=X, y=y,
-                                 scoring='f1_macro',
+                                 scoring='recall_micro',
                                  random_seed=1)
 
-    assert round(t, 3) == -1.872, t
-    assert round(p, 3) == 0.094, p
+    assert round(t, 3) == -1.861, t
+    assert round(p, 3) == 0.096, p
 
 
 def test_regressor():

--- a/mlxtend/evaluate/tests/test_paired_ttest_resampled.py
+++ b/mlxtend/evaluate/tests/test_paired_ttest_resampled.py
@@ -14,11 +14,13 @@ from sklearn.linear_model import Lasso
 from sklearn.linear_model import Ridge
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import train_test_split
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
 
 
 def test_train_size():
     X, y = iris_data()
-    clf1 = LogisticRegression()
+    clf1 = LogisticRegression(solver='liblinear', multi_class='ovr')
     clf2 = DecisionTreeClassifier()
 
     expected_err_msg = ("train_size must be of type int or float. "
@@ -39,7 +41,9 @@ def test_train_size():
 
 def test_classifier_defaults():
     X, y = iris_data()
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(multi_class='ovr',
+                              solver='liblinear',
+                              random_state=1)
     clf2 = DecisionTreeClassifier(random_state=1)
 
     X_train, X_test, y_train, y_test = \
@@ -57,8 +61,12 @@ def test_classifier_defaults():
                                   X=X, y=y,
                                   random_seed=1)
 
-    assert round(t, 3) == -1.809, t
-    assert round(p, 3) == 0.081, p
+    if Version(sklearn_version) < Version("0.20"):
+        assert round(t, 3) == -1.809, t
+        assert round(p, 3) == 0.081, p
+    else:
+        assert round(t, 3) == -1.702, t
+        assert round(p, 3) == 0.10, p
 
     # change maxdepth of decision tree classifier
 
@@ -79,7 +87,9 @@ def test_classifier_defaults():
 
 def test_scoring():
     X, y = iris_data()
-    clf1 = LogisticRegression(random_state=1)
+    clf1 = LogisticRegression(multi_class='ovr',
+                              solver='liblinear',
+                              random_state=1)
     clf2 = DecisionTreeClassifier(random_state=1)
 
     X_train, X_test, y_train, y_test = \
@@ -98,8 +108,12 @@ def test_scoring():
                                   scoring='accuracy',
                                   random_seed=1)
 
-    assert round(t, 3) == -1.809, t
-    assert round(p, 3) == 0.081, p
+    if Version(sklearn_version) < Version('0.20'):
+        assert round(t, 3) == -1.809, t
+        assert round(p, 3) == 0.081, p
+    else:
+        assert round(t, 3) == -1.702, t
+        assert round(p, 3) == 0.1, p
 
     t, p = paired_ttest_resampled(estimator1=clf1,
                                   estimator2=clf2,
@@ -107,8 +121,12 @@ def test_scoring():
                                   scoring='f1_macro',
                                   random_seed=1)
 
-    assert round(t, 3) == -1.690, t
-    assert round(p, 3) == 0.102, p
+    if Version(sklearn_version) < Version("0.20"):
+        assert round(t, 3) == -1.690, t
+        assert round(p, 3) == 0.102, p
+    else:
+        assert round(t, 3) == -1.561, t
+        assert round(p, 3) == 0.129, p
 
 
 def test_regressor():

--- a/mlxtend/feature_selection/tests/test_column_selector.py
+++ b/mlxtend/feature_selection/tests/test_column_selector.py
@@ -40,7 +40,8 @@ def test_ColumnSelector_in_gridsearch():
     iris = datasets.load_iris()
     X, y = iris.data, iris.target
     pipe = make_pipeline(ColumnSelector(),
-                         LogisticRegression(multi_class='ovr', solver='liblinear'))
+                         LogisticRegression(multi_class='ovr',
+                                            solver='liblinear'))
     grid = {'columnselector__cols': [[1, 2], [1, 2, 3], 0, [1]],
             'logisticregression__C': [0.1, 1.0, 10.0]}
 

--- a/mlxtend/feature_selection/tests/test_column_selector.py
+++ b/mlxtend/feature_selection/tests/test_column_selector.py
@@ -40,12 +40,13 @@ def test_ColumnSelector_in_gridsearch():
     iris = datasets.load_iris()
     X, y = iris.data, iris.target
     pipe = make_pipeline(ColumnSelector(),
-                         LogisticRegression())
+                         LogisticRegression(multi_class='ovr', solver='liblinear'))
     grid = {'columnselector__cols': [[1, 2], [1, 2, 3], 0, [1]],
             'logisticregression__C': [0.1, 1.0, 10.0]}
 
     gsearch1 = GridSearchCV(estimator=pipe,
                             param_grid=grid,
+                            iid=False,
                             cv=5,
                             n_jobs=1,
                             refit=False)
@@ -95,6 +96,7 @@ def test_ColumnSelector_with_dataframe_in_gridsearch():
                             param_grid=grid,
                             cv=5,
                             n_jobs=1,
+                            iid=False,
                             scoring='neg_mean_squared_error',
                             refit=False)
 

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -26,6 +26,9 @@ from mlxtend.classifier import SoftmaxRegression
 from mlxtend.feature_selection import SequentialFeatureSelector as SFS
 from mlxtend.utils import assert_raises
 
+from distutils.version import LooseVersion as Version
+from sklearn import __version__ as sklearn_version
+
 
 def nan_roc_auc_score(y_true, y_score, average='macro', sample_weight=None):
     if len(np.unique(y_true)) != 2:
@@ -453,7 +456,13 @@ def test_regression():
                 verbose=0)
     sfs_r = sfs_r.fit(X, y)
     assert len(sfs_r.k_feature_idx_) == 13
-    assert round(sfs_r.k_score_, 4) == -34.7631
+
+    if Version(sklearn_version) < '0.20':
+        assert round(sfs_r.k_score_, 4) == -34.7631, \
+            round(sfs_r.k_score_, 4)
+    else:
+        assert round(sfs_r.k_score_, 4) == -34.7053, \
+            round(sfs_r.k_score_, 4)
 
 
 def test_regression_sffs():
@@ -499,7 +508,11 @@ def test_regression_in_range():
                 verbose=0)
     sfs_r = sfs_r.fit(X, y)
     assert len(sfs_r.k_feature_idx_) == 9
-    assert round(sfs_r.k_score_, 4) == -31.1537
+
+    if Version(sklearn_version) < '0.20':
+        assert round(sfs_r.k_score_, 4) == -31.1537, round(sfs_r.k_score_, 4)
+    else:
+        assert round(sfs_r.k_score_, 4) == -31.1299, round(sfs_r.k_score_, 4)
 
 
 def test_clone_params_fail():
@@ -713,6 +726,7 @@ def test_gridsearch():
     gs = GridSearchCV(estimator=pipe,
                       param_grid=param_grid,
                       n_jobs=1,
+                      iid=False,
                       cv=5,
                       refit=False)
 

--- a/mlxtend/plotting/tests/test_learning_curves.py
+++ b/mlxtend/plotting/tests/test_learning_curves.py
@@ -17,7 +17,7 @@ def test_training_size():
     X = iris.data
     y = iris.target
     X_train, X_test, y_train, y_test = (train_test_split(X, y,
-                                        train_size=0.6, random_state=2))
+                                        test_size=0.4, random_state=2))
 
     clf = DecisionTreeClassifier(max_depth=1, random_state=1)
     training_errors, test_errors = (plot_learning_curves(X_train, y_train,
@@ -35,7 +35,7 @@ def test_scikit_metrics():
     X = iris.data
     y = iris.target
     X_train, X_test, y_train, y_test = (train_test_split(X, y,
-                                        train_size=0.6, random_state=2))
+                                        test_size=0.4, random_state=2))
 
     clf = DecisionTreeClassifier(max_depth=1, random_state=1)
     training_acc, test_acc = (plot_learning_curves(X_train, y_train,

--- a/mlxtend/preprocessing/tests/test_copy_transformer.py
+++ b/mlxtend/preprocessing/tests/test_copy_transformer.py
@@ -42,8 +42,9 @@ def test_pipeline():
     param_grid = [{'logisticregression__C': [1, 0.1, 10]}]
     pipe = make_pipeline(StandardScaler(),
                          CopyTransformer(),
-                         LogisticRegression())
-    grid = GridSearchCV(pipe, param_grid, cv=3, n_jobs=1)
+                         LogisticRegression(solver='liblinear',
+                                            multi_class='ovr'))
+    grid = GridSearchCV(pipe, param_grid, cv=3, n_jobs=1, iid=False)
     grid.fit(X, y)
 
 

--- a/mlxtend/preprocessing/tests/test_dense_transformer.py
+++ b/mlxtend/preprocessing/tests/test_dense_transformer.py
@@ -34,8 +34,8 @@ def test_sparse_to_dense():
 
 
 def test_pipeline():
-    rf = RandomForestClassifier()
+    rf = RandomForestClassifier(n_estimators=10)
     param_grid = [{'randomforestclassifier__n_estimators': [1, 5, 10]}]
     pipe = make_pipeline(StandardScaler(), DenseTransformer(), rf)
-    grid = GridSearchCV(pipe, param_grid, cv=3, n_jobs=1)
+    grid = GridSearchCV(pipe, param_grid, cv=3, n_jobs=1, iid=False)
     grid.fit(X, y)

--- a/mlxtend/regressor/tests/test_stacking_cv_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_cv_regression.py
@@ -33,9 +33,9 @@ y2 = np.zeros((40,))
 
 def test_different_models():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf)
     stack.fit(X1, y).predict(X1)
@@ -46,9 +46,9 @@ def test_different_models():
 
 def test_use_features_in_secondary():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf,
                                 cv=3,
@@ -61,9 +61,9 @@ def test_use_features_in_secondary():
 
 def test_multivariate():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf)
     stack.fit(X2, y).predict(X2)
@@ -89,9 +89,9 @@ def test_internals():
 
 
 def test_gridsearch_numerate_regr():
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, ridge, ridge],
                                 meta_regressor=svr_rbf)
 
@@ -104,6 +104,7 @@ def test_gridsearch_numerate_regr():
     grid = GridSearchCV(estimator=stack,
                         param_grid=params,
                         cv=5,
+                        iid=False,
                         refit=True,
                         verbose=0)
     grid = grid.fit(X1, y)
@@ -134,7 +135,7 @@ def test_get_params():
 
 def test_regressor_gridsearch():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr],
                                  meta_regressor=svr_rbf)
@@ -143,6 +144,7 @@ def test_regressor_gridsearch():
 
     grid = GridSearchCV(estimator=stregr,
                         param_grid=params,
+                        iid=False,
                         cv=5,
                         refit=True)
     grid.fit(X1, y)
@@ -152,7 +154,7 @@ def test_regressor_gridsearch():
 
 def test_predict_meta_features():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr, ridge],
                                  meta_regressor=svr_rbf)
@@ -164,7 +166,7 @@ def test_predict_meta_features():
 
 def test_train_meta_features_():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr, ridge],
                                  meta_regressor=svr_rbf,
@@ -177,7 +179,7 @@ def test_train_meta_features_():
 
 def test_not_fitted_predict():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr, ridge],
                                  meta_regressor=svr_rbf,
@@ -200,7 +202,7 @@ def test_not_fitted_predict():
 
 def test_clone():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingCVRegressor(regressors=[lr, ridge],
                                  meta_regressor=svr_rbf,
@@ -210,9 +212,9 @@ def test_clone():
 
 def test_sparse_matrix_inputs():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf)
 
@@ -231,9 +233,9 @@ def test_sparse_matrix_inputs():
 
 def test_sparse_matrix_inputs_with_features_in_secondary():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf,
                                 use_features_in_secondary=True)
@@ -261,9 +263,9 @@ w = np.array([random.random() for _ in range(40)])
 
 def test_sample_weight():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf,
                                 cv=KFold(4, shuffle=True, random_state=7))
@@ -281,9 +283,9 @@ def test_weight_ones():
     # should give the same result, provided that the
     # randomness of the models is controled
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
                                 meta_regressor=svr_rbf,
                                 cv=KFold(5, shuffle=True, random_state=5))
@@ -295,10 +297,10 @@ def test_weight_ones():
 @raises(TypeError)
 def test_unsupported_regressor():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     lasso = Lasso(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge, lasso],
                                 meta_regressor=svr_rbf)
     stack.fit(X1, y, sample_weight=w).predict(X1)
@@ -307,7 +309,7 @@ def test_unsupported_regressor():
 @raises(TypeError)
 def test_unsupported_meta_regressor():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     lasso = Lasso()
     stack = StackingCVRegressor(regressors=[svr_lin, lr, ridge],
@@ -318,7 +320,7 @@ def test_unsupported_meta_regressor():
 def test_weight_unsupported_with_no_weight():
     # should be okay since we do not pass weight
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     lasso = Lasso()
     stack = StackingCVRegressor(regressors=[svr_lin, lr, lasso],

--- a/mlxtend/regressor/tests/test_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_regression.py
@@ -33,9 +33,9 @@ w = np.random.random(40)
 
 def test_different_models():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge],
                                meta_regressor=svr_rbf)
     stregr.fit(X1, y).predict(X1)
@@ -46,9 +46,9 @@ def test_different_models():
 
 def test_multivariate():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge],
                                meta_regressor=svr_rbf)
     stregr.fit(X2, y).predict(X2)
@@ -73,9 +73,9 @@ def test_multivariate_class():
 
 def test_sample_weight():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge],
                                meta_regressor=svr_rbf)
     pred1 = stregr.fit(X1, y, sample_weight=w).predict(X1)
@@ -91,9 +91,9 @@ def test_sample_weight():
 def test_weight_ones():
     # sample weight of ones should produce equivalent outcome as no weight
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge],
                                meta_regressor=svr_rbf)
     pred1 = stregr.fit(X1, y).predict(X1)
@@ -107,9 +107,9 @@ def test_weight_unsupported_regressor():
     # including regressor that does not support
     # sample_weight should raise error
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     lasso = Lasso(random_state=1)
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge, lasso],
                                meta_regressor=svr_rbf)
@@ -121,7 +121,7 @@ def test_weight_unsupported_meta():
     # meta regressor with no support for
     # sample_weight should raise error
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     lasso = Lasso(random_state=1)
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge],
@@ -133,9 +133,9 @@ def test_weight_unsupported_with_no_weight():
     # pass no weight to regressors with no weight support
     # should not be a problem
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     lasso = Lasso(random_state=1)
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge, lasso],
                                meta_regressor=svr_rbf)
@@ -148,9 +148,9 @@ def test_weight_unsupported_with_no_weight():
 
 def test_gridsearch():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stregr = StackingRegressor(regressors=[svr_lin, lr, ridge],
                                meta_regressor=svr_rbf)
 
@@ -161,6 +161,7 @@ def test_gridsearch():
     grid = GridSearchCV(estimator=stregr,
                         param_grid=params,
                         cv=5,
+                        iid=False,
                         refit=True,
                         verbose=0)
     grid = grid.fit(X1, y)
@@ -170,9 +171,9 @@ def test_gridsearch():
 
 
 def test_gridsearch_numerate_regr():
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stregr = StackingRegressor(regressors=[svr_lin, ridge, ridge],
                                meta_regressor=svr_rbf)
 
@@ -184,6 +185,7 @@ def test_gridsearch_numerate_regr():
     grid = GridSearchCV(estimator=stregr,
                         param_grid=params,
                         cv=5,
+                        iid=False,
                         refit=True,
                         verbose=0)
     grid = grid.fit(X1, y)
@@ -194,7 +196,7 @@ def test_gridsearch_numerate_regr():
 
 def test_get_coeff():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[svr_lin, lr],
                                meta_regressor=ridge)
@@ -206,7 +208,7 @@ def test_get_coeff():
 
 def test_get_intercept():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[svr_lin, lr],
                                meta_regressor=ridge)
@@ -220,7 +222,7 @@ def test_get_intercept():
 @raises(AttributeError, ValueError)
 def test_get_coeff_fail():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[ridge, lr],
                                meta_regressor=svr_rbf)
@@ -231,7 +233,7 @@ def test_get_coeff_fail():
 
 def test_get_params():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[ridge, lr],
                                meta_regressor=svr_rbf)
@@ -251,7 +253,7 @@ def test_get_params():
 
 def test_regressor_gridsearch():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[lr],
                                meta_regressor=svr_rbf)
@@ -261,6 +263,7 @@ def test_regressor_gridsearch():
     grid = GridSearchCV(estimator=stregr,
                         param_grid=params,
                         cv=5,
+                        iid=False,
                         refit=True)
     grid.fit(X1, y)
 
@@ -269,7 +272,7 @@ def test_regressor_gridsearch():
 
 def test_predict_meta_features():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[lr, ridge],
                                meta_regressor=svr_rbf)
@@ -281,7 +284,7 @@ def test_predict_meta_features():
 
 def test_train_meta_features_():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[lr, ridge],
                                meta_regressor=svr_rbf,
@@ -294,7 +297,7 @@ def test_train_meta_features_():
 
 def test_not_fitted_predict():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[lr, ridge],
                                meta_regressor=svr_rbf,
@@ -317,7 +320,7 @@ def test_not_fitted_predict():
 
 def test_clone():
     lr = LinearRegression()
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[lr, ridge],
                                meta_regressor=svr_rbf,
@@ -327,10 +330,10 @@ def test_clone():
 
 def test_features_in_secondary():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
-    rf = RandomForestRegressor(random_state=2)
+    svr_lin = SVR(kernel='linear', gamma='auto')
+    rf = RandomForestRegressor(n_estimators=10, random_state=2)
     ridge = Ridge(random_state=0)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingRegressor(regressors=[svr_lin, lr, ridge, rf],
                               meta_regressor=svr_rbf,
                               use_features_in_secondary=True)
@@ -355,7 +358,7 @@ def test_features_in_secondary():
 
 def test_predictions_from_sparse_matrix():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
+    svr_lin = SVR(kernel='linear', gamma='auto')
     ridge = Ridge(random_state=1)
     stregr = StackingRegressor(regressors=[svr_lin, lr],
                                meta_regressor=ridge)
@@ -373,10 +376,10 @@ def test_predictions_from_sparse_matrix():
 
 def test_sparse_matrix_inputs_and_features_in_secondary():
     lr = LinearRegression()
-    svr_lin = SVR(kernel='linear')
-    rf = RandomForestRegressor(random_state=2)
+    svr_lin = SVR(kernel='linear', gamma='auto')
+    rf = RandomForestRegressor(n_estimators=10, random_state=2)
     ridge = Ridge(random_state=0)
-    svr_rbf = SVR(kernel='rbf')
+    svr_rbf = SVR(kernel='rbf', gamma='auto')
     stack = StackingRegressor(regressors=[svr_lin, lr, ridge, rf],
                               meta_regressor=svr_rbf,
                               use_features_in_secondary=True)


### PR DESCRIPTION
### Description

Makes appropriate changes in unit tests to also support scikit-learn 0.20.





### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
