### PR TITLE
try travis 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ matrix:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
         - python: 3.6
-          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
+          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.6
+        - python: 3.6 # python 3.7
+          env: LATEST="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
         - python: 3.6
-          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.6
-        - python: 3.6 # python 3.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     include:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
-        - python: 3.6
+        - python: 3.7
           env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
         - python: 3.6
-          env: LATEST="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
+          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
     include:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
-        - python: 3.7
-          env: LATEST="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
+        - python: 3.6
+          env: LATEST="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     include:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
-        - python: 3.7 # python 3.7
+        - python: 3.6 # python 3.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     include:
         - python: 3.6
           env: LATEST="false" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
-        - python: 3.6
+        - python: 3.7 # python 3.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7
           env: LATEST="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -13,6 +13,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
+conda update -q pip
 conda info -a
 
 conda create -q -n test-environment python=$MINICONDA_PYTHON_VERSION

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -29,7 +29,7 @@ fi
 conda install jupyter
 
 if [ "${COVERAGE}" = "true" ]; then
-    pip install coverage coveralls codecov
+    conda install coveralls
 fi
 
 python --version


### PR DESCRIPTION
### Description

In this particular Python 3.7 miniconda environment, pip has trouble installing coveralls

    pip._vendor.pkg_resources.RequirementParseError: Invalid requirement, parse error at "'; extra '"

Hence, for now, just use Python 3.6 for coveralls

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
