### PR TITLE
Language typo fixes in PCA docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 matrix:
     include:
         - python: 3.6
-          env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.15.1" SCIPY_VERSION="1.1.0" SKLEARN_VERSION="0.20" PANDAS_VERSION="0.23.4"  MINICONDA_PYTHON_VERSION=3.6
+          env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.15.4" SCIPY_VERSION="1.1.0" SKLEARN_VERSION="0.20" PANDAS_VERSION="0.23.4"  MINICONDA_PYTHON_VERSION=3.6
         - python: 3.6 # python 3.7
           env: LATEST="true" IMAGE="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 3.6 # python 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 matrix:
     include:
         - python: 3.6
-          env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.15.4" SCIPY_VERSION="1.1.0" SKLEARN_VERSION="0.20" PANDAS_VERSION="0.23.4"  MINICONDA_PYTHON_VERSION=3.6
+          env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.14.6" SCIPY_VERSION="1.1.0" SKLEARN_VERSION="0.20.1" PANDAS_VERSION="0.23.4"  MINICONDA_PYTHON_VERSION=3.7
         - python: 3.6 # python 3.7
           env: LATEST="true" IMAGE="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
         - python: 3.6 # python 3.7

--- a/docs/sources/user_guide/feature_extraction/PrincipalComponentAnalysis.ipynb
+++ b/docs/sources/user_guide/feature_extraction/PrincipalComponentAnalysis.ipynb
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After evoking the `fit` method, the factor loadings are available via the `loadings_` attribute. In simple terms, the the loadings are the unstandardized values of the eigenvectors. Or in other words, we can interpret the loadings as the covariances (or correlation in case we standardized the input features) between the input features and the and the principal components (or eigenvectors), which have been scaled to unit length.\n",
+    "After evoking the `fit` method, the factor loadings are available via the `loadings_` attribute. In simple terms, the loadings are the unstandardized values of the eigenvectors. Or in other words, we can interpret the loadings as the covariances (or correlation in case we standardized the input features) between the input features and the principal components (or eigenvectors), which have been scaled to unit length.\n",
     "\n",
     "By having the loadings scaled, they become comparable by magnitude and we can assess how much variance in a component is attributed to the input features (as the components are  just a weighted linear combination of the input features)."
    ]
@@ -506,7 +506,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
### Description

Language typo fixes in PCA docs
### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->