### PR TITLE
.632plus bootstrap

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,9 +4,6 @@ environment:
   matrix:
     - PYTHON_VERSION: 3.6
       MINICONDA: C:/Miniconda36-x64
-    - PYTHON_VERSION: 2.7
-      MINICONDA: C:/Miniconda-x64
-
 init:
   - ECHO %PYTHON_VERSION% %MINICONDA%
   - ECHO conda --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
         - python: 3.6
           env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.18.1" SKLEARN_VERSION="0.19" PANDAS_VERSION="0.19.1"  MINICONDA_PYTHON_VERSION=3.6
         - python: 3.6 # python 3.7
-          env: LATEST="true" IMAGE="true" COVERAGE="false" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
+          env: LATEST="true" IMAGE="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 3.6 # python 3.7
           env: LATEST="true" IMAGE="false" COVERAGE="false" NOTEBOOKS="false" MINICONDA_PYTHON_VERSION=3.7
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ matrix:
           env: LATEST="true" IMAGE="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 3.6 # python 3.7
           env: LATEST="true" IMAGE="false" COVERAGE="false" NOTEBOOKS="false" MINICONDA_PYTHON_VERSION=3.7
-        - python: 2.7
-          env: LATEST="true" IMAGE="true" COVERAGE="false" NOTEBOOKS="false"  MINICONDA_PYTHON_VERSION=2.7
+CONDA_PYTHON_VERSION=2.7
 install:
     - sudo apt-get update
     - source ci/.travis_install.sh

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/7vx20e0h5dxcyla2/branch/master?svg=true)](https://ci.appveyor.com/project/rasbt/mlxtend/branch/master)
 [![Code Health](https://landscape.io/github/rasbt/mlxtend/master/landscape.svg?style=flat)](https://landscape.io/github/rasbt/mlxtend/master)
 [![Coverage Status](https://coveralls.io/repos/rasbt/mlxtend/badge.svg?branch=master&service=github)](https://coveralls.io/github/rasbt/mlxtend?branch=master)
-![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
+![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)
 ![License](https://img.shields.io/badge/license-BSD-blue.svg)
 [![Discuss](https://img.shields.io/badge/discuss-google_group-blue.svg)](https://groups.google.com/forum/#!forum/mlxtend)
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -22,6 +22,8 @@ The CHANGELOG for the current development version is available at
 - Added a `PredefinedHoldoutSplit` class to perform a train/valid split, based on user-specified indices, without rotation in `SequentialFeatureSelector`, scikit-learn `GridSearchCV` etc. ([#443](https://github.com/rasbt/mlxtend/pull/443))
 - Created a new `mlxtend.image` submodule for working on image processing-related tasks. ([#457](https://github.com/rasbt/mlxtend/pull/457))
 - Added a new convenience function `extract_face_landmarks` based on `dlib` to `mlxtend.image`. ([#458](https://github.com/rasbt/mlxtend/pull/458))
+- Added a `method='oob'` option to the `mlxtend.evaluate.bootstrap_point632_score` method to compute the classic out-of-bag bootstrap estimate ([#459](https://github.com/rasbt/mlxtend/pull/459))
+- Added a `method='.632+'` option to the `mlxtend.evaluate.bootstrap_point632_score` method to compute the .632+ bootstrap estimate that addresses the optimism bias of the .632 bootstrap ([#459](https://github.com/rasbt/mlxtend/pull/459))
 
 ##### Changes
 

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -8,8 +8,8 @@
 
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00638/status.svg)](https://doi.org/10.21105/joss.00638)
 [![PyPI version](https://badge.fury.io/py/mlxtend.svg)](http://badge.fury.io/py/mlxtend)
-![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
+![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](./license)
 [![Discuss](https://img.shields.io/badge/discuss-google_group-blue.svg)](https://groups.google.com/forum/#!forum/mlxtend)
 

--- a/docs/sources/user_guide/evaluate/bootstrap_point632_score.ipynb
+++ b/docs/sources/user_guide/evaluate/bootstrap_point632_score.ipynb
@@ -40,8 +40,10 @@
     "The figure above illustrates how three random bootstrap samples drawn from an exemplary ten-sample dataset ($X_1,X_2, ..., X_{10}$) and their out-of-bag sample for testing may look like. In practice, Bradley Efron and Robert Tibshirani recommend drawing 50 to 200 bootstrap samples as being sufficient for reliable estimates [2].\n",
     "\n",
     "\n",
+    "### .632 Bootstrap\n",
     "\n",
-    "In 1983, Bradley Efron described the *.632 Estimate*, a further improvement to address the pessimistic bias of the bootstrap cross-validation approach described above (Efron, 1983). The pessimistic bias in the \"classic\" bootstrap method can be attributed to the fact that the bootstrap samples only contain approximately 63.2% of the unique samples from the original dataset. For instance, we can compute the probability that a given sample from a dataset of size *n* is *not* drawn as a bootstrap sample as\n",
+    "\n",
+    "In 1983, Bradley Efron described the *.632 Estimate*, a further improvement to address the pessimistic bias of the bootstrap cross-validation approach described above [3]. The pessimistic bias in the \"classic\" bootstrap method can be attributed to the fact that the bootstrap samples only contain approximately 63.2% of the unique samples from the original dataset. For instance, we can compute the probability that a given sample from a dataset of size *n* is *not* drawn as a bootstrap sample as\n",
     "\n",
     "$$P (\\text{not chosen}) =  \\bigg(1 - \\frac{1}{n}\\bigg)^n,$$\n",
     "\n",
@@ -54,7 +56,34 @@
     "\n",
     "$$\\text{ACC}_{boot} = \\frac{1}{b} \\sum_{i=1}^b \\big(0.632 \\cdot \\text{ACC}_{h, i} + 0.368 \\cdot \\text{ACC}_{r, i}\\big), $$\n",
     "\n",
-    "where $\\text{ACC}_{r, i}$ is the resubstitution accuracy, and $\\text{ACC}_{h, i}$ is the accuracy on the out-of-bag sample."
+    "where $\\text{ACC}_{r, i}$ is the resubstitution accuracy, and $\\text{ACC}_{h, i}$ is the accuracy on the out-of-bag sample.\n",
+    "\n",
+    "### .632+ Bootstrap\n",
+    "\n",
+    "Now, while the *.632 Boostrap* attempts to address the pessimistic bias of the estimate, an optimistic bias may occur with models that tend to overfit so that Bradley Efron and Robert Tibshirani proposed the *The .632+ Bootstrap Method* (Efron and Tibshirani, 1997). Instead of using a fixed \"weight\" $\\omega = 0.632$ in\n",
+    "\n",
+    "$$\n",
+    "ACC_{\\text{boot}} = \\frac{1}{b} \\sum_{i=1}^b \\big(\\omega \\cdot \\text{ACC}_{h, i} + (1-\\omega) \\cdot \\text{ACC}_{r, i} \\big), $$\n",
+    "\n",
+    "we compute the weight $\\gamma$ as\n",
+    "\n",
+    "$$\\omega = \\frac{0.632}{1 - 0.368 \\times R},$$\n",
+    "\n",
+    "where *R* is the *relative overfitting rate*\n",
+    "\n",
+    "$$R = \\frac{(-1) \\times (\\text{ACC}_{h, i} - \\text{ACC}_{r, i})}{\\gamma - (1 -\\text{ACC}_{h, i})}.$$\n",
+    "\n",
+    "(Since we are plugging $\\omega$ into the equation for computing $$ACC_{boot}$$ that we defined above, $$\\text{ACC}_{h, i}$$ and $\\text{ACC}_{r, i}$ still refer to the resubstitution and out-of-bag accuracy estimates in the *i*th bootstrap round, respectively.)\n",
+    "\n",
+    "Further, we need to determine the *no-information rate* $\\gamma$ in order to compute *R*. For instance, we can compute $\\gamma$ by fitting a model to a dataset that contains all possible combinations between samples $x_{i'}$ and target class labels $y_{i}$ &mdash; we pretend that the observations and class labels are independent:\n",
+    "\n",
+    "$$\\gamma = \\frac{1}{n^2} \\sum_{i=1}^{n} \\sum_{i '=1}^{n} L(y_{i}, f(x_{i '})).$$\n",
+    "\n",
+    "Alternatively, we can estimate the no-information rate $\\gamma$ as follows:\n",
+    "\n",
+    "$$\\gamma = \\sum_{k=1}^K p_k (1 - q_k),$$\n",
+    "\n",
+    "where $p_k$ is the proportion of class $k$ samples observed in the dataset, and $q_k$ is the proportion of class $k$ samples that the classifier predicts in the dataset."
    ]
   },
   {
@@ -64,14 +93,16 @@
     "### References\n",
     "\n",
     "- [1]  https://sebastianraschka.com/blog/2016/model-evaluation-selection-part2.html\n",
-    "- [2] Efron, Bradley, and Robert J. Tibshirani. An introduction to the bootstrap. CRC press, 1994. Management of Data (ACM SIGMOD '97), pages 265-276, 1997."
+    "- [2] Efron, Bradley, and Robert J. Tibshirani. An introduction to the bootstrap. CRC press, 1994. Management of Data (ACM SIGMOD '97), pages 265-276, 1997.\n",
+    "[3] Efron, Bradley. 1983. “Estimating the Error Rate of a Prediction Rule: Improvement on Cross-Validation.” Journal of the American Statistical Association 78 (382): 316. doi:10.2307/2288636.\n",
+    "- [4] Efron, Bradley, and Robert Tibshirani. 1997. “Improvements on Cross-Validation: The .632+ Bootstrap Method.” Journal of the American Statistical Association 92 (438): 548. doi:10.2307/2965703."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1 -- Evaluating the predictive performance of a model"
+    "## Example 1 -- Evaluating the predictive performance of a model via the classic out-of-bag Bootstrap"
    ]
   },
   {
@@ -90,23 +121,112 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 94.99%\n",
-      "95% Confidence interval: [90.76, 98.28]\n"
+      "Accuracy: 94.52%\n",
+      "95% Confidence interval: [88.88, 98.28]\n"
      ]
     }
    ],
    "source": [
-    "from sklearn import datasets, linear_model\n",
+    "from sklearn import datasets\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
     "from mlxtend.evaluate import bootstrap_point632_score\n",
     "import numpy as np\n",
     "\n",
     "iris = datasets.load_iris()\n",
     "X = iris.data\n",
     "y = iris.target\n",
-    "lr = linear_model.LogisticRegression()\n",
+    "tree = DecisionTreeClassifier(random_state=0)\n",
     "\n",
     "# Model accuracy\n",
-    "scores = bootstrap_point632_score(lr, X, y)\n",
+    "scores = bootstrap_point632_score(tree, X, y, method='oob')\n",
+    "acc = np.mean(scores)\n",
+    "print('Accuracy: %.2f%%' % (100*acc))\n",
+    "\n",
+    "\n",
+    "# Confidence interval\n",
+    "lower = np.percentile(scores, 2.5)\n",
+    "upper = np.percentile(scores, 97.5)\n",
+    "print('95%% Confidence interval: [%.2f, %.2f]' % (100*lower, 100*upper))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2 -- Evaluating the predictive performance of a model via the .632 Bootstrap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 96.58%\n",
+      "95% Confidence interval: [92.37, 98.97]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn import datasets\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from mlxtend.evaluate import bootstrap_point632_score\n",
+    "import numpy as np\n",
+    "\n",
+    "iris = datasets.load_iris()\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "tree = DecisionTreeClassifier(random_state=0)\n",
+    "\n",
+    "# Model accuracy\n",
+    "scores = bootstrap_point632_score(tree, X, y)\n",
+    "acc = np.mean(scores)\n",
+    "print('Accuracy: %.2f%%' % (100*acc))\n",
+    "\n",
+    "\n",
+    "# Confidence interval\n",
+    "lower = np.percentile(scores, 2.5)\n",
+    "upper = np.percentile(scores, 97.5)\n",
+    "print('95%% Confidence interval: [%.2f, %.2f]' % (100*lower, 100*upper))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3 -- Evaluating the predictive performance of a model via the .632+ Bootstrap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 96.40%\n",
+      "95% Confidence interval: [92.34, 99.00]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn import datasets\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from mlxtend.evaluate import bootstrap_point632_score\n",
+    "import numpy as np\n",
+    "\n",
+    "iris = datasets.load_iris()\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "tree = DecisionTreeClassifier(random_state=0)\n",
+    "\n",
+    "# Model accuracy\n",
+    "scores = bootstrap_point632_score(tree, X, y, method='.632+')\n",
     "acc = np.mean(scores)\n",
     "print('Accuracy: %.2f%%' % (100*acc))\n",
     "\n",
@@ -126,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -135,9 +255,21 @@
      "text": [
       "## bootstrap_point632_score\n",
       "\n",
-      "*bootstrap_point632_score(estimator, X, y, n_splits=200, method='.632', scoring=None, random_seed=None)*\n",
+      "*bootstrap_point632_score(estimator, X, y, n_splits=200, method='.632', scoring_func=None, random_seed=None, clone_estimator=True)*\n",
       "\n",
-      "Implementation of the 0.632 bootstrap for supervised learning\n",
+      "Implementation of the .632 [1] and .632+ [2] bootstrap\n",
+      "for supervised learning\n",
+      "\n",
+      "References:\n",
+      "\n",
+      "- [1] Efron, Bradley. 1983. “Estimating the Error Rate\n",
+      "of a Prediction Rule: Improvement on Cross-Validation.”\n",
+      "Journal of the American Statistical Association\n",
+      "78 (382): 316. doi:10.2307/2288636.\n",
+      "- [2] Efron, Bradley, and Robert Tibshirani. 1997.\n",
+      "“Improvements on Cross-Validation: The .632+ Bootstrap Method.”\n",
+      "Journal of the American Statistical Association\n",
+      "92 (438): 548. doi:10.2307/2965703.\n",
       "\n",
       "**Parameters**\n",
       "\n",
@@ -167,30 +299,33 @@
       "\n",
       "- `method` : str (default='.632')\n",
       "\n",
-      "    The bootstrap method, which can be either the\n",
-      "    regular '.632' bootstrap (default) or the '.632+'\n",
-      "    bootstrap (not implemented, yet).\n",
+      "    The bootstrap method, which can be either\n",
+      "    - 1) '.632' bootstrap (default)\n",
+      "    - 2) '.632+' bootstrap\n",
+      "    - 3) 'oob' (regular out-of-bag, no weighting)\n",
+      "    for comparison studies.\n",
       "\n",
       "\n",
-      "- `scoring` : str, callable, or None (default: None)\n",
+      "- `scoring_func` : callable,\n",
       "\n",
-      "    If None (default), uses 'accuracy' for sklearn classifiers\n",
-      "    and 'r2' for sklearn regressors.\n",
-      "    If str, uses a sklearn scoring metric string identifier, for example\n",
-      "    {'accuracy', 'f1', 'precision', 'recall', 'roc_auc', etc.}\n",
-      "    for classifiers,\n",
-      "    {'mean_absolute_error', 'mean_squared_error'/'neg_mean_squared_error',\n",
-      "    'median_absolute_error', 'r2', etc.} for regressors.\n",
-      "    If a callable object or function is provided, it has to be conform with\n",
-      "    sklearn's signature ``scorer(estimator, X, y)``; see\n",
-      "    http://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html\n",
-      "    for more information.\n",
+      "    Score function (or loss function) with signature\n",
+      "``scoring_func(y, y_pred, **kwargs)``.\n",
+      "    If none, uses classification accuracy if the\n",
+      "\n",
+      "estimator is a classifier and mean squared error\n",
+      "    if the estimator is a regressor.\n",
       "\n",
       "\n",
       "- `random_seed` : int (default=None)\n",
       "\n",
       "    If int, random_seed is the seed used by\n",
       "    the random number generator.\n",
+      "\n",
+      "\n",
+      "- `clone_estimator` : bool (default=True)\n",
+      "\n",
+      "    Clones the estimator if true, otherwise fits\n",
+      "    the original.\n",
       "\n",
       "**Returns**\n",
       "\n",
@@ -248,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.7"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/evaluate/bootstrap_point632.py
+++ b/mlxtend/evaluate/bootstrap_point632.py
@@ -24,7 +24,8 @@ def _check_arrays(X, y=None):
             raise ValueError('y must be a 1D array.')
 
     if not len(y) == X.shape[0]:
-        raise ValueError('X and y must contain the same number of samples')
+        raise ValueError('X and y must contain the'
+                         'same number of samples')
 
 
 def no_information_rate(targets, predictions, loss_fn):

--- a/mlxtend/evaluate/bootstrap_point632.py
+++ b/mlxtend/evaluate/bootstrap_point632.py
@@ -51,12 +51,12 @@ def bootstrap_point632_score(estimator, X, y, n_splits=200,
 
     References:
 
-    - [1] Efron, Bradley. 1983. “Estimating the Error Rate
-      of a Prediction Rule: Improvement on Cross-Validation.”
+    - [1] Efron, Bradley. 1983. "Estimating the Error Rate
+      of a Prediction Rule: Improvement on Cross-Validation."
       Journal of the American Statistical Association
       78 (382): 316. doi:10.2307/2288636.
     - [2] Efron, Bradley, and Robert Tibshirani. 1997.
-      “Improvements on Cross-Validation: The .632+ Bootstrap Method.”
+      "Improvements on Cross-Validation: The .632+ Bootstrap Method."
       Journal of the American Statistical Association
       92 (438): 548. doi:10.2307/2965703.
 

--- a/mlxtend/evaluate/bootstrap_point632.py
+++ b/mlxtend/evaluate/bootstrap_point632.py
@@ -8,7 +8,6 @@
 
 import numpy as np
 from .bootstrap_outofbag import BootstrapOutOfBag
-from sklearn.metrics.scorer import check_scoring
 from sklearn.base import clone
 
 
@@ -28,10 +27,37 @@ def _check_arrays(X, y=None):
         raise ValueError('X and y must contain the same number of samples')
 
 
+def no_information_rate(targets, predictions, loss_fn):
+    combinations = np.array(np.meshgrid(targets, predictions)).reshape(-1, 2)
+    return loss_fn(combinations[:, 0], combinations[:, 1])
+
+
+def accuracy(targets, predictions):
+    return np.mean(np.array(targets) == np.array(predictions))
+
+
+def mse(targets, predictions):
+    return np.mean((np.array(targets) - np.array(predictions))**2)
+
+
 def bootstrap_point632_score(estimator, X, y, n_splits=200,
-                             method='.632', scoring=None, random_seed=None):
+                             method='.632', scoring_func=None,
+                             random_seed=None,
+                             clone_estimator=True):
     """
-    Implementation of the 0.632 bootstrap for supervised learning
+    Implementation of the .632 [1] and .632+ [2] bootstrap
+    for supervised learning
+
+    References:
+
+    - [1] Efron, Bradley. 1983. “Estimating the Error Rate
+      of a Prediction Rule: Improvement on Cross-Validation.”
+      Journal of the American Statistical Association
+      78 (382): 316. doi:10.2307/2288636.
+    - [2] Efron, Bradley, and Robert Tibshirani. 1997.
+      “Improvements on Cross-Validation: The .632+ Bootstrap Method.”
+      Journal of the American Statistical Association
+      92 (438): 548. doi:10.2307/2965703.
 
     Parameters
     ----------
@@ -52,26 +78,26 @@ def bootstrap_point632_score(estimator, X, y, n_splits=200,
         Must be larger than 1.
 
     method : str (default='.632')
-        The bootstrap method, which can be either the
-        regular '.632' bootstrap (default) or the '.632+'
-        bootstrap (not implemented, yet).
+        The bootstrap method, which can be either
+        - 1) '.632' bootstrap (default)
+        - 2) '.632+' bootstrap
+        - 3) 'oob' (regular out-of-bag, no weighting)
+        for comparison studies.
 
-    scoring : str, callable, or None (default: None)
-        If None (default), uses 'accuracy' for sklearn classifiers
-        and 'r2' for sklearn regressors.
-        If str, uses a sklearn scoring metric string identifier, for example
-        {'accuracy', 'f1', 'precision', 'recall', 'roc_auc', etc.}
-        for classifiers,
-        {'mean_absolute_error', 'mean_squared_error'/'neg_mean_squared_error',
-        'median_absolute_error', 'r2', etc.} for regressors.
-        If a callable object or function is provided, it has to be conform with
-        sklearn's signature ``scorer(estimator, X, y)``; see
-        http://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html
-        for more information.
+    scoring_func : callable,
+        Score function (or loss function) with signature
+        ``scoring_func(y, y_pred, **kwargs)``.
+        If none, uses classification accuracy if the
+        estimator is a classifier and mean squared error
+        if the estimator is a regressor.
 
     random_seed : int (default=None)
         If int, random_seed is the seed used by
         the random number generator.
+
+    clone_estimator : bool (default=True)
+        Clones the estimator if true, otherwise fits
+        the original.
 
     Returns
     -------
@@ -104,27 +130,52 @@ def bootstrap_point632_score(estimator, X, y, n_splits=200,
         raise ValueError('Number of splits must be'
                          ' greater than 1. Got %s.' % n_splits)
 
-    allowed_methods = ('.632', '.632+')
+    allowed_methods = ('.632', '.632+', 'oob')
     if not isinstance(method, str) or method not in allowed_methods:
         raise ValueError('The `method` must '
                          'be in %s. Got %s.' % (allowed_methods, method))
 
-    if method == '.632+':
-        raise NotImplementedError('The .632+ method is not implemented, yet.')
-
     _check_arrays(X, y)
 
-    estimator = clone(estimator)
-    scorer = check_scoring(estimator, scoring=scoring)
+    if clone_estimator:
+        cloned_est = clone(estimator)
+    else:
+        cloned_est = estimator
+
+    if scoring_func is None:
+        if cloned_est._estimator_type == 'classifier':
+            scoring_func = accuracy
+        elif cloned_est._estimator_type == 'regressor':
+            scoring_func = mse
+        else:
+            raise AttributeError('Estimator type undefined.'
+                                 'Please provide a scoring_func argument.')
 
     oob = BootstrapOutOfBag(n_splits=n_splits, random_seed=random_seed)
     scores = np.empty(dtype=np.float, shape=(n_splits,))
     cnt = 0
     for train, test in oob.split(X):
-        estimator.fit(X[train], y[train])
-        train_acc = scorer(estimator, X[train], y[train])
-        test_acc = scorer(estimator, X[test], y[test])
-        acc = 0.368*train_acc + 0.632*test_acc
+        cloned_est.fit(X[train], y[train])
+
+        test_acc = scoring_func(y[test], cloned_est.predict(X[test]))
+
+        if method == 'oob':
+            acc = test_acc
+
+        else:
+            train_acc = scoring_func(y[train], cloned_est.predict(X[train]))
+            if method == '.632+':
+                gamma = no_information_rate(y,
+                                            cloned_est.predict(X),
+                                            scoring_func)
+                R = (-(test_acc - train_acc)) / (gamma - (1 - test_acc))
+                weight = 0.632 / (1-0.368 * R)
+
+            else:
+                weight = 0.632
+
+            acc = weight*test_acc + (1. - weight)*train_acc
+
         scores[cnt] = acc
         cnt += 1
     return scores

--- a/mlxtend/evaluate/tests/test_bootstrap_point632.py
+++ b/mlxtend/evaluate/tests/test_bootstrap_point632.py
@@ -19,7 +19,7 @@ def test_defaults():
     scores = bootstrap_point632_score(lr, X, y, random_seed=123)
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.95, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.95306, np.round(acc, 5)
 
 
 def test_oob():
@@ -27,7 +27,7 @@ def test_oob():
     scores = bootstrap_point632_score(tree, X, y, random_seed=123, method='oob')
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.95, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.94667, np.round(acc, 5)
 
 
 def test_632():
@@ -36,14 +36,14 @@ def test_632():
                                       method='.632')
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.97, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.96629, np.round(acc, 5)
 
     tree2 = DecisionTreeClassifier(random_state=123, max_depth=1)
     scores = bootstrap_point632_score(tree2, X, y, random_seed=123,
                                       method='.632')
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.66, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.65512, np.round(acc, 5)
 
 
 def test_632plus():
@@ -52,14 +52,14 @@ def test_632plus():
                                       method='.632+')
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.97, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.96528, np.round(acc, 5)
 
     tree2 = DecisionTreeClassifier(random_state=123, max_depth=1)
     scores = bootstrap_point632_score(tree2, X, y, random_seed=123,
                                       method='.632+')
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.65, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.65034, np.round(acc, 5)
 
 
 def test_custom_accuracy():
@@ -73,7 +73,7 @@ def test_custom_accuracy():
                                       scoring_func=accuracy2)
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.95, np.round(acc, 2)
+    assert np.round(acc, 5) == 0.95306, np.round(acc, 5)
 
 
 def test_invalid_splits():

--- a/mlxtend/evaluate/tests/test_bootstrap_point632.py
+++ b/mlxtend/evaluate/tests/test_bootstrap_point632.py
@@ -9,6 +9,7 @@ from mlxtend.evaluate import bootstrap_point632_score
 from mlxtend.utils import assert_raises
 from mlxtend.data import iris_data
 from sklearn.linear_model import LogisticRegression
+from sklearn.tree import DecisionTreeClassifier
 
 X, y = iris_data()
 
@@ -18,7 +19,61 @@ def test_defaults():
     scores = bootstrap_point632_score(lr, X, y, random_seed=123)
     acc = np.mean(scores)
     assert len(scores == 200)
-    assert np.round(acc, 2) == 0.95
+    assert np.round(acc, 2) == 0.95, np.round(acc, 2)
+
+
+def test_oob():
+    tree = DecisionTreeClassifier(random_state=123)
+    scores = bootstrap_point632_score(tree, X, y, random_seed=123, method='oob')
+    acc = np.mean(scores)
+    assert len(scores == 200)
+    assert np.round(acc, 2) == 0.95, np.round(acc, 2)
+
+
+def test_632():
+    tree = DecisionTreeClassifier(random_state=123)
+    scores = bootstrap_point632_score(tree, X, y, random_seed=123,
+                                      method='.632')
+    acc = np.mean(scores)
+    assert len(scores == 200)
+    assert np.round(acc, 2) == 0.97, np.round(acc, 2)
+
+    tree2 = DecisionTreeClassifier(random_state=123, max_depth=1)
+    scores = bootstrap_point632_score(tree2, X, y, random_seed=123,
+                                      method='.632')
+    acc = np.mean(scores)
+    assert len(scores == 200)
+    assert np.round(acc, 2) == 0.66, np.round(acc, 2)
+
+
+def test_632plus():
+    tree = DecisionTreeClassifier(random_state=123)
+    scores = bootstrap_point632_score(tree, X, y, random_seed=123,
+                                      method='.632+')
+    acc = np.mean(scores)
+    assert len(scores == 200)
+    assert np.round(acc, 2) == 0.97, np.round(acc, 2)
+
+    tree2 = DecisionTreeClassifier(random_state=123, max_depth=1)
+    scores = bootstrap_point632_score(tree2, X, y, random_seed=123,
+                                      method='.632+')
+    acc = np.mean(scores)
+    assert len(scores == 200)
+    assert np.round(acc, 2) == 0.65, np.round(acc, 2)
+
+
+def test_custom_accuracy():
+
+    def accuracy2(targets, predictions):
+        return sum([i == j for i, j in
+                    zip(targets, predictions)]) / len(targets)
+    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
+    scores = bootstrap_point632_score(lr, X, y,
+                                      random_seed=123,
+                                      scoring_func=accuracy2)
+    acc = np.mean(scores)
+    assert len(scores == 200)
+    assert np.round(acc, 2) == 0.95, np.round(acc, 2)
 
 
 def test_invalid_splits():
@@ -34,7 +89,7 @@ def test_invalid_splits():
 
 
 def test_allowed_methods():
-    msg = "The `method` must be in ('.632', '.632+'). Got 1."
+    msg = "The `method` must be in ('.632', '.632+', 'oob'). Got 1."
     lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     assert_raises(ValueError,
                   msg,
@@ -45,7 +100,7 @@ def test_allowed_methods():
                   200,
                   1)
 
-    msg = "The `method` must be in ('.632', '.632+'). Got test."
+    msg = "The `method` must be in ('.632', '.632+', 'oob'). Got test."
     lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     assert_raises(ValueError,
                   msg,
@@ -56,22 +111,12 @@ def test_allowed_methods():
                   200,
                   'test')
 
-    msg = "The .632+ method is not implemented, yet."
-    lr = LogisticRegression(solver='liblinear', multi_class='ovr')
-    assert_raises(NotImplementedError,
-                  msg,
-                  bootstrap_point632_score,
-                  lr,
-                  X,
-                  y,
-                  200,
-                  '.632+')
-
 
 def test_scoring():
+    from sklearn.metrics import f1_score
     lr = LogisticRegression(solver='liblinear', multi_class='ovr')
     scores = bootstrap_point632_score(lr, X[:100], y[:100],
-                                      scoring='f1',
+                                      scoring_func=f1_score,
                                       random_seed=123)
     f1 = np.mean(scores)
     assert len(scores == 200)


### PR DESCRIPTION
### Description

Adds the ".632+" bootstrap method to the `mlxtend.evaluate.bootstrap_point632_score` function.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->