### PR TITLE
Adds a pre-check for image dimensions to EyepadAlign.fit_directory

### DIFF
--- a/docs/sources/user_guide/image/eyepad_align.ipynb
+++ b/docs/sources/user_guide/image/eyepad_align.ipynb
@@ -182,6 +182,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Pre-Checking directory for consistent image dimensions...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [#########] 100% | ETA: 00:00:00"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Fitting the average facial landmarks for 9 face images \n"
      ]
     },
@@ -189,13 +203,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Total time elapsed: 00:00:00\n",
       "0% [#####    ] 100% | ETA: 00:00:00/Users/sebastian/code/mlxtend/mlxtend/image/extract_face_landmarks.py:61: UserWarning: No face detected.\n",
       "  warnings.warn('No face detected.')\n",
-      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:185: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
       "  % f)\n",
       "0% [#########] 100% | ETA: 00:00:00\n",
       "Total time elapsed: 00:00:00\n",
-      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:185: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
       "  % f)\n"
      ]
     },
@@ -437,6 +453,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Pre-Checking directory for consistent image dimensions...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [#########] 100% | ETA: 00:00:00"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Fitting the average facial landmarks for 9 face images \n"
      ]
     },
@@ -444,20 +474,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Total time elapsed: 00:00:00\n",
       "0% [#####    ] 100% | ETA: 00:00:00/Users/sebastian/code/mlxtend/mlxtend/image/extract_face_landmarks.py:61: UserWarning: No face detected.\n",
       "  warnings.warn('No face detected.')\n",
-      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:185: UserWarning: No face detected in image 000004.jpg. Image ignored.\n",
       "  % f)\n",
       "0% [#########] 100% | ETA: 00:00:00\n",
       "Total time elapsed: 00:00:00\n",
-      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:160: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
+      "/Users/sebastian/code/mlxtend/mlxtend/image/eyepad_align.py:185: UserWarning: No face detected in image 000003.jpg. Image ignored.\n",
       "  % f)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<mlxtend.image.eyepad_align.EyepadAlign at 0x1c169076a0>"
+       "<mlxtend.image.eyepad_align.EyepadAlign at 0x1c1839ba90>"
       ]
      },
      "execution_count": 10,
@@ -604,8 +636,6 @@
       "- `target_width_` : the width of the transformed output image.\n",
       "\n",
       "\n",
-      "    file_extension str (default='.jpg'): File extension of the image files.\n",
-      "\n",
       "For more usage examples, please see\n",
       "[http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/](http://rasbt.github.io/mlxtend/user_guide/image/EyepadAlign/)\n",
       "\n",
@@ -618,7 +648,7 @@
       "\n",
       "<hr>\n",
       "\n",
-      "*fit_directory(target_img_dir, target_height, target_width, file_extension='.jpg')*\n",
+      "*fit_directory(target_img_dir, target_height, target_width, file_extension='.jpg', pre_check=True)*\n",
       "\n",
       "Calculates the average landmarks for all face images\n",
       "in a directory which will then be set as the target landmark set.\n",
@@ -638,6 +668,14 @@
       "- `target_width` : int\n",
       "\n",
       "    Expected image width of the images in the directory\n",
+      "\n",
+      "    file_extension str (default='.jpg'): File extension of the image files.\n",
+      "\n",
+      "    pre_check Bool (default=True): Checks that each image has the dimensions\n",
+      "    specificed via `target_height` and `target_width` on the whole\n",
+      "    directory first to identify potential issues that are recommended\n",
+      "    to be fixed before proceeding. Raises a warning for each image if\n",
+      "    dimensions differ from the ones specified and expected.\n",
       "\n",
       "**Returns**\n",
       "\n",

--- a/mlxtend/image/eyepad_align.py
+++ b/mlxtend/image/eyepad_align.py
@@ -111,9 +111,10 @@ class EyepadAlign(object):
 
         file_extension str (default='.jpg'): File extension of the image files.
 
-        pre_check Bool (default=True): Checks that each image has the dimensions
-            specificed via `target_height` and `target_width` on the whole
-            directory first to identify potential issues that are recommended
+        pre_check Bool (default=True): Checks that each image has the
+            dimensions specificed via `target_height`
+            and `target_width` on the whole directory first to identify
+            potential issues that are recommended
             to be fixed before proceeding. Raises a warning for each image if
             dimensions differ from the ones specified and expected.
 
@@ -151,10 +152,10 @@ class EyepadAlign(object):
                     warnings.warn('Image %s has '
                                   'dimensions %d x %d '
                                   'instead of %d x %d.'
-                                   % (f, img.shape[0],
-                                      img.shape[1],
-                                      self.target_height_,
-                                      self.target_width_))
+                                  % (f, img.shape[0],
+                                     img.shape[1],
+                                     self.target_height_,
+                                     self.target_width_))
 
         if self.verbose >= 1:
             print("Fitting the average facial landmarks "


### PR DESCRIPTION
### Description

Adds a pre-check for image dimensions and raises a warning if `fit_directory` and an image in the folder has dimensions that don't match the ones specified via the method arguments.

@vmirly 

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
