### PR TITLE
Whitening parameter for PCA

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -17,6 +17,7 @@ The CHANGELOG for the current development version is available at
 ##### New Features
 
 - Adds a new function, `mlxtend.evaluate.bias_variance_decomp` that decomposes the loss of a regressor or classifier into bias and variance terms. ([#470](https://github.com/rasbt/mlxtend/pull/470))
+- Adds a `whitening` parameter to `PrincipalComponentAnalysis`, to optionally whiten the transformed data such that the features have unit variance. ([#475](https://github.com/rasbt/mlxtend/pull/475))
 
 ##### Changes
 

--- a/docs/sources/user_guide/feature_extraction/PrincipalComponentAnalysis.ipynb
+++ b/docs/sources/user_guide/feature_extraction/PrincipalComponentAnalysis.ipynb
@@ -417,8 +417,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 6 - Whitening"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Certain algorithms require the data to be whitened. This means that the features have unit variance and the off-diagonals are all zero (i.e., the features are uncorrelated). PCA already ensures that the features are uncorrelated, hence, we only need to apply a simple scaling to whiten the transformed data.\n",
+    "\n",
+    "For instance, for a given transformed feature $X'_i$, we divide it by the square-root of the corresponding eigenvalue $\\lambda_i$:\n",
+    "\n",
+    "$$X'_{\\text{whitened}} = \\frac{X'_i}{\\sqrt{\\lambda_i}}.$$\n",
+    "\n",
+    "The whitening via the `PrincipalComponentAnalysis` can be achieved by setting `whitening=True` during initialization. Let's demonstrate that with an example."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from mlxtend.data import wine_data\n",
+    "\n",
+    "X, y = wine_data()\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=123, test_size=0.3, stratify=y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Regular PCA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -457,6 +498,131 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Covariance matrix:\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[4.9, 0. ],\n",
+       "       [0. , 2.5]])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.set_printoptions(precision=1, suppress=True)\n",
+    "\n",
+    "print('Covariance matrix:\\n')\n",
+    "np.cov(X_train_transf.T)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, the features are uncorrelated after transformation but don't have unit variance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PCA with Whitening"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAagAAAEYCAYAAAAJeGK1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3XtYVOW+B/DvgExy1UADtT1YpEleSqys01FPok+YsDUvXBtM0zLNFD2kR9zEJkHLDN3uyLQ0RErUU27FLk9gTx6rY4nbS4odIwEvoEhbccBhRmadP8YZGZg1ay5r1mXm93keHmGtmVm/WeD6zfuu9/29CoZhGBBCCCES4yN2AIQQQog1lKAIIYRIEiUoQgghkkQJihBCiCRRgiKEECJJ3cQOwBGVlZVih0AIIcQNRowY0WWbrBIUYP1NSEFVVRWio6PFDsMpco1drnED8o2d4haeXGN3JG62xgd18RFCCJEkSlCEEEIkiRIUIYQQSaIERQghRJIoQRFCCJEkSlCEEEIkiRIUIYQQSaIERQghRJIoQRHPVlIC9O8P+PgY/y0pETsiQoidZFdJghC7lZQAL70EtLYaf66tNf4MAGlp4sVFCLELtaCI58rKupOcTFpbjdsJIZJHCYp4rro6x7YTQiSFEhTxXCqVY9sJIZJCCYp4rrw8ICDAcltAgHE7IUTyKEERz5WWBmzaBERGAgqF8d9Nm2iABCEyQaP4iGdLS6OERIhMUQuKEEKIJAnWgtLr9Vi+fDkuXrwInU6HV155BbGxseb9Bw4cwHvvvYdu3bph6tSpSExMFCo0QgghEiRYgtq7dy969uyJNWvW4F//+heee+45c4LS6/VYtWoVdu/eDX9/f6SkpODpp59G7969hQqPEEKIxAjWxRcXF4eFCxeaf/b19TV/X11dDZVKhR49ekCpVGLEiBE4cuSIUKERQgiRIMFaUIGBgQAAjUaD1157DYsWLTLv02g0CA4OtnisRqOx+jpVVVXuDdRJWq1WsrFxkWvsco0bkG/sFLfw5Bo7H3ELOoqvvr4e8+fPR2pqKhISEszbg4KC0NLSYv65paXFImF1FB0d7fY4nVFVVSXZ2LjINXa5xg3IN3aKW3hyjd2RuCsrK61uF6yL7+rVq5g1axYyMzMxbdo0i31RUVGora3FtWvXoNPpcOTIEQwfPlyo0AghhEiQYC2ojRs3orm5GYWFhSgsLAQATJ8+HTdv3kRSUhKWLVuGF198EQzDYOrUqQgPDxcqNEIIIRIkWIJasWIFVqxYwbp/7NixGDt2rFDhEEIIkTiaqEsIIUSSKEERQgiRJEpQhEgJLVFPiBkViyVEKmiJekIsUAuKEKmgJeoJsUAJihCpcHWJeme6B6lLkUgYdfERIhUqlbFbz9p2Ls50D1KXIpE4akERIhWuLFHvTPcgdSkSiaMERYhUuLJEvTPdg652KRLiZtTFR4iUOLtEvTPdg650KRIiAGpBEeIJnOkedKVLkRABUIIixBM40z3oSpciIQKgLj5C5KykxDiooa7O2DWXl+dYgnG2S5EQAVCCIkSuaJg48XDUxUfk5/bk0kGDB3vv5NKSEmDGDBomTjwataCIvHRoNSgA72w1mM5Be7v1/TRMnHgIakEReaHJpdbPQUc0TJx4CEpQRF5ocqnt90rDxIkHoQRF5IWtdeBNrQa29+rrS8PEiUehBEXkRcqTS4WqDM52DoqKKDkRjyJ4gjp+/DjUanWX7Vu3bsXEiROhVquhVqvx+++/Cx0akYMOk0sZeyaXCpU0TAMXamsBhrkzeMMdx6MJtsRLCDqKb/Pmzdi7dy/8/f277Dt16hTeeustDBkyRMiQiBzdnlx6pqoK0dHR7I8Tcp6QrcEb7kgcjk6wNU3ora01dgW2txsTm6MTewkRkIJhGEaog3399dd48MEH8frrr2Pnzp0W+yZMmIABAwagsbER//Ef/4GXX365y/MrKysR0LlrQyK0Wi26d+8udhhOkWvsXHFHxcZCWV/fZbuuTx9UV1TwGsugwYOhsPJfiVEocObUqS7bhTznIWVl6JOdDR+ttss+Q/fuqM/NRXN8vF2v5al/K1Im19gdibu1tRUjRozouoMR2Pnz55np06d32b5hwwamqamJaWtrY+bMmcMcOHCgy2OOHDkiRIhOOX36tNghOE2usZ8+fZphtm9nmMhIhlEojP9u337nAQoFwxg73Cy/FAr+g4mMtH6syEj22IXCFhtHjNbI+m9FpuQauyNxs13bJTFIgmEYzJgxA6GhoVAqlRgzZgxOnz4tdlhE4kLKymzf9xFyxJ8YgzdKSoBevYz3oRQK4/fW7nlxDcH3piH6RFYkkaA0Gg3i4+PR0tIChmFw+PBhuhflqXgctNC7oMD2pF0hk4bQAxdKSoCZM4GmpjvbmpqAWbO6nlOuhOxNQ/SJrIiaoPbt24fS0lIEBwcjIyMD6enpSE1NxQMPPIAxY8aIGRpxB55Huvk1NFjfYWoRCJ000tKAmhrAYDD+687BB1lZgF7fdbtO17WqhrVEbSKVIfqEWMNPb6Mw6B6UewgWu4P3abi09enD6+sJyaFzbu0+G9v9NbZ7bKbXABjG1/fOeep4z47vuCVErnEzjHxj95h7UMRL8FymqDEjQ7guPKHmU1k7rrVWZ2go+3OsddmZWncMA9y6ZfzX3a08QlxECYoIh+dBC83x8cJ04Qk5CbcztvlVAODn1/XxSqU4XXZiJXDi0ShBEeG4Y9CCEPd9xKygzta6bGoCQkIst4WFAVu2CN8qEjOBE49GCYoIR64lesSsoM7WulQoLEfwBQQA69eLcy5pCRTiJpSgiLCEHOnGFzErqFtrdSoUxpZKR2ImBFoChbgJJShyB91HsE7oSbgdfw9ZWcal3Tu2Otmqk4mVEGgJFOImlKCIEd1HYCdk16S130NRkTEZmlqdkZHWnytWQpDyEihE1ihBESO6j2CbUF2T9vwe2CbeajTifKCQ671FInmUoIgR3UeQBnt+D6aEEBZm+ZimJvFavfYkcOpCJg6iBEWM6D6CNNj7e0hLA4KCuj7OXa3e28ll0ODBziUX6kImTqAERYzoPoI0OPJ7EKrV2yG5KJxNLtSFTJxACYoY0X0EaXDk9yBUq5eP5EJdyMQJlKC8Cdc9ADnOUfJE9v4ehGr18pFcqAuZOIESlLegewCeR6hWLx/JhbqQiRMoQXkLugfgmYRo9fKRXBxNpjTijwDoJnYARCB0D4A4y5REsrLA1NVBoVIZk5OjyTAtzb7nmFr7pg9UptZ+x1iIV6AWlLegewDEFbdbamdOnRJmtWBq7RPYSFDHjh3DlClTkJKSgiNHjpi3z58/X5DACM/oHgCRC2rtk9tYE9Tq1auxdu1a5ObmIi8vD4cOHQIANDc3CxYc4RENIydyQa19chtrgvLz88N9992HAQMGYNOmTXjrrbfw66+/QqFQuHTA48ePQ61Wd9l+4MABTJ06FUlJSdi5c6dLxyAsPHEYOd1M9zzU2ie3sSaowMBAbNu2DTqdDr1798Y777yDRYsW4eLFi04fbPPmzVixYgXa2tostuv1eqxatQpbtmxBcXExSktL0djY6PRxiHcIKSujofOeiFr75DbWBPXOO+/g+vXr0Ol0AIAHH3wQGzZswIMPPuj0wVQqFTZs2NBle3V1NVQqFXr06AGlUokRI0ZY3PcixJreBQV0M91TWWvtU2vZ67AOMw8KCsKCBQsstj3wwAMoLCx0+mDPPPMMLly40GW7RqNBcHCw+efAwEBoNBqrr1FVVeX08d1Jq9VKNjYuco19UEOD1e1MXR3OsLyfkLIy9C4ogF9DA/QREWjMyEBzfLw7w7RKrudcrLhDysrQJzsbPlqtcUNtLQyzZ6P+0iW7fn9yPd+AfGPnI25JzIMKCgpCS0uL+eeWlhaLhNVRdHS0UGE5pKqqSrKxWSgpMbYw6uqMN53z8lAVEyOP2E1uvweGZWVZhUpl/f2UlAA5OeZWl7K+Hv1yctCvb1/Bu49k8/fSiWhxT5gAmJLTbT5aLfq99x76ZWZyPl2u5xuQb+yOxF1ZWWl1uyTmQUVFRaG2thbXrl2DTqfDkSNHMHz4cLHD8jzWyh2p1Rj00EPy6TLpWFnb2n5bN9Npfo10ONpdR0PPvRJrgmpvb4dOp8Orr74KvV4PnU6HtrY2pKen83bwffv2obS0FH5+fli2bBlefPFFJCcnY+rUqQgPD+ftOOQ2axdohjFe6O0dYCD2fQBr78GE62Y6XeSkwZm6kDT03CuxdvH993//NzZu3IirV68iLi4ODMPAx8cHjz76qEsHvPfee83DyBMSEszbx44di7Fjx7r02oQD14XY1JqwVR9N7BI0bO9BoTDeTLdFpTLGbG07EY6tlqytyu0d//YAGnruBVgTVGJiIhITE7F7925MmzZNyJiIu7BdoDuylcScubDwzZUkQxc5aWD7G7T1t9mhHmDH+6c09Nyzcd6Deuqpp7B582b8/e9/N38RmbI2AbIzWxd6KXSRuTKJU8z5NZ26RkPKytx/TKny9XVsu4knTjQnNnEmqIULF0Kj0aBXr17mLyJTHS/QgPEi3RHXhV4K9wE6vAfGmSQjxkXOyj2XPtnZ8hiU4g7t7Y5tJ16LM0EFBgYiIyMDycnJ5i8iY6YLNMMAxcWOXeilUoJGyMrafLDSNeqj1Xrv6EHTByR7txOvxZmgBgwYgP379+P333/HuXPncO7cOSHiIkJw9EJPJWicI4WuUSmRygcdInmcE3WrqqosZgMrFAps27bNrUERCbN30TlyB40etEQDHoidOBNUcXExbty4gYsXL+JPf/oTAgMDhYiLEM9hZfSgoXt3+Hhzi4Hrg46ViieUwLwPZ4L6+uuv8f7776O9vR1xcXFQKBSYN2+eELERIm8dL7KhoYC/P/DHH4BKhfr589GPLrjWSWG+HZEEzntQW7duxc6dO9GzZ0/MmzcP5eXlQsRFiLx1HrnX1ATcvGkcmFJTI0qBWtmgklTkNs4E5ePjA6VSCYVCAYVCAX9/fyHiIkTepHCRFbsslbNoUAm5jTNBPfroo1i8eDEuX76M7OxsDB06VIi4CJE3sS+yztS7kwopzLcjksCZoBYvXozJkydj+vTpePrpp7Fs2TIh4iJE3sS+yEqhBecsIYehy7WV6SU4E5RGozFXkrh+/Tr27NkjRFyEyJvYc33EbsG5Qqj5dnJuZXoJzlF88+bNwz333IM+ffoAMM6DIoRwEHuuj9znXgkx304KxY+JTZwJimEYvPPOO0LEQohnEXNSM1Vu5ybnVqaX4Ozie/DBB3H8+HHodDrzFyFE4qgsFTex7xMSTpwtqJ9++gkHDhww/6xQKFBRUeHWoAghPKCyVLZRK1PyOFtQe/fuRUVFBXbt2oVvvvmGkhMh3uj2aLdBgwc7PtpNqiPlqJUpeZwtqMOHD2P58uUIDg5Gc3Mz3nzzTTz11FNCxEYIkYIOpYcUgGOlh6RetohamZLG2YJat24dPvnkE+zZsweffvop1q1bJ0RchBCpcGVOlZznYxHRcSYoX19fhIeHAwDCw8Nx1113OX0wg8GA7OxsJCUlQa1Wo7bTMNiVK1diypQpUKvVUKvVuHHjhtPHIoTwxNZoN67uOxopR1zA2cUXFBSE4uJiPPbYY/j555/Ro0cPpw9WXl4OnU6H0tJSHDt2DKtXr8b7779v3n/q1Cl8+OGHCA0NdfoYhBCesc2pCg3l7r6T+3wsIirOFtSaNWtw6dIlrFu3DvX19cjPz3f6YJWVlRg1ahQA4JFHHsEvv/xi3mcwGFBbW4vs7GwkJydj9+7dTh+HyIRUb54TS2xVMQDu7juxK2oQWeNsQQUHByMmJgZ33303BgwY4FILSqPRICgoyPyzr68vbt26hW7duqG1tRXPP/88Zs6cifb2dqSnp2PIkCEYNGiQxWt0XN1XSrRarWRj4yJG7CFlZeiTnQ0frda4obYWhtmzUX/pkt1LUdA5F0hMDEJyctC7oAB+DQ3QR0SgMSMDfZcuhbW6MkxdHc6Y3hvLc5tjYgAB37+szncnco2dj7gVDMMwth6QlZWF1tZWPPLIIzh69CjCw8OxfPlypw62atUqPPzww3j22WcBAKNHj8bBgwcBAO3t7bh586Y5gb399tsYOHAgJk+ebH5+ZWUlRowY4dSx3a2qqgrR0dFih+EUUWLv3996109kJFBTY9dL0DkXnkXcPPwOhSLX8w3IN3ZH4ma7tnN28f3f//0fCgoKMGPGDKxfvx7Hjh1zPNLbYmJizAnp2LFjGDhwoHlfTU0NUlNT0d7eDr1ej6NHj2Lw4MFOH4tIHN08d55Uukbd3X0nlfdJRMPZxadSqXD+/Hn86U9/QlNTk7lorDPGjx+P77//HsnJyWAYBvn5+di6dStUKhViY2ORkJCAxMRE+Pn5YdKkSRgwYIDTxyISRzfPnSOleUXuLIgrpfdJRMOZoI4dO4YJEyagb9++uHz5MpRKJf793/8dAHDo0CGHDubj44Pc3FyLbVFRUebv58yZgzlz5jj0mkSmqMyMc6RWgdtdE12l9j6JKDgTFJU2Im4h9nIUcuUtXaPe8j6JTZwJ6sCBA/jss8/Q1tZm3rZ582a3BkXkq6TEgZxDZWYc5y1do97yPolNnAnqrbfeQm5urkvDy4l3oNsGAvCWrlFveZ/EJs4ENWDAAIwcOVKIWIjM0W0DAXhL16i3vE9iE2eCio2NRVJSEu6//37ztlWrVrk1KCJPdNtAIN7SNeot75Ow4kxQxcXFmD17NoKDg4WIh8iEtXtNdNuAEMInzgTVq1cvc+UHQgD2e00zZgBFRXTbgBDCD84E1b17d7z44ot46KGHoFAYK28tXrzY7YER6WK71/TFF8YFSem2ASGED5wJ6umnnxYiDiIjtu410W0DQghfOGvxJSQkoLW1FSdOnEBzczMmTpwoRFxEwtjuKdG9JiIXJSdL0H9df/j81Qf91/VHyUmq8ydFnAkqOzsb58+fx1NPPYWLFy9ixYoVQsRFJIyW+CFyVnKyBC/tewm112vBgEHt9Vq8tO8lSlISxJmgamtrsWzZMowbNw7Lly9HHY0Z9nppacZ7TZGRgEJh/HfTJuraI/KQVZGFVr3lTdRWfSuyKrJYnkHEwnkPqq2tDTdv3oS/vz+0Wi3a29uFiItIHN1rInJVd936h2y27UQ8nC2o9PR0TJo0CfPnz8ekSZPwwgsvCBAWcRdaYod4O1UP6zdL2bYT8XC2oP785z9j9OjROH/+PO69917cfffdQsRF3IBt/lJOTghkuGAnIU7Ji83DS/tesujmC/ALQF4s3USVGtYWlEajwZIlS6DRaNCzZ0/U1tYiNzcXGo1GyPgIj9jmLxUU9BYnIEJEkDY0DZsSNiGyRyQUUCCyRyQ2JWxC2lDqs5Ya1gT1xhtvYOjQoQgMDAQAxMXFYciQIcjJyREqNsIztvEtDQ1+wgZCxEN9vACMSapmUQ0MbxhQs6hGtOREw91tY01Q9fX1eOGFF8zVI7p164YXX3wR58+fFyw4wi+2eUoREXphA7GFLqDuY+rjra0FGOZOHy+dY1HQcHdurAnKx8f6Lj8/+rQtV2zzl8aM0UgjJ9AF1L1srYdC7hDoQxINd+fGmqAiIyNRXl5usa2iogK9ezt/v8JgMCA7OxtJSUlQq9Wo7VT6eufOnZgyZQoSExPx7bffOn0cYp21+UszZgB79vSURk5guYBqFtJ/WF7QeijcBPyQRMPdubEmqKVLl2LHjh147rnnsGDBAkybNg2lpaV44403nD5YeXk5dDodSktLsWTJEqxevdq8r7GxEcXFxdixYwc++ugjvPvuu9DpdE4fy2Pw/GkuLQ2oqQEMBuO/X3wBaLWWfwaifahmuVAGNNVRI4oPVKOKm4CtTBruzo11mHlISAg+/PBDXLp0CVeuXEGfPn0QHh7u0sEqKysxatQoAMAjjzyCX375xbzvxIkTGD58OJRKJZRKJVQqFc6cOYNhw4a5dExZE2ANdUl9qGZZUKoOKlqVlw+0jDo3Af9D0HB3bpzzoPr27Yu+ffvycjCNRoOgoCDzz76+vrh16xa6desGjUZjsShiYGCg1SHtVVVVvMTCN61Wy3tsUZmZUFr5NKfLzER1TAwvx4iIiEJ9vdLKdh2qqqp5OYa9QubPR8/XcxCIO++5BQFYjjzU1TGoqjpj8Xh3nHOhiBJ7TAxCcnLQu6AAfg0N0EdEoDEjA80xMYCdscj1nNsbd1REBJT19V226yIiUM3z+47pFoOcmBwUnCxAQ2sDIgIikDE0AzHdYixi9fRzbhMjoPz8fGb//v3mn0eNGmX+vry8nHnjjTfMP8+bN485ceKExfOPHDni9hiddfr0af5fVKFgGGNPuOWXQsHbIbZvZ5ju3dstXj4gwLi942MiI42HjYy03Me3BWHbmXOIZNqhYM4hkknBdgYwHrczt5xzgcg1do+Pe/t2438AW/8hBObx55xhv7ZzljriU0xMDA4ePAgAOHbsGAYOHGjeN2zYMFRWVqKtrQ03btxAdXW1xX6vJMA9g7Q0IDe3nrXwq9AD60auT8PggBr4woD7UINPkQalEtBoJDDKkHg+qoQsKaxdfElJSeY5UCYMw0ChUGDHjh1OHWz8+PH4/vvvkZycDIZhkJ+fj61bt0KlUiE2NhZqtRqpqalgGAYZGRm46667nDqOxxDonkF8fDMyM/tZ3WfrnrE7/s+aXtO0Km9oKNDcDDQ1Gbd3vA3HUy8nIZaoErJksCaod999l/eD+fj4IDc312JbVFSU+fvExEQkJibyflzZ6ny1FmENdTEGUXS8PvTvfyc5mZgS5Jdfui8GQoj4WLv4+vXrh379+uHWrVsoKyvD559/js8//xwffPCBkPGRzuPCBf5kJ/bIZHclSCpYQYj0cd6DWrp0KQDg6NGjuHDhAq5du+b2oAi/XLkYi716bmioY9vtQQUrXEc15IgQOBNU9+7d8fLLLyM8PByrV6/G1atXhYhLNkwX/8GDB0nyk7irF2NPvGdMFX9cI/cacpRc5YMzQTEMg8bGRrS0tKC1tRXXr18XIi5ZsLz4KyT5SZyPi7GYvYx//OHYdntIanKyDMm5hpw7kyslPv5xJqhXX30V33zzDSZNmoTY2FiMHj1aiLhkQQ6fxOV+MXbHPTCx76vJnZxryLkrucq9VSlVnAnqscceQ1xcHHr16oUvv/zSfE+KyOPiL/eLsTvugYl9X03u5FxDjq/k2rm1tPDLhbJtVUoZZ4IqKSlBcnIyNm3ahKSkJPzjH/8QIi5ZkMPFX+4XY3fcA+N6TRrhZ1tebB4C/Cz/qORSQ46P5GqttdR0s8nqY+XQqpQyzgS1a9cu7Nu3D++99x727NmDbdu2CRGXLMjh4u8JgxzccQ+M7TVphB83OS+ZzkdytdZNyEYOrUop4ywWGxYWBl9fXwDGEX09e/Z0e1ByYTmPloFKpRB6Hq1daGK8/YSunCFXaUPTZJGQOjPFnFWRhbrrdVD1UCEvNs+h92Jvq0gurUop40xQDMNg8uTJGD58OE6fPo1bt25hyZIlAIC1a9e6PUCpM138q6rOIDo6WuxwiIvkcF+RuMbV5KrqoULt9a7LwoT5hyFIGeR04iNdcSaouXPnmr9PSEhwazCEiI1lSSpJ3VckjiurLcOEryfwkjzY1nFaP2E9JSSesd6DMi25/vvvv+PcuXMWX48//jgef/xxwYIkRChyuK9IHFNysgTZR7J5GwLuyj04mivlGNYWlKmkEVWOIN5EAvV5Cc+yKrKgbddabDMNAXe2xeNMN+G8/fOw8chGMGAAwJwoTa9HumJtQT333HMAjN16/fv3x6uvvgqtVovJkycLFhwhYhC5Pi/hmRQmFpecLLFITiY0V8o2u4rF9u7dGwAwZswYZEmpTAIhhHCQwsTirIqsLsnJhOZKsbNrRd2RI0cCMFaVMBgMbg2IEEL4lBebh+6+3S222TMEnM/7RbaSEM2VYseZoEJCQlBaWopff/0Vu3btQmBgoBBxEYmjagtELtKGpiH30VyHBjXwXVuPLQkpoKC5UjZwJqjVq1fjt99+w5o1a1BdXY38/Hwh4iIS5mq1BUpuRGjxkfGoWVQDwxsG1Cyq4RyUwHdRWWsVLBRQYO6jc2mAhA2cCSo0NBRz585Fbm4u0tPTodVquZ5C7CSFC3VJCRAbG+VQDGzVFmbM4H4+lRIicsD3wAprQ9OLpxSjcGKhK2F6PM6Jujk5OTh48CDuueceMAwDhUKBHTt2CBGbRzNdqE0XetOFGhBu1NidGJQOxcBWVaG9nfv5fJQSKikxDQMfRMPAiVuwVYtw5X6RXMtDiYmzBXXixAmUl5djx44dKC0tdTo5abVaLFiwAKmpqZgzZw7+sLLi3Ny5c5GcnAy1Wo3Zs2c7dRwxOdIicmYtKb5bXM6uZ2WrqgLX810tJSSHRSKJ/Mm5Yrsn4UxQkZGRaGtrc/lAn376KQYOHIhPPvkEkydPRmFh16ZtXV0dPv30UxQXF+PDDz90+ZhCKisLcajrytELtTu6xpxNFtaqLdj7fFeXKJHDIpFE/uRcsd2TcCao+vp6PP3000hKSkJSUhKSk5OdOlBlZSVGjRoFABg9ejR+/PFHi/1Xr15Fc3Mz5s6di5SUFHOpJbkoKOjt0IXT0Qu1Oy7MziYL0xIet4vcO/R8V0sJUTFX4m6m4eXqz9QAgOIpxXYNrCD847wH5UzF8l27dqGoqMhiW1hYGIKDgwEAgYGBuHHjhsV+vV6PWbNmIT09HdevX0dKSgqGDRuGsLAwi8dVVVU5HI8QGhoGWd1eV8egqupMl+3z54cgO7sPtNo7nxG6dzdg/vx6VFU1W3mdQQAUdr++PRyNoaOYGGDVKsefHxMD5OSEoKCgNxoa/BARoUdGRiNiYpphz682IiIK9fVKK9t1qKqq5n4BidBqtZL9W7bF0+Muqy1D9pFsc2mk2uu1mP2P2bh08RLiI+N5jamstgwFJwvQ0NqAiIAIZAzNsHoMKZ1ze2MGeIqbYbFz506GYRjmnXfeYdauXWvx5Yz58+czx48fZxiGYZqbm5mJEyda7NfpdEy2gpz3AAAa7UlEQVRLS4v559dee435+eefLR5z5MgRp44thD592hhj55vlV2Qk+3O2bzfuVyiM/27fzv7YyMiur831+vbYvt0Yuz0xsD3f3vfAh+3bGSYgwPIcBAS4/7h8O336tNghOMXT444siGSQgy5fkQWRvMaz/cR2JiAvwOIYAXkBzPYTXf+QpXLOHYmZYRyLm+3aztrFFxERAcB4D+q+++6z+HJGTEwMvvvuOwDAwYMHMWLECIv9P/zwAxYtWgQAaGlpwdmzZ3H//fc7dSwxZGQ0Otx15UjNN3dV2U5LAyoqqp2uOyd03TrLFYIZWa4QTKRLqLp9fM+zEoIYMbN28ZnuF33xxRfYsmWLywdKSUnB0qVLkZKSAj8/P3PX4dtvv424uDiMGTMGhw4dQmJiInx8fLB48WKEhoa6fFyhxMc3o2/ffm6rgk1Vtu+gRSKJu7hjeLk1Uihg6ygxYua8BxUcHIyKigr0798fPj7GBpczrSh/f3/87W9/67L99ddfN38v90K07l5anZZuJ8S92BYj5Ht4uVCJkE9ixMw5iu+PP/7Axx9/jJycHGRnZ+ONN95wWzCEECImoYaXuzLPSqxFD8WYG2azBaXRaLBp0yb4+/u7LQDinDvVFLy7u48QvglR8cH0+lkVWQ4tQ28qYmtq4Qm56KGzMbuCtQW1fft2/PnPf8akSZPwP//zP24LgDiOj0m7HatSxMZGUSUGQgSWNjTNoQK2gH0DFdzZwnImZlewJqiysjJ89dVX2LFjR5c5TURcbJN2Fy607/mdE1x9vZLKBREiA1wDFfheJkRsrAlKqVRCqVQiNDQUer1eyJgIB7aqCU1NrlUjl/kYFUI8HtfqwHIcvm6LXSvqMoz1pYqJOGyVErInyVC5IELkiWugghyHr9vCOkjit99+w5IlS8AwjPl7E2fKHxH+5OUBzz9vfZ89SUalMnbvWdtOCJEuroEKchy+bgtrglq3bp35e2cLxBL3SEsz3m9qauq6z54kk5dnuRYVwE9VCkKI+9kaZSjUPC6hsHbxPf7446xfxL3sWfdp/XpA2bVmKjQa7vtQaWnG1W9N1ch9fBjMmEHD1AmRO09bJsSue1DepqQE6NULUCiMX716CTfCzZEh5NZuDTY1cQ85LykBioqMK+ACgMGgQFERjeIjxBMIPRTcnShBdVJSAsyaZdl91tQEzJwpzAXc3hF2WVkA2+BKrhF5NIqPeDKxKi24kye+J3tQguokKwvQ6bpu1+uFuYDbO8KOazCErf00io94qpKTJZi5Z6bFPKCZe2airLZM7NCcVlZb5lFzmxxBCaoTZy7sfLJ3lVuuwRC29ru67DohUrXwy4XQGyy7FvQGPfKOynOQAAAUnCzwqLlNjqAE1YkzF3Y+2bvuk7XH2Xq8M8cgRG6abloZ2grguv66wJHwp6G1wep2uc5tcgQlqE7y8qyPjvPzE+YCbrkgH1gX5Ov4OODOiDx7FvDrfIw+fXS06B8hEhUREGF1u2lukyffn6IE1UlaGrBlCxAWdmdbWBiwdavxe67h33zFYM8qtabHMQxw65bxX3tXte14jIqKakpOxCOE+YdZ3d5T2VPgSPiTMTSDtXqEp9Xe64wSlBVpacDVq8YLPsMYvwdcryBuj85zoObNEyYpEiImvloB6yesh9LXsgtE6avE8uHL+QiTkztaM/GR8axzmzyt9l5nnCvqEiNbQ7P5an2Y5kCZjlNbC7z//p39pqQIUHcc8Rx8rnHEVgooplsMv0Fb4c61mtiqR3ha7b3OqAVlJyGGZltLgp3RfCXiafhuBYg1UVWM1gxXdXO5owRlJyGGZtub7Gi+EvEkntIKEON9iLEMu5AET1DffPONRWX0jnbu3IkpU6YgMTER3377rcCR2SbE0Gx7kx3NVyKexFNaAWK8D0+rvdeZoAlq5cqVWLt2LQwGQ5d9jY2NKC4uxo4dO/DRRx/h3Xffhc5aSQeR2Dv82xW25jaZuGO+UllZCA3EIKLxlFaAWO/Dk2rvdaZgBFyN8IsvvkBoaChKS0tRUFBgsa+iogLfffcdcnNzAQDz58/Hyy+/jGHDhpkfU1lZiQCuK7hItFotunfv7vLrlJWFoKCgNxoa/BARoceYMRp8912Q+eeMjEbExzfzEPGd42VnR0Cr9TVv697dgNzcel6P4w58nXMxyDV2d8VdVluGgpMFaGhtQERABDKGZiA+Mp631xfqfLvjfXjD30praytGjBjRZbtbRvHt2rULRUVFFtvy8/Px7LPP4vDhw1afo9FoEBwcbP45MDAQGo2my+Oio6P5DZYnVVVVvMQWHQ1kZpp+UgII7bBXCaDf7S9+TJgAaLWW27RaH7z3Xj9kZvJ3HHfg65yLQa6xuyvu6OhoZMZlcj/QSUKdb3e8D2/4W6msrLS63S0Javr06Zg+fbpDzwkKCkJLS4v555aWFouERRxXUmIc8VdXZ7xvlZfXtUuSCscS4pySkyWsK9sSfkhmHtSwYcOwbt06tLW1QafTobq6GgMHDhQ7LNmyNqfK2hwqWv6dEMfZmvMEsC/JThwjeoLaunUrVCoVYmNjoVarkZqaCoZhkJGRgbvuukvs8GTL3onFeXnA7NkGaLV3xstQ4VhCbGOb87Twy4W4eeumWybreiPBE9TIkSMxcuRI888zZ840f5+YmIjExEShQ/JI9nbdpaUBly7V4733+tnsCiSE3ME2t8laNXXTZF1KUI6jiboS1rkunyPDvx2ZWBwf32xXcVpCvIE99fQcndskt0nHUkEJSqJM95CcLU5Laz4R4jh7q4OzzXliq6Yut0nHUkEJSqLY7iHNmGFfi0qIicWEeBp76+mxVXBYP2G9R0w6lgrRB0kQ69juIbW3G/+1p7J5WprlPlOXId1r8jwGgwE5OTn49ddfoVQqsXLlSkSaVrMkdnOknh5bhXGARvHxhVpQEmXPMG9HKpu72mVI+MV3eany8nLodDqUlpZiyZIlWL16NR9heh0+6ul5cukhoVGCkih76vIB9k+otTXsnAirpATIzu7D64eFyspKjBo1CgDwyCOP4JdffuEpWu8ix7qAtOQ7EVzne0i+vtYfZ++EWqoYIR1ZWbCYdwa4/mFBo9EgKCjI/LOvry9u3brl/At6KblVB6cl34lo0tJgHv5dVOTaqDwh1rMi9nHHh4XOpcIMBgO6daNbzM6QUxedpy/5TglKJlwdlUfDzqXDHR8WYmJicPDgQQDAsWPHqEyYl/CUxR7ZUIKSkY4tKkcn1NKwc+nIyzMuadKRqx8Wxo8fD6VSieTkZKxatQr/9V//5WKURA48ZbFHNtQH4EU6Dzsn4nBHeSkfHx/zWmrEe+TF5lkUrQWkP6jDEdSCIkQEVF7Ks4g1kk5ugzocRS0oQgiB8+s72Vp6Q4hEYWvCsNxRC8rNXCn4SggRhivDtRd+udCjR9KJiRKUG1H1BkLkwdnh2iUnS6wusQF4zkg6MVGCciOq3kCIPDg7XNtWAvOUkXRiogTlRlKs3kBdjoR05exwbVsJzFNG0omJEpQbSa16A1uXY1lZiDgBEd4dP34carVa7DBkx9kafGwJLMw/zGMHLgiJEpQbSa16A1uXY0FBb3EC8mIhZWW8N2U3b96MFStWoK2tzeXX8jbODtdmS2zrJ6x3Z7heQ/Bh5t988w2++uorrF27tsu+lStX4ujRowgMDAQAFBYWIjg4WOgQeWOa25KVJY01mNi6Fhsa/IQNxNuVlKBPdjag1Rp/tmdxLzuoVCps2LABr7/+Og9Beh97h2t3Ho4+4+EZ+OLsF7T+kxsImqBWrlyJQ4cOITo62ur+U6dO4cMPP0RoaKiQYbmVlKo3qFTGa2FnERF6AErB4/FaWVnwMSUnE9PoGRf+WJ555hlcuHDBxeC8i6Nzn6zNeSo6XsT75NiOcUUERGDNrTVemfQE7eKLiYlBTk6O1X0GgwG1tbXIzs5GcnIydu/eLWRoXoGtyzEjo1GcgLyVFEfPeCFn5j4JUT28c1z1rfUetYSGI9zSgtq1axeKioostuXn5+PZZ5/F4cOHrT6ntbUVzz//PGbOnIn29nakp6djyJAhGDRokMXjqqqq3BGyy7RarWRjM4mJAXJyQlBQ0BsNDX6IiNAjI6MR48ZdQVVVs9jhOUwO59yaqIgIKOvru2zXRUSg2sX3c/nyZdy8edNt50Wu57xj3GW1ZSg4WYD61q6/g1Z9KzK/ykRMtxirr2NrODpf5yXzq0yrSdBWXFLEx9+KWxLU9OnTMX36dIee4+/vj/T0dPj7+wMAnnjiCZw5c6ZLgmLrHhRbVVWVZGPrKDoayMw0/aQE0A9VVc2yiL0zuZzzLtasgWH2bMtuvoAAKNescfn9BAcHw9/f323nRa7n3BR3yckS5BzN6ZIAOmpobWB9j6oeKtRe79pPruqh4u28NOxscDguKXLkb6WystLqdsmM4qupqUFqaira29uh1+tx9OhRDB48WOywCOFfWhrqc3PdsvbJvffei507d/IQpGey1kXXma25T0IsCe/pS2g4QvQEtXXrVlRUVCAqKgoJCQlITEyEWq3GpEmTMGDAALHDI8QtmuPjnV/ciziNqzIEV7IRonq4EElQLgQfZj5y5EiMHDnS/PPMmTPN38+ZMwdz5swROiRCiJdg66IDgMgekXYNEXd39XDTa1uM4oujUXwEVAqIEE/G1jrZPmU7ahbVSCYJpA1NQ82iGhjeMKAivkIycQmNElQHVH2cEM/m6Qv8eRpasLADW9XH6RYBIZ7Bkxf48zTUguqA5k8S4tnEWpqdOIdaUB2wlQISq/o4IfbS6/VYvnw5Ll68CJ1Oh1deeQWxsbFihyUpYi/NThxHLagOpFZ9nHiustoyXj/J7927Fz179sQnn3yCzZs348033+QpUs8hRJkiwi9qQXUgterjxDOVnCxB9pFsaNuNlST4+CQfFxeHZ555xvyzr6+v64F6GGdXzSXi8aoWlD1DyNPSaP4kca+siixzcjJx9ZN8YGAggoKCoNFo8Nprr2HRokWuhulxqEKD/HhNgqIh5EQq3PVJvr6+Hunp6Zg0aRISEhJcei1PRBUa5MdrEpStIeSECMkdn+SvXr2KWbNmITMzE9OmTXP6dTwZzYGSH6+5B0VDyIlU5MXmYfY/Zlt087n6SX7jxo1obm5GYWEhCgsLARiXgO/evbvL8XoSmgMlL16ToGgIOZGKtKFpuHTxEt478x5vy4SvWLECK1as4DFKQsTnNQkqL894z6ljNx8NISdiiY+MR2ZcJvcDCfFiXnMPKi3NuOSOG5bgIYQQ4gZe04ICjMmIEhIhhMiD17SgCCGEyAslKEIIIZJECYoQQogkUYIihBAiSZSgCCGESBIlKEIIIZKkYBiGETsIe1VWVoodAiGEEDcYMWJEl22ySlCEEEK8B3XxEUIIkSRKUIQQQiSJEhQhhBBJogTlom+++QZLliyxum/lypWYMmUK1Go11Go1bty4IXB07GzFvXPnTkyZMgWJiYn49ttvBY6MnVarxYIFC5Camoo5c+bgjz/+6PKYuXPnIjk5GWq1GrNnzxYhyjsMBgOys7ORlJQEtVqN2k7rvUj1PAPcsUv5bxsAjh8/DrVa3WX7gQMHMHXqVCQlJWHnzp0iRGYbW9xbt27FxIkTzef7999/FyE66/R6PTIzM5Gamopp06ahoqLCYr9L55whTnvzzTeZZ555hlm0aJHV/cnJyUxTU5PAUXGzFfeVK1eY+Ph4pq2tjWlubjZ/LwVbtmxh/va3vzEMwzBlZWXMm2++2eUxEyZMYAwGg9ChWfX1118zS5cuZRiGYf75z38yc+fONe+T8nlmGNuxM4x0/7YZhmE2bdrExMfHM9OnT7fYrtPpmHHjxjHXrl1j2tramClTpjBXrlwRKcqu2OJmGIZZsmQJc/LkSRGi4rZ7925m5cqVDMMwzB9//MGMGTPGvM/Vc04tKBfExMQgJyfH6j6DwYDa2lpkZ2cjOTkZu3fvFjY4G2zFfeLECQwfPhxKpRLBwcFQqVQ4c+aMsAGyqKysxKhRowAAo0ePxo8//mix/+rVq2hubsbcuXORkpIiequkY7yPPPIIfvnlF/M+KZ9nwHbsUv7bBgCVSoUNGzZ02V5dXQ2VSoUePXpAqVRixIgROHLkiAgRWscWNwCcOnUKmzZtQkpKCj744AOBI7MtLi4OCxcuNP/s6+tr/t7Vc+5Vy204a9euXSgqKrLYlp+fj2effRaHDx+2+pzW1lY8//zzmDlzJtrb25Geno4hQ4Zg0KBBQoQMwLm4NRoNgoODzT8HBgZCo9G4NU5rrMUeFhZmji0wMLBLt5Jer8esWbOQnp6O69evIyUlBcOGDUNYWJhgcXek0WgQFBRk/tnX1xe3bt1Ct27dJHOe2diKXQp/27Y888wzuHDhQpftUj/nbHEDwMSJE5GamoqgoCC8+uqr+Pbbb/H0008LHKF1gYGBAIzn97XXXsOiRYvM+1w955Sg7DB9+nRMnz7doef4+/sjPT0d/v7+AIAnnngCZ86cEfQ/sTNxBwUFoaWlxfxzS0uLxR+YUKzF/uqrr5pja2lpQUhIiMX+Xr16ITk5Gd26dUNYWBiio6Nx7tw50RJU53NpMBjQrVs3q/vEOs9sbMUuhb9tZ0j9nLNhGAYzZswwxzpmzBicPn1aMgkKAOrr6zF//nykpqYiISHBvN3Vc05dfG5SU1OD1NRUtLe3Q6/X4+jRoxg8eLDYYXEaNmwYKisr0dbWhhs3bqC6uhoDBw4UOywAxq7J7777DgBw8ODBLjPPf/jhB/Ont5aWFpw9exb333+/4HGaxMTE4ODBgwCAY8eOWZxHKZ9nwHbscv3bjoqKQm1tLa5duwadTocjR45g+PDhYofFSaPRID4+Hi0tLWAYBocPH8aQIUPEDsvs6tWrmDVrFjIzMzFt2jSLfa6ec2pB8Wzr1q1QqVSIjY1FQkICEhMT4efnh0mTJmHAgAFih8eqY9xqtRqpqalgGAYZGRm46667xA4PAJCSkoKlS5ciJSUFfn5+WLt2LQDg7bffRlxcHMaMGYNDhw4hMTERPj4+WLx4MUJDQ0WLd/z48fj++++RnJwMhmGQn58vi/MMcMcup7/tffv2obW1FUlJSVi2bBlefPFFMAyDqVOnIjw8XOzwWHWMOyMjA+np6VAqlXjyyScxZswYscMz27hxI5qbm1FYWIjCwkIAxh6QmzdvunzOqdQRIYQQSaIuPkIIIZJECYoQQogkUYIihBAiSZSgCCGESBIlKEIIIZJECYp4lMOHD+PJJ580F9VMTExEcXFxl8cdPHgQpaWlDr32Z5991qUQJpcLFy4gMTGxy/br169j+fLlSEtLQ3JyMjIyMiRXcJVLaWkp9Hq91X22ihETYi+aB0U8zhNPPIGCggIAgE6nQ1xcHCZNmmRReWL06NEOv+6UKVN4i3Hx4sVITk7G+PHjAQAff/wxsrOzzXHLwQcffIDJkyd32b5y5UocOnQI0dHRIkRFPAklKOLRNBoNfHx84OvrC7VajbvvvhvNzc2YOHEiamtrkZycjCVLliAiIgLnz5/H0KFD8de//hVNTU1YtmwZbty4AYZh8NZbb2Hfvn3o1asX7r//fmzcuBE+Pj5obGxEUlIS0tLS8NNPP+Hvf/87AOPSIG+99Rb8/Py6xHTx4kVcvXrVnJwAQK1WY+rUqQCAvXv3oqioCEqlEv3790dubi727duHb7/9FlqtFo2NjUhPT0dFRQXOnj2L119/HePGjUNsbCwefvhh1NXVYcCAAcjLy4NGo0FmZiY0Gg3a29uxcOFCPPnkk0hISMDjjz+OX3/9FQqFAoWFhQgODsbatWvx888/g2EYvPDCC5gwYQLUajUGDRqEs2fPQqPRYP369fjhhx/Q2NiIjIwM8+RMk5iYGIwbN87hFiohnVGCIh7nf//3f6FWq6FQKODn54e//OUv5oKWCQkJGD9+PD777DPz42tqavDRRx/B398f48aNQ2NjIz744AOMHTsWKSkp+PHHH3HixAmLY1y+fBl79uyBwWBAQkIC4uLicPbsWaxZswbh4eHYuHEjvvrqK4u6ZCZXrlzBvffea7HN19cXwcHB+Ne//oUNGzbg888/R1BQEPLz81FaWoqAgAC0tLRgy5Yt2L9/Pz7++GPs3LkThw8fxrZt2zBu3DhcvnwZCxcuRGRkJBYuXIjy8nL885//xL/9279hxowZuHz5MlJSUlBeXo6WlhZMnDgRf/nLX7BkyRIcPHgQQUFBuHDhAnbs2IG2tjYkJibiqaeeAmAszZSVlYWCggLs378fL730Et5//32rLT5bxYgJcQQlKOJxOnbxdXbfffd12aZSqcyVu3v37o22tjacO3fOXFfsySefBACLpRBMS2UAwIABA1BXV4fw8HDk5eUhICAAly9fRkxMjNUY+vbti4aGBotter0eX331FSIjI/HAAw+Y43nsscdw6NAhPPzww+Yus+DgYERFRUGhUKBHjx5oa2sDAPTp0weRkZHm+M6dO4fq6mpzkgwPD0dQUJB5oceHHnrI/Ly2tjZcunQJp06dMi+Yd+vWLVy6dMnisREREbh69arV90UI32iQBPEqCoXCrm1RUVE4efIkAODnn3/GmjVrLPZXVVWhvb0dN2/exG+//YbIyEisWLEC+fn5WL16Ne655x6wVRELDw/H3XffjfLycvO2bdu2oby8HPfeey+qq6vR2toKAPjpp5/MSdVanB1dvnwZjY2NAICjR4/igQceQFRUlHn9ncuXL6O5uRk9e/a0+nr3338/Ro4cieLiYhQVFWHChAldWnodKRQKGAwGmzER4gpqQRFixdy5c7F8+XLs3bsXgHEdrT179pj337p1C3PmzMG1a9fwyiuvIDQ0FJMmTUJiYiJCQkLQq1cvXLlyhfX13377beTm5mLLli3Q6/VQqVRYuXIlgoODsWDBAqSnp8PHxwcqlQr/+Z//if3793PGrFQq8eabb6K+vh4PP/wwxo4dixEjRmD58uX4+uuvodVqkZuba142o7OxY8fip59+QmpqKlpbWzFu3DiLNaE6e/TRR/HSSy9h27ZtnMmTEGdQsVhCHHT48GHs2LFDciPunnrqKXz//fdih0EIb6iLjxBCiCRRC4oQQogkUQuKEEKIJFGCIoQQIkmUoAghhEgSJShCCCGSRAmKEEKIJP0/jkStqnsWB94AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sc = StandardScaler()\n",
+    "\n",
+    "pca1 = PrincipalComponentAnalysis(n_components=2, whitening=True)\n",
+    "\n",
+    "X_train_scaled = sc.fit_transform(X_train)\n",
+    "X_train_transf = pca1.fit(X_train_scaled).transform(X_train_scaled)\n",
+    "\n",
+    "\n",
+    "with plt.style.context('seaborn-whitegrid'):\n",
+    "    plt.figure(figsize=(6, 4))\n",
+    "    for lab, col in zip((0, 1, 2),\n",
+    "                        ('blue', 'red', 'green')):\n",
+    "        plt.scatter(X_train_transf[y_train==lab, 0],\n",
+    "                    X_train_transf[y_train==lab, 1],\n",
+    "                    label=lab,\n",
+    "                    c=col)\n",
+    "    plt.xlabel('Principal Component 1')\n",
+    "    plt.ylabel('Principal Component 2')\n",
+    "    plt.legend(loc='lower center')\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Covariance matrix:\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[1., 0.],\n",
+       "       [0., 1.]])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.set_printoptions(precision=1, suppress=True)\n",
+    "\n",
+    "print('Covariance matrix:\\n')\n",
+    "np.cov(X_train_transf.T)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see above, the whitening achieves that all features now have unit variance. I.e., the covariance matrix of the transformed features becomes the identity matrix."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -465,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +640,7 @@
      "text": [
       "## PrincipalComponentAnalysis\n",
       "\n",
-      "*PrincipalComponentAnalysis(n_components=None, solver='eigen')*\n",
+      "*PrincipalComponentAnalysis(n_components=None, solver='svd', whitening=False)*\n",
       "\n",
       "Principal Component Analysis Class\n",
       "\n",
@@ -485,10 +651,15 @@
       "    The number of principal components for transformation.\n",
       "    Keeps the original dimensions of the dataset if `None`.\n",
       "\n",
-      "- `solver` : str (default: 'eigen')\n",
+      "- `solver` : str (default: 'svd')\n",
       "\n",
       "    Method for performing the matrix decomposition.\n",
       "    {'eigen', 'svd'}\n",
+      "\n",
+      "- `whitening` : bool (default: False)\n",
+      "\n",
+      "    Performs whitening such that the covariance matrix of\n",
+      "    the transformed data will be the identity matrix.\n",
       "\n",
       "**Attributes**\n",
       "\n",
@@ -524,7 +695,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit(X)*\n",
+      "*fit(X, y=None)*\n",
       "\n",
       "Learn model from training data.\n",
       "\n",

--- a/mlxtend/feature_extraction/principal_component_analysis.py
+++ b/mlxtend/feature_extraction/principal_component_analysis.py
@@ -22,6 +22,9 @@ class PrincipalComponentAnalysis(_BaseModel):
     solver : str (default: 'svd')
         Method for performing the matrix decomposition.
         {'eigen', 'svd'}
+    whitening : bool (default: False)
+        Performs whitening such that the covariance matrix of
+        the transformed data will be the identity matrix.
 
     Attributes
     ----------
@@ -47,7 +50,7 @@ class PrincipalComponentAnalysis(_BaseModel):
     http://rasbt.github.io/mlxtend/user_guide/feature_extraction/PrincipalComponentAnalysis/
 
     """
-    def __init__(self, n_components=None, solver='svd'):
+    def __init__(self, n_components=None, solver='svd', whitening=False):
         valid_solver = {'eigen', 'svd'}
         if solver not in valid_solver:
             raise AttributeError('Must be in %s. Found %s'
@@ -58,6 +61,7 @@ class PrincipalComponentAnalysis(_BaseModel):
             raise AttributeError('n_components must be > 1 or None')
         self.n_components = n_components
         self._is_fitted = False
+        self.whitening = whitening
 
     def fit(self, X, y=None):
         """Learn model from training data.
@@ -96,7 +100,9 @@ class PrincipalComponentAnalysis(_BaseModel):
 
         self.w_ = self._projection_matrix(eig_vals=self.e_vals_,
                                           eig_vecs=self.e_vecs_,
+                                          whitening=self.whitening,
                                           n_components=n_components)
+        
         self.loadings_ = self._loadings()
         return self
 
@@ -118,7 +124,16 @@ class PrincipalComponentAnalysis(_BaseModel):
         self._check_arrays(X=X)
         if not hasattr(self, 'w_'):
             raise AttributeError('Object as not been fitted, yet.')
-        return X.dot(self.w_)
+            
+        transformed = X.dot(self.w_)
+        if self.whitening:
+            ### Debug 1
+            #norm = np.sqrt(np.diag(self.e_vals_[:self.w_.shape[1]]))
+            #for i, column in enumerate(transformed.T):
+            #    transformed[:, i] /= np.max(norm[:, i])
+            norm = np.diag((1./np.sqrt(self.e_vals_[:self.w_.shape[1]])))
+            transformed = norm.dot(transformed.T).T            
+        return transformed 
 
     def _covariance_matrix(self, X):
         mean_vec = np.mean(X, axis=0)
@@ -141,6 +156,6 @@ class PrincipalComponentAnalysis(_BaseModel):
         """Compute factor loadings"""
         return self.e_vecs_ * np.sqrt(self.e_vals_)
 
-    def _projection_matrix(self, eig_vals, eig_vecs, n_components):
+    def _projection_matrix(self, eig_vals, eig_vecs, whitening, n_components):
         matrix_w = np.vstack([eig_vecs[:, i] for i in range(n_components)]).T
         return matrix_w

--- a/mlxtend/feature_extraction/principal_component_analysis.py
+++ b/mlxtend/feature_extraction/principal_component_analysis.py
@@ -102,7 +102,7 @@ class PrincipalComponentAnalysis(_BaseModel):
                                           eig_vecs=self.e_vecs_,
                                           whitening=self.whitening,
                                           n_components=n_components)
-        
+
         self.loadings_ = self._loadings()
         return self
 
@@ -124,16 +124,16 @@ class PrincipalComponentAnalysis(_BaseModel):
         self._check_arrays(X=X)
         if not hasattr(self, 'w_'):
             raise AttributeError('Object as not been fitted, yet.')
-            
+
         transformed = X.dot(self.w_)
         if self.whitening:
-            ### Debug 1
-            #norm = np.sqrt(np.diag(self.e_vals_[:self.w_.shape[1]]))
-            #for i, column in enumerate(transformed.T):
+            # ## Debug 1
+            # norm = np.sqrt(np.diag(self.e_vals_[:self.w_.shape[1]]))
+            # for i, column in enumerate(transformed.T):
             #    transformed[:, i] /= np.max(norm[:, i])
             norm = np.diag((1./np.sqrt(self.e_vals_[:self.w_.shape[1]])))
-            transformed = norm.dot(transformed.T).T            
-        return transformed 
+            transformed = norm.dot(transformed.T).T
+        return transformed
 
     def _covariance_matrix(self, X):
         mean_vec = np.mean(X, axis=0)

--- a/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
+++ b/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
@@ -22,6 +22,18 @@ def test_default_components():
     assert res.shape[1] == 4
 
 
+def test_whitening():
+    pca = PCA(n_components=2)
+    res = pca.fit(X).transform(X)
+    diagonals_sum = np.sum(np.diagonal(np.cov(res.T)))
+    assert round(diagonals_sum, 1) == 3.9, diagonals_sum
+
+    pca = PCA(n_components=2, whitening=True)
+    res = pca.fit(X).transform(X)
+    diagonals_sum = np.sum(np.diagonal(np.cov(res.T)))
+    assert round(diagonals_sum, 1) == 2.0, diagonals_sum
+
+
 def test_default_2components():
     pca = PCA(n_components=2)
     res = pca.fit(X).transform(X)


### PR DESCRIPTION
### Description

Adds a `whitening` parameter to `PrincipalComponentAnalysis`, to optionally whiten the transformed data such that the features have unit variance.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->