### PR TITLE
fix mnist iris mixup

### DIFF
--- a/docs/sources/user_guide/data/loadlocal_mnist.ipynb
+++ b/docs/sources/user_guide/data/loadlocal_mnist.ipynb
@@ -50,7 +50,7 @@
     "- Number of samples: 50000 images\n",
     "\n",
     "\n",
-    "- Target variable (discrete): {50x Setosa, 50x Versicolor, 50x Virginica}\n"
+    "- Target variable (discrete): Uniformly distributed class labels 0-9 corresponding to the respective handwritten digit shown in the image.\n"
    ]
   },
   {
@@ -302,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.1"
   },
   "toc": {
    "nav_menu": {},
@@ -318,5 +318,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/mlxtend/__init__.py
+++ b/mlxtend/__init__.py
@@ -4,4 +4,4 @@
 #
 # License: BSD 3 clause
 
-__version__ = '0.17.0'
+__version__ = '0.18.0dev0'


### PR DESCRIPTION
### Description

Typo fix in MNIST dataset docs.


### Related issues or pull requests

Fixes #571



### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->