### PR TITLE
Use of safe_indexing in StackingCVClassifier

### DIFF
--- a/mlxtend/classifier/stacking_cv_classification.py
+++ b/mlxtend/classifier/stacking_cv_classification.py
@@ -354,7 +354,7 @@ class StackingCVClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
             Returns the meta-features for test data.
 
         """
-        check_is_fitted(self, 'clfs_')
+        check_is_fitted(self, ['clfs_', 'meta_clf_'])
 
         per_model_preds = []
 
@@ -381,7 +381,7 @@ class StackingCVClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         meta_features = self.predict_meta_features(X)
 
         if self.use_features_in_secondary:
-            self._stack_first_level_features(X, meta_features)
+            meta_features = self._stack_first_level_features(X, meta_features)
 
         return predict_fn(meta_features)
 
@@ -400,6 +400,8 @@ class StackingCVClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
             Predicted class labels.
 
         """
+        check_is_fitted(self, ['clfs_', 'meta_clf_'])
+
         return self._do_predict(X, self.meta_clf_.predict)
 
     def predict_proba(self, X):
@@ -417,4 +419,6 @@ class StackingCVClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
             Probability for each class per sample.
 
         """
+        check_is_fitted(self, ['clfs_', 'meta_clf_'])
+
         return self._do_predict(X, self.meta_clf_.predict_proba)

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -493,8 +493,8 @@ def test_sparse_inputs_with_features_in_secondary():
     stclf = StackingCVClassifier(classifiers=[rf, rf],
                                  meta_classifier=lr,
                                  use_features_in_secondary=True)
-    X_train, X_test, y_train,  y_test = train_test_split(X_breast, y_breast,
-                                                         test_size=0.3)
+    X_train, X_test, y_train, y_test = train_test_split(X_breast, y_breast,
+                                                        test_size=0.3)
 
     # dense
     stclf.fit(X_train, y_train)

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -329,39 +329,6 @@ def test_verbose():
     sclf.fit(X_iris, y_iris)
 
 
-def test_list_of_lists():
-    X_list = [i for i in X_iris]
-    meta = LogisticRegression(multi_class='ovr', solver='liblinear')
-    clf1 = RandomForestClassifier(n_estimators=10)
-    clf2 = GaussianNB()
-    sclf = StackingCVClassifier(classifiers=[clf1, clf2],
-                                use_probas=True,
-                                meta_classifier=meta,
-                                shuffle=False,
-                                verbose=0)
-
-    try:
-        sclf.fit(X_list, y_iris)
-    except TypeError as e:
-        assert 'are NumPy arrays. If X and y are lists' in str(e)
-
-
-def test_pandas():
-    X_df = pd.DataFrame(X_iris)
-    meta = LogisticRegression(multi_class='ovr', solver='liblinear')
-    clf1 = RandomForestClassifier(n_estimators=10)
-    clf2 = GaussianNB()
-    sclf = StackingCVClassifier(classifiers=[clf1, clf2],
-                                use_probas=True,
-                                meta_classifier=meta,
-                                shuffle=False,
-                                verbose=0)
-    try:
-        sclf.fit(X_df, y_iris)
-    except KeyError as e:
-        assert 'are NumPy arrays. If X and y are pandas DataFrames' in str(e)
-
-
 def test_get_params():
     clf1 = KNeighborsClassifier(n_neighbors=1)
     clf2 = RandomForestClassifier(random_state=1)

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -505,3 +505,41 @@ def test_sparse_inputs_with_features_in_secondary():
     stclf.fit(sparse.csr_matrix(X_train), y_train)
     assert round(stclf.score(X_train, y_train), 2) == 0.99, \
         round(stclf.score(X_train, y_train), 2)
+
+
+def test_works_with_df_if_fold_indexes_missing():
+    """This is a regression test to make sure fitting will still work even if
+    training data has ids that cannot be indexed using the indexes from the cv
+    (e.g. skf)
+
+    Some possibilities:
+    + Output of the folds are not neatly consecutive (i.e. [341, 345, 543, ...]
+      instead of [0, 1, ... n])
+    + Indexes just start from some number greater than the size of the input
+      (see test case)
+
+    Training data sometimes has ids that carry other information, and selection
+    of rows based on cv should not break.
+
+    This is fixed in the code using `safe_indexing`
+    """
+
+    np.random.seed(123)
+    rf = RandomForestClassifier(n_estimators=10)
+    lr = LogisticRegression(multi_class='ovr', solver='liblinear')
+    stclf = StackingCVClassifier(classifiers=[rf, rf],
+                                 meta_classifier=lr,
+                                 use_features_in_secondary=True)
+
+    X_modded = pd.DataFrame(X_breast,
+                            index=np.arange(X_breast.shape[0]) + 1000)
+    y_modded = pd.Series(y_breast,
+                         index=np.arange(y_breast.shape[0]) + 1000)
+
+    X_train, X_test, y_train, y_test = train_test_split(X_modded, y_modded,
+                                                        test_size=0.3)
+
+    # dense
+    stclf.fit(X_train, y_train)
+    assert round(stclf.score(X_train, y_train), 2) == 0.99, \
+        round(stclf.score(X_train, y_train), 2)


### PR DESCRIPTION
### Description

Updated `StackingCVClassifier` to use `safe_indexing` from `sklearn`.

Also did some refactoring: instead of iteratively concatenating the model predictions from each fold, I saved all the predictions in a list and concatenated them all at once. Not sure if the iterative concatenation was meant to save memory, but I thought it shouldn't really make a difference since the overhead of storing them all in a list should be quite small.

### Related issues or pull requests

None! Was using this for Kaggle and found that it was breaking on fitting, so I added this fix!

Did some refactoring while fixing the code

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `nosetests ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `nosetests ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
