### PR TITLE
Sort eigvecs in PCA

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,7 +24,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- -
+- The eigenvectors maybe have not been sorted in certain edge cases if solver was `'eigen'` in `PrincipalComponentAnalysis`. ([#477](https://github.com/rasbt/mlxtend/pull/477))
 
 
 

--- a/mlxtend/feature_extraction/principal_component_analysis.py
+++ b/mlxtend/feature_extraction/principal_component_analysis.py
@@ -134,7 +134,7 @@ class PrincipalComponentAnalysis(_BaseModel):
             e_vals = e_vals ** 2 / n_samples
 
         sort_idx = np.argsort(e_vals)[::-1]
-        e_vals, e_vecs = e_vals[sort_idx], e_vecs[sort_idx]
+        e_vals, e_vecs = e_vals[sort_idx], e_vecs[:, sort_idx]
         return e_vals, e_vecs
 
     def _loadings(self):


### PR DESCRIPTION
### Description

The eigenvectors maybe have not been sorted in certain edge cases if solver was `'eigen'` in `PrincipalComponentAnalysis`.



### Related issues or pull requests

Fixes #476


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->