### PR TITLE
Constant number of eigenvalues

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -35,6 +35,7 @@ The CHANGELOG for the current development version is available at
 ##### Bug Fixes
 
 - Fixed documentation of `iris_data()` under `iris.py` by adding a note about differences in the iris data in R and UCI machine learning repo.
+- Make sure that if the `'svd'` mode is used in PCA, the number of eigenvalues is the same as when using `'eigen'` (append 0's zeros in that case) ([#565](https://github.com/rasbt/mlxtend/pull/565))
 
 ### Version 0.16.0 (05/12/2019)
 

--- a/mlxtend/feature_extraction/principal_component_analysis.py
+++ b/mlxtend/feature_extraction/principal_component_analysis.py
@@ -160,6 +160,10 @@ class PrincipalComponentAnalysis(_BaseModel):
             u, s, v = np.linalg.svd(mat_centered.T)
             e_vecs, e_vals = u, s
             e_vals = e_vals ** 2 / n_samples
+            if e_vals.shape[0] < e_vecs.shape[1]:
+                new_e_vals = np.zeros(e_vecs.shape[1])
+                new_e_vals[:e_vals.shape[0]] = e_vals
+                e_vals = new_e_vals
 
         sort_idx = np.argsort(e_vals)[::-1]
         e_vals, e_vecs = e_vals[sort_idx], e_vecs[:, sort_idx]


### PR DESCRIPTION
### Description

In some cases, the number of eigenvalues when using the `svd` mode in the PCA could be smaller than the number of eigenvalues when using the eigensolver. This is fixed now.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
