### PR TITLE
implementation of f-test

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,6 +24,7 @@ The CHANGELOG for the current development version is available at
 - Added a new convenience function `extract_face_landmarks` based on `dlib` to `mlxtend.image`. ([#458](https://github.com/rasbt/mlxtend/pull/458))
 - Added a `method='oob'` option to the `mlxtend.evaluate.bootstrap_point632_score` method to compute the classic out-of-bag bootstrap estimate ([#459](https://github.com/rasbt/mlxtend/pull/459))
 - Added a `method='.632+'` option to the `mlxtend.evaluate.bootstrap_point632_score` method to compute the .632+ bootstrap estimate that addresses the optimism bias of the .632 bootstrap ([#459](https://github.com/rasbt/mlxtend/pull/459))
+- Added a new `mlxtend.evaluate.ftest` function to perform an F-test for comparing the accuracies of two or more classification models. ([#460](https://github.com/rasbt/mlxtend/pull/460))
 
 ##### Changes
 

--- a/docs/sources/USER_GUIDE_INDEX.md
+++ b/docs/sources/USER_GUIDE_INDEX.md
@@ -30,6 +30,7 @@
 - [cochrans_q](user_guide/evaluate/cochrans_q.md)
 - [confusion_matrix](user_guide/evaluate/confusion_matrix.md)
 - [feature_importance_permutation](user_guide/evaluate/feature_importance_permutation.md)
+- [ftest](user_guide/evaluate/ftest.md)
 - [lift_score](user_guide/evaluate/lift_score.md)
 - [mcnemar_table](user_guide/evaluate/mcnemar_table.md)
 - [mcnemar_tables](user_guide/evaluate/mcnemar_tables.md)

--- a/docs/sources/user_guide/evaluate/ftest.ipynb
+++ b/docs/sources/user_guide/evaluate/ftest.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# F-Test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "F-test for comparing the performance of multiple classifiers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> `from mlxtend.evaluate import ftest`    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the context of evaluating machine learning models, the F-test by George W. Snedecor [1] can be regarded as analogous to Cochran's Q test that can be applied to evaluate multiple classifiers (i.e., whether their accuracies estimated on a test set differ) as described by Looney [2][3]. \n",
+    "\n",
+    "More formally, assume the task to test the null hypothesis that there is no difference between the classification accuracies [1]: \n",
+    "\n",
+    "$$p_i: H_0 = p_1 = p_2 = \\cdots = p_L.$$\n",
+    "\n",
+    "Let $\\{D_1, \\dots , D_L\\}$ be a set of classifiers who have all been tested on the same dataset. If the L classifiers don't perform differently, then the F statistic is distributed according to an F distribution with $(L-1$) and $(L-1)\\times(N)$ degrees of freedom, where $N$ is the number of examples in the test set.\n",
+    "\n",
+    "The calculation of the F statistic consists of several components, which are listed below (adopted from [3]).\n",
+    "\n",
+    "Sum of squares of the classifiers:\n",
+    "\n",
+    "$$\n",
+    "SSA = N \\sum_{i=1}^{N} (L_j)^2,\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "where $L_j$ is the number of classifiers out of $L$ that correctly classified object $\\mathbf{z}_j \\in \\mathbf{Z}_{N}$, where $\\mathbf{Z}_{N} = \\{\\mathbf{z}_1, ... \\mathbf{z}_{N}\\}$ is the test dataset on which the classifers are tested on.\n",
+    "\n",
+    "The sum of squares for the objects:\n",
+    "\n",
+    "$$\n",
+    "SSB= \\frac{1}{L} \\sum_{j=1}^N (L_j)^2 - L\\cdot N \\cdot ACC_{avg}^2,\n",
+    "$$\n",
+    "\n",
+    "where $ACC_{avg}$ is the average of the accuracies of the different models $ACC_{avg} = \\sum_{i=1}^L ACC_i$.\n",
+    "\n",
+    "The total sum of squares:\n",
+    "\n",
+    "$$\n",
+    "SST = L\\cdot N \\cdot ACC_{avg}^2 (1 - ACC_{avg}^2).\n",
+    "$$\n",
+    "\n",
+    "The sum of squares for the classification--object interaction:\n",
+    "\n",
+    "$$\n",
+    "SSAB = SST - SSA - SSB.\n",
+    "$$\n",
+    "\n",
+    "The mean SSA and mean SSAB values:\n",
+    "\n",
+    "$$\n",
+    "MSA = \\frac{SSA}{L-1},\n",
+    "$$\n",
+    "\n",
+    "and\n",
+    "\n",
+    "$$\n",
+    "MSAB = \\frac{SSAB}{(L-1) (N-1)}.\n",
+    "$$\n",
+    "\n",
+    "From the MSA and MSAB, we can then calculate the F-value as\n",
+    "\n",
+    "$$\n",
+    "F = \\frac{MSA}{MSAB}.\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "After computing the F-value, we can then look up the p-value from a F-distribution table for the corresponding degrees of freedom or obtain it computationally from a cumulative F-distribution function. In practice, if we successfully rejected the null hypothesis at a previously chosen significance threshold, we could perform multiple post hoc pair-wise tests -- for example, McNemar tests with a Bonferroni correction -- to determine which pairs have different population proportions.\n",
+    "\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- [1]  Snedecor, George W. and Cochran, William G. (1989), Statistical Methods, Eighth Edition, Iowa State University Press.\n",
+    "- [2] Looney, Stephen W. \"A statistical technique for comparing the accuracies of several classifiers.\" Pattern Recognition Letters 8, no. 1 (1988): 5-9.\n",
+    "- [3] Kuncheva, Ludmila I. Combining pattern classifiers: methods and algorithms. John Wiley & Sons, 2004.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1 - F-test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from mlxtend.evaluate import ftest\n",
+    "\n",
+    "## Dataset:\n",
+    "\n",
+    "# ground truth labels of the test dataset:\n",
+    "\n",
+    "y_true = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                   0, 0, 0, 0, 0])\n",
+    "\n",
+    "\n",
+    "# predictions by 3 classifiers (`y_model_1`, `y_model_2`, and `y_model_3`):\n",
+    "\n",
+    "y_model_1 = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0])\n",
+    "\n",
+    "y_model_2 = np.array([1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0])\n",
+    "\n",
+    "y_model_3 = np.array([1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    "                      1, 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assuming a significance level $\\alpha=0.05$, we can conduct Cochran's Q test as follows, to test the null hypothesis there is no difference between the classification accuracies, $p_i: H_0 = p_1 = p_2 = \\cdots = p_L$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "F: 3.873\n",
+      "p-value: 0.022\n"
+     ]
+    }
+   ],
+   "source": [
+    "f, p_value = ftest(y_true, \n",
+    "                   y_model_1, \n",
+    "                   y_model_2, \n",
+    "                   y_model_3)\n",
+    "\n",
+    "print('F: %.3f' % f)\n",
+    "print('p-value: %.3f' % p_value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the p-value is smaller than $\\alpha$, we can reject the null hypothesis and conclude that there is a difference between the classification accuracies. As mentioned in the introduction earlier, we could now perform multiple post hoc pair-wise tests -- for example, McNemar tests with a Bonferroni correction -- to determine which pairs have different population proportions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## ftest\n",
+      "\n",
+      "*ftest(y_target, *y_model_predictions)*\n",
+      "\n",
+      "F-Test test to compare 2 or more models.\n",
+      "\n",
+      "**Parameters**\n",
+      "\n",
+      "- `y_target` : array-like, shape=[n_samples]\n",
+      "\n",
+      "    True class labels as 1D NumPy array.\n",
+      "\n",
+      "\n",
+      "- `*y_model_predictions` : array-likes, shape=[n_samples]\n",
+      "\n",
+      "    Variable number of 2 or more arrays that\n",
+      "    contain the predicted class labels\n",
+      "    from models as 1D NumPy array.\n",
+      "\n",
+      "**Returns**\n",
+      "\n",
+      "\n",
+      "- `f, p` : float or None, float\n",
+      "\n",
+      "    Returns the F-value and the p-value\n",
+      "\n",
+      "**Examples**\n",
+      "\n",
+      "For usage examples, please see\n",
+      "    [http://rasbt.github.io/mlxtend/user_guide/evaluate/ftest/](http://rasbt.github.io/mlxtend/user_guide/evaluate/ftest/)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open('../../api_modules/mlxtend.evaluate/ftest.md', 'r') as f:\n",
+    "    s = f.read() \n",
+    "print(s)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/mlxtend/evaluate/__init__.py
+++ b/mlxtend/evaluate/__init__.py
@@ -22,6 +22,7 @@ from .ttest import paired_ttest_kfold_cv
 from .ttest import paired_ttest_5x2cv
 from .holdout import RandomHoldoutSplit
 from .holdout import PredefinedHoldoutSplit
+from .f_test import ftest
 
 
 __all__ = ["scoring", "confusion_matrix",
@@ -32,4 +33,5 @@ __all__ = ["scoring", "confusion_matrix",
            "cochrans_q", "paired_ttest_resampled",
            "paired_ttest_kfold_cv", "paired_ttest_5x2cv",
            "feature_importance_permutation",
-           "RandomHoldoutSplit"]
+           "RandomHoldoutSplit", "PredefinedHoldoutSplit",
+           "ftest"]

--- a/mlxtend/evaluate/f_test.py
+++ b/mlxtend/evaluate/f_test.py
@@ -1,0 +1,105 @@
+# Sebastian Raschka 2014-2018
+# mlxtend Machine Learning Library Extensions
+#
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+import numpy as np
+import scipy.stats
+import itertools
+
+
+def ftest(y_target, *y_model_predictions):
+    """
+    F-Test test to compare 2 or more models.
+
+    Parameters
+    -----------
+    y_target : array-like, shape=[n_samples]
+        True class labels as 1D NumPy array.
+
+    *y_model_predictions : array-likes, shape=[n_samples]
+        Variable number of 2 or more arrays that
+        contain the predicted class labels
+        from models as 1D NumPy array.
+
+    Returns
+    -----------
+
+    f, p : float or None, float
+        Returns the F-value and the p-value
+
+    Examples
+    -----------
+    For usage examples, please see
+    http://rasbt.github.io/mlxtend/user_guide/evaluate/ftest/
+
+    """
+
+    num_models = len(y_model_predictions)
+
+    # Checks
+    model_lens = set()
+    y_model_predictions = list(y_model_predictions)
+    for ary in ([y_target] + y_model_predictions):
+        if len(ary.shape) != 1:
+            raise ValueError('One or more input arrays are not 1-dimensional.')
+        model_lens.add(ary.shape[0])
+
+    if len(model_lens) > 1:
+        raise ValueError('Each prediction array must have the '
+                         'same number of samples.')
+
+    if num_models < 2:
+        raise ValueError('Provide at least 2 model prediction arrays.')
+
+    num_examples = len(y_target)
+
+    accuracies = []
+    correctly_classified_all_models = 0
+    correctly_classified_collection = []
+    for pred in y_model_predictions:
+        correctly_classified = (y_target == pred).sum()
+        acc = correctly_classified / num_examples
+        accuracies.append(acc)
+        correctly_classified_all_models += correctly_classified
+        correctly_classified_collection.append(correctly_classified)
+
+    avg_acc = sum(accuracies) / len(accuracies)
+
+    # sum squares of classifiers
+    ssa = (num_examples * sum([acc**2 for acc in accuracies])
+           - num_examples*num_models*avg_acc**2)
+
+    # sum squares of models
+    binary_combin = list(itertools.product([0, 1], repeat=num_models))
+    ary = np.hstack(((y_target == mod).reshape(-1, 1) for
+                    mod in y_model_predictions)).astype(int)
+    correctly_classified_objects = 0
+    binary_combin_totals = np.zeros(len(binary_combin))
+    for i, c in enumerate(binary_combin):
+        binary_combin_totals[i] = ((ary == c).sum(axis=1) == num_models).sum()
+
+        correctly_classified_objects += (sum(c)**2 * binary_combin_totals[i])
+
+    ssb = (1./num_models * correctly_classified_objects
+           - num_examples*num_models*avg_acc**2)
+
+    # total sum of squares
+    sst = num_examples*num_models*avg_acc*(1 - avg_acc)
+
+    # sum squares for classification-object interaction
+    ssab = sst - ssa - ssb
+
+    mean_ssa = ssa / (num_models - 1)
+    mean_ssab = ssab / ((num_models - 1)*(num_examples - 1))
+
+    f = mean_ssa / mean_ssab
+
+    degrees_of_freedom_1 = num_models - 1
+    degrees_of_freedom_2 = degrees_of_freedom_1 * num_examples
+
+    p_value = scipy.stats.f.sf(f, degrees_of_freedom_1, degrees_of_freedom_2)
+
+    return f, p_value

--- a/mlxtend/evaluate/tests/test_f_test.py
+++ b/mlxtend/evaluate/tests/test_f_test.py
@@ -1,0 +1,93 @@
+# Sebastian Raschka 2014-2018
+# mlxtend Machine Learning Library Extensions
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+from mlxtend.evaluate import ftest
+from mlxtend.utils import assert_raises
+import numpy as np
+
+
+def test_input_array_1d():
+    t = np.array([[1, 2], [3, 4]])
+    assert_raises(ValueError,
+                  'One or more input arrays are not 1-dimensional.',
+                  ftest,
+                  t,
+                  t,
+                  t)
+
+
+def test_input_array_lengths_1():
+    t = np.array([1, 2])
+    t2 = np.array([1, 2, 3])
+    assert_raises(ValueError,
+                  ('Each prediction array must have'
+                   ' the same number of samples.'),
+                  ftest,
+                  t,
+                  t2,
+                  t)
+
+
+def test_model_have_same_len():
+    y_true = np.array([1, 1, 0])
+    y_1 = np.array([0, 1, 0])
+    y_2 = np.array([1, 1, 0])
+    y_3 = np.array([1, 1])
+
+    assert_raises(ValueError,
+                  ('Each prediction array must have'
+                   ' the same number of samples.'),
+                  ftest,
+                  y_true,
+                  y_1,
+                  y_2,
+                  y_3)
+
+
+def test_min_number_of_models():
+    y_true = np.array([1, 1, 0])
+    y_1 = np.array([0, 1, 0])
+
+    assert_raises(ValueError,
+                  ('Provide at least 2 model prediction arrays.'),
+                  ftest,
+                  y_true,
+                  y_1)
+
+
+def test_on_dataset():
+    y_true = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0])
+
+    ym1 = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0])
+
+    ym2 = np.array([1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0])
+
+    ym3 = np.array([1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 1])
+
+    f, p_value = ftest(y_true, ym1, ym2, ym3)
+
+    assert round(f, 3) == 3.873
+    assert round(p_value, 3) == 0.022


### PR DESCRIPTION
### Description

Implements the F-test for comparing 2 or more classification models.



### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
