### PR TITLE
raise error if image directory is empty in eyepad align

### DIFF
--- a/mlxtend/image/eyepad_align.py
+++ b/mlxtend/image/eyepad_align.py
@@ -57,7 +57,7 @@ class EyepadAlign(object):
 
     target_width_ : the width of the transformed output image.
 
-    file_extensions : str (default='.jpg'): File extension of the image files. 
+    file_extensions : str (default='.jpg'): File extension of the image files.
 
     For more usage examples, please see
     http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/
@@ -156,7 +156,8 @@ class EyepadAlign(object):
             if np.sum(landmarks) is not None:  # i.e., None == no face detected
                 landmarks_list.append(landmarks)
             else:
-                warnings.warn('No face detected in image %s. Image ignored.' % f)
+                warnings.warn('No face detected in image %s. Image ignored.'
+                              % f)
         self.target_landmarks_ = np.mean(landmarks_list, axis=0)
 
         props = self._calc_eye_properties(self.target_landmarks_)

--- a/mlxtend/image/eyepad_align.py
+++ b/mlxtend/image/eyepad_align.py
@@ -53,9 +53,11 @@ class EyepadAlign(object):
     eye_distance_ : the distance between left and right eyes
         in the target landmarks.
 
+    target_height_ : the height of the transformed output image.
+
     target_width_ : the width of the transformed output image.
 
-    target_height_ : the height of the transformed output image.
+    file_extensions : str (default='.jpg'): File extension of the image files. 
 
     For more usage examples, please see
     http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/
@@ -116,11 +118,15 @@ class EyepadAlign(object):
         self.target_height_ = target_height
         self.target_width_ = target_width
 
-        file_list = [os.path.relpath(os.path.join(dirpath, file),
+        file_list = [os.path.relpath(os.path.join(dirpath, f),
                                      target_img_dir)
                      for (dirpath, dirnames, filenames)
                      in os.walk(target_img_dir)
-                     for file in filenames if file.endswith(file_extensions)]
+                     for f in filenames if f.endswith(file_extensions)]
+
+        if not len(file_list):
+            raise ValueError('No images found in %s with extension %s.'
+                             % (target_img_dir, file_extensions))
 
         if self.verbose >= 1:
             print("Fitting the average facial landmarks "

--- a/mlxtend/image/tests/test_eyepad_align.py
+++ b/mlxtend/image/tests/test_eyepad_align.py
@@ -9,6 +9,7 @@ from mlxtend.image import extract_face_landmarks
 import imageio
 import numpy as np
 import os
+from nose.tools import assert_raises
 
 
 def test_defaults():
@@ -48,7 +49,8 @@ def test_fit2dir():
     path = 'mlxtend/image/tests/data/'
     eyepad = EyepadAlign()
     eyepad.fit_directory(target_img_dir=os.path.join(path, 'celeba-subset/'),
-                         target_width=178, target_height=218,
+                         target_width=178,
+                         target_height=218,
                          file_extensions='.jpg')
 
     img = imageio.imread(os.path.join(path, 'lena-small.png'))
@@ -76,3 +78,17 @@ def test_fit2dir():
         assert np.sum(np.abs(landmarks_tr[:10] - true_vals) > 0) == 0, \
                 np.sum(np.abs(landmarks_tr[:10] - true_vals) > 0)
         np.testing.assert_array_equal(landmarks_tr[:10], true_vals)
+
+
+def test_empty_dir():
+    path = 'mlxtend/image/tests/data/'
+    eyepad = EyepadAlign()
+
+    def tmp_func():
+        eyepad.fit_directory(target_img_dir=os.path.join(path,
+                                                         'celeba-subset/'),
+                             target_width=178,
+                             target_height=218,
+                             file_extensions='.PNG')
+
+    assert_raises(ValueError, tmp_func)


### PR DESCRIPTION
### Description

Raises a meaningful error if `fit_dir` call in `EyePadAlign` can't find images files in the specified directory.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
