### PR TITLE
Stacking dtype

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -28,7 +28,8 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- Now uses the latest joblib library under the hood for multiprocessing instead of `sklearn.externals.joblib` ([#547](https://github.com/rasbt/mlxtend/pull/547))
+- Now uses the latest joblib library under the hood for multiprocessing instead of `sklearn.externals.joblib`. ([#547](https://github.com/rasbt/mlxtend/pull/547))
+- Changes to `StackingCVClassifier` and `StackingCVRegressor` such that first-level models are allowed to generate output of non-numeric type. ([#562](https://github.com/rasbt/mlxtend/pull/562))
 
 
 ##### Bug Fixes

--- a/docs/sources/CONTRIBUTING.md
+++ b/docs/sources/CONTRIBUTING.md
@@ -16,9 +16,8 @@ and checking off items as you go.
 3. [ ]  Create and check out a new topic branch (please don't make modifications in the master branch)
 4. [ ]  Implement the new feature or apply the bug-fix  
 5. [ ]  Add appropriate unit test functions in `mlxtend/*/tests`
-6. [ ]  Run `nosetests ./mlxtend -sv` and make sure that all unit tests pass  
-7. [ ]  Check/improve the test coverage by running `nosetests ./mlxtend --with-coverage`
-8. [ ]  Check for style issues by running `flake8 ./mlxtend` (you may want to run `nosetests` again after you made modifications to the code)
+6. [ ]  Run `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass  
+7. [ ]  Check for style issues by running `flake8 ./mlxtend` (you may want to run `pytest` again after you made modifications to the code)
 8. [ ]  Add a note about the modification/contribution to the `./docs/sources/changelog.md` file  
 9. [ ]  Modify documentation in the appropriate location under `mlxtend/docs/sources/`  
 10. [ ]  Push the topic branch to the server and create a pull request
@@ -164,14 +163,9 @@ Now it's time to modify existing code or to contribute new code to the project.
 Add the respective unit tests and check if they pass:
 
 ```bash
-$ nosetests -sv
+$ PYTHONPATH='.' pytest ./mlxtend ---with-coverage
 ```
 
-Use the `--with-coverage` flag to ensure that all code is being covered in the unit tests:
-
-```bash
-$ nosetests --with-coverage
-```
 
 #### 5. Documenting changes
 

--- a/mlxtend/classifier/stacking_cv_classification.py
+++ b/mlxtend/classifier/stacking_cv_classification.py
@@ -208,7 +208,7 @@ class StackingCVClassifier(_BaseXComposition, ClassifierMixin,
             final_cv.random_state = self.random_state
 
         # Input validation.
-        X, y = check_X_y(X, y, accept_sparse=['csc', 'csr'])
+        X, y = check_X_y(X, y, accept_sparse=['csc', 'csr'], dtype=None)
 
         if sample_weight is None:
             fit_params = None

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -164,7 +164,7 @@ class StackingCVRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
             self.regr_ = self.regressors
             self.meta_regr_ = self.meta_regressor
 
-        X, y = check_X_y(X, y, accept_sparse=['csc', 'csr'])
+        X, y = check_X_y(X, y, accept_sparse=['csc', 'csr'], dtype=None)
 
         kfold = check_cv(self.cv, y)
         if isinstance(self.cv, int):


### PR DESCRIPTION
### Description

Changes to `StackingCVClassifier` and `StackingCVRegressor` such that first-level models are allowed to generate output of non-numeric type.



### Related issues or pull requests

Fixes #562 

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->