### PR TITLE
Raise apriori SparseDataFrame ValueError

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,7 +25,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
--
+- Raises a more informative error if a `SparseDataFrame` is passed to `apriori` and the dataframe has integer column names that don't start with `0` due to current limitations of the `SparseDataFrame` implementation in pandas. ([#503](https://github.com/rasbt/mlxtend/pull/503))
 
 ### Version 0.15.0 (01-19-2019)
 

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -110,8 +110,14 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, n_jobs=1):
                  ' are True, False, 0, 1. Found value %s' % (val))
             raise ValueError(s)
 
-    is_sparse = hasattr(df, "to_coo")
+    is_sparse = hasattr(df, "to_coo")  
     if is_sparse:
+        if not isinstance(df.columns[0], str) and df.columns[0] != 0:
+            raise ValueError('Due to current limitations in Pandas, '
+                             'if the SparseDataFrame has integer column names, '
+                             'please make sure they either start with `0` or cast them '
+                             'as string column names: `df.columns = [str(i) for i in df.columns`.')
+
         X = df.to_coo().tocsc()
         support = np.array(np.sum(X, axis=0) / float(X.shape[0])).reshape(-1)
     else:

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -1,5 +1,5 @@
 # Sebastian Raschka 2014-2019
-# mlxtend Machine Learning Library Extensions
+# myxtend Machine Learning Library Extensions
 # Author: Sebastian Raschka <sebastianraschka.com>
 #
 # License: BSD 3 clause
@@ -110,13 +110,14 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, n_jobs=1):
                  ' are True, False, 0, 1. Found value %s' % (val))
             raise ValueError(s)
 
-    is_sparse = hasattr(df, "to_coo")  
+    is_sparse = hasattr(df, "to_coo")
     if is_sparse:
         if not isinstance(df.columns[0], str) and df.columns[0] != 0:
             raise ValueError('Due to current limitations in Pandas, '
-                             'if the SparseDataFrame has integer column names, '
-                             'please make sure they either start with `0` or cast them '
-                             'as string column names: `df.columns = [str(i) for i in df.columns`.')
+                             'if the SparseDataFrame has integer column names,'
+                             'names, please make sure they either start '
+                             'with `0` or cast them as string column names: '
+                             '`df.columns = [str(i) for i in df.columns`].')
 
         X = df.to_coo().tocsc()
         support = np.array(np.sum(X, axis=0) / float(X.shape[0])).reshape(-1)

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -108,3 +108,18 @@ def test_raise_error_if_input_is_not_binary():
                   'The allowed values for a DataFrame are True, '
                   'False, 0, 1. Found value 2',
                   apriori, df2)
+
+
+def test_sparsedataframe_notzero_column():
+    dfs = pd.SparseDataFrame(df)
+    dfs.columns = [i for i in range(len(dfs.columns))]
+    apriori(dfs)
+
+    dfs = pd.SparseDataFrame(df)
+    dfs.columns = [i+1 for i in range(len(dfs.columns))]
+    assert_raises(ValueError,
+                  'Due to current limitations in Pandas, '
+                  'if the SparseDataFrame has integer column names, '
+                  'please make sure they either start with `0` or cast them '
+                  'as string column names: `df.columns = [str(i) for i in df.columns`.',
+                  apriori, dfs)

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -119,7 +119,8 @@ def test_sparsedataframe_notzero_column():
     dfs.columns = [i+1 for i in range(len(dfs.columns))]
     assert_raises(ValueError,
                   'Due to current limitations in Pandas, '
-                  'if the SparseDataFrame has integer column names, '
-                  'please make sure they either start with `0` or cast them '
-                  'as string column names: `df.columns = [str(i) for i in df.columns`.',
+                  'if the SparseDataFrame has integer column names,'
+                  'names, please make sure they either start '
+                  'with `0` or cast them as string column names: '
+                  '`df.columns = [str(i) for i in df.columns`].',
                   apriori, dfs)


### PR DESCRIPTION
### Description

Raises a more informative error if a `SparseDataFrame` is passed to `apriori` and the dataframe has integer column names that don't start with `0` due to current limitations of the `SparseDataFrame` implementation in pandas.



### Related issues or pull requests

Fixes #501 


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->