### PR TITLE
Rename file_extensions to file_extension in EyepadAlign

### DIFF
--- a/docs/sources/user_guide/image/eyepad_align.ipynb
+++ b/docs/sources/user_guide/image/eyepad_align.ipynb
@@ -189,14 +189,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "0% [#####    ] 100% | ETA: 00:00:00/Users/sebastian/Desktop/eyepad_mlxtend/mlxtend/image/extract_face_landmarks.py:61: UserWarning: No face detected.\n",
+      "0% [#####    ] 100% | ETA: 00:00:00/Users/sebastian/code/mlxtend/mlxtend/image/extract_face_landmarks.py:61: UserWarning: No face detected.\n",
       "  warnings.warn('No face detected.')\n",
-      "/Users/sebastian/Desktop/eyepad_mlxtend/mlxtend/image/eyepad_align.py:153: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
-      "  warnings.warn('No face detected in image %s. Image ignored.' % f)\n",
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
+      "  % f)\n",
       "0% [#########] 100% | ETA: 00:00:00\n",
       "Total time elapsed: 00:00:00\n",
-      "/Users/sebastian/Desktop/eyepad_mlxtend/mlxtend/image/eyepad_align.py:153: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
-      "  warnings.warn('No face detected in image %s. Image ignored.' % f)\n"
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
+      "  % f)\n"
      ]
     },
     {
@@ -217,7 +217,7 @@
     "\n",
     "eyepad.fit_directory(target_img_dir='celeba-subset/',\n",
     "                     target_width=178, target_height=218,\n",
-    "                     file_extensions='.jpg')\n",
+    "                     file_extension='.jpg')\n",
     "\n",
     "img = imageio.imread('test-face.png')\n",
     "img_tr = eyepad.transform(img)\n",
@@ -444,20 +444,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "0% [#####    ] 100% | ETA: 00:00:00/Users/sebastian/Desktop/eyepad_mlxtend/mlxtend/image/extract_face_landmarks.py:61: UserWarning: No face detected.\n",
+      "0% [#####    ] 100% | ETA: 00:00:00/Users/sebastian/code/mlxtend/mlxtend/image/extract_face_landmarks.py:61: UserWarning: No face detected.\n",
       "  warnings.warn('No face detected.')\n",
-      "/Users/sebastian/Desktop/eyepad_mlxtend/mlxtend/image/eyepad_align.py:153: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
-      "  warnings.warn('No face detected in image %s. Image ignored.' % f)\n",
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
+      "  % f)\n",
       "0% [#########] 100% | ETA: 00:00:00\n",
       "Total time elapsed: 00:00:00\n",
-      "/Users/sebastian/Desktop/eyepad_mlxtend/mlxtend/image/eyepad_align.py:153: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
-      "  warnings.warn('No face detected in image %s. Image ignored.' % f)\n"
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
+      "  % f)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<mlxtend.image.eyepad_align.EyepadAlign at 0x1c16c83a20>"
+       "<mlxtend.image.eyepad_align.EyepadAlign at 0x1c169076a0>"
       ]
      },
      "execution_count": 10,
@@ -476,7 +476,7 @@
     "\n",
     "eyepad.fit_directory(target_img_dir='celeba-subset/',\n",
     "                     target_width=178, target_height=218,\n",
-    "                     file_extensions='.jpg')"
+    "                     file_extension='.jpg')"
    ]
   },
   {
@@ -597,12 +597,14 @@
       "    in the target landmarks.\n",
       "\n",
       "\n",
+      "- `target_height_` : the height of the transformed output image.\n",
+      "\n",
+      "\n",
+      "\n",
       "- `target_width_` : the width of the transformed output image.\n",
       "\n",
       "\n",
-      "\n",
-      "- `target_height_` : the height of the transformed output image.\n",
-      "\n",
+      "    file_extension str (default='.jpg'): File extension of the image files.\n",
       "\n",
       "For more usage examples, please see\n",
       "[http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/](http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/)\n",
@@ -616,7 +618,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit_directory(target_img_dir, target_height, target_width, file_extensions='.jpg')*\n",
+      "*fit_directory(target_img_dir, target_height, target_width, file_extension='.jpg')*\n",
       "\n",
       "Calculates the average landmarks for all face images\n",
       "in a directory which will then be set as the target landmark set.\n",

--- a/mlxtend/image/eyepad_align.py
+++ b/mlxtend/image/eyepad_align.py
@@ -57,7 +57,7 @@ class EyepadAlign(object):
 
     target_width_ : the width of the transformed output image.
 
-    file_extensions : str (default='.jpg'): File extension of the image files.
+    file_extension str (default='.jpg'): File extension of the image files.
 
     For more usage examples, please see
     http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/
@@ -94,7 +94,7 @@ class EyepadAlign(object):
         return self
 
     def fit_directory(self, target_img_dir, target_height,
-                      target_width,  file_extensions='.jpg'):
+                      target_width,  file_extension='.jpg'):
         """
         Calculates the average landmarks for all face images
         in a directory which will then be set as the target landmark set.
@@ -122,11 +122,11 @@ class EyepadAlign(object):
                                      target_img_dir)
                      for (dirpath, dirnames, filenames)
                      in os.walk(target_img_dir)
-                     for f in filenames if f.endswith(file_extensions)]
+                     for f in filenames if f.endswith(file_extension)]
 
         if not len(file_list):
             raise ValueError('No images found in %s with extension %s.'
-                             % (target_img_dir, file_extensions))
+                             % (target_img_dir, file_extension))
 
         if self.verbose >= 1:
             print("Fitting the average facial landmarks "

--- a/mlxtend/image/tests/test_eyepad_align.py
+++ b/mlxtend/image/tests/test_eyepad_align.py
@@ -51,7 +51,7 @@ def test_fit2dir():
     eyepad.fit_directory(target_img_dir=os.path.join(path, 'celeba-subset/'),
                          target_width=178,
                          target_height=218,
-                         file_extensions='.jpg')
+                         file_extension='.jpg')
 
     img = imageio.imread(os.path.join(path, 'lena-small.png'))
 
@@ -89,6 +89,6 @@ def test_empty_dir():
                                                          'celeba-subset/'),
                              target_width=178,
                              target_height=218,
-                             file_extensions='.PNG')
+                             file_extension='.PNG')
 
     assert_raises(ValueError, tmp_func)


### PR DESCRIPTION
### Description

Renames `file_extensions` to `file_extension` in EyepadAlign to be less ambiguous


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->