### PR TITLE
Fix unreadable labels in plot_confusion_matrix in case of imbalanced data and show_normed=True

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,7 +25,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- Fix unreable labels in `plot_confusion_matrix` for imbalanced datasets if `show_absolute=True` and `show_normed=True`.
+- Fix unreadable labels in `plot_confusion_matrix` for imbalanced datasets if `show_absolute=True` and `show_normed=True`. ([#504](https://github.com/rasbt/mlxtend/pull/504))
 
 - Raises a more informative error if a `SparseDataFrame` is passed to `apriori` and the dataframe has integer column names that don't start with `0` due to current limitations of the `SparseDataFrame` implementation in pandas. ([#503](https://github.com/rasbt/mlxtend/pull/503))
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,6 +25,8 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
+- Fix unreable labels in `plot_confusion_matrix` for imbalanced datasets if `show_absolute=True` and `show_normed=True`.
+
 - Raises a more informative error if a `SparseDataFrame` is passed to `apriori` and the dataframe has integer column names that don't start with `0` due to current limitations of the `SparseDataFrame` implementation in pandas. ([#503](https://github.com/rasbt/mlxtend/pull/503))
 
 ### Version 0.15.0 (01-19-2019)

--- a/mlxtend/plotting/plot_confusion_matrix.py
+++ b/mlxtend/plotting/plot_confusion_matrix.py
@@ -66,10 +66,10 @@ def plot_confusion_matrix(conf_mat,
     if figsize is None:
         figsize = (len(conf_mat)*1.25, len(conf_mat)*1.25)
 
-    if show_absolute:
-        matshow = ax.matshow(conf_mat, cmap=cmap)
-    else:
+    if show_normed:
         matshow = ax.matshow(normed_conf_mat, cmap=cmap)
+    else:
+        matshow = ax.matshow(conf_mat, cmap=cmap)
 
     if colorbar:
         fig.colorbar(matshow)


### PR DESCRIPTION
### Change
If show_normed is True, use the normed conf mat for *background* coloring instead of the absolute conf matrix, because *label* coloring (black/white) also follows normed conf matrix. This fixes unreadable labels that can occur with imbalanced datasets.

### Description

If arg `show_absolute=True` and `show_normed=True` the *background*-color is choosen by the absolute value, while the *label* color is chosen by the normed value. This can lead to unreadable labels for imbalanced dataset. 

Before / After:
![Example](https://stratus.picnico.de/apps/files_sharing/publicpreview/kqjCZD5QsJnm53H?x=1846&y=747&a=true&file=example.png&scalingup=0)

### Related issues or pull requests

n/a

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
