### PR TITLE
Sort eigvecs in LDA

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,3 +21,13 @@ install:
 
 test_script:
   - nosetests -s -v --exclude-dir=mlxtend/plotting
+
+notifications:
+
+  # Email
+  - provider: Email
+    to:
+      - mail@sebastianraschka.com
+    subject: 'Build {{status}}'
+    message: "{{message}}, {{commitId}}, ..."
+    on_build_status_changed: true

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -22,9 +22,10 @@ The CHANGELOG for the current development version is available at
 
 - Changed the default solver in `PrincipalComponentAnalysis` to `'svd'` instead of `'eigen'` to improve numerical stability. ([#474](https://github.com/rasbt/mlxtend/pull/474))
 
+
 ##### Bug Fixes
 
-- -
+- The eigenvectors maybe have not been sorted in certain edge cases in `LinearDiscriminantAnalysis`. ([#478](https://github.com/rasbt/mlxtend/pull/478))
 
 
 

--- a/mlxtend/feature_extraction/linear_discriminant_analysis.py
+++ b/mlxtend/feature_extraction/linear_discriminant_analysis.py
@@ -145,7 +145,7 @@ class LinearDiscriminantAnalysis(_BaseModel):
         e_vals, e_vecs = np.linalg.eig(np.linalg.inv(within_scatter).dot(
             between_scatter))
         sort_idx = np.argsort(e_vals)[::-1]
-        e_vals, e_vecs = e_vals[sort_idx], e_vecs[sort_idx]
+        e_vals, e_vecs = e_vals[sort_idx], e_vecs[:, sort_idx]
         return e_vals, e_vecs
 
     def _projection_matrix(self, eig_vals, eig_vecs, n_discriminants):


### PR DESCRIPTION
### Description

- The eigenvectors maybe have not been sorted in certain edge cases in `LinearDiscriminantAnalysis`. ([#478](https://github.com/rasbt/mlxtend/pull/478))


### Related issues or pull requests





### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->