### PR TITLE
Change dof in svd-mode PCA to n-1

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -28,7 +28,7 @@ The CHANGELOG for the current development version is available at
 - Behavior of `fpgrowth` and `apriori` consistent for edgecases such as `min_support=0`. ([#573](https://github.com/rasbt/mlxtend/pull/573) via [Steve Harenberg](https://github.com/harenbergsd))
 - `fpmax` returns an empty data frame now instead of raising an error if the frequent itemset set is empty. ([#573](https://github.com/rasbt/mlxtend/pull/573) via [Steve Harenberg](https://github.com/harenbergsd))
 - Fixes and issue in `mlxtend.plotting.plot_confusion_matrix`, where the font-color choice for medium-dark cells was not ideal and hard to read. [#588](https://github.com/rasbt/mlxtend/pull/588) via [sohrabtowfighi](https://github.com/sohrabtowfighi))
-
+- The `svd` mode of `mlxtend.feature_extraction.PrincipalComponentAnalysis` now also *n-1* degrees of freedom instead of *n* d.o.f. when computing the eigenvalues to match the behavior of `eigen`. [#595](https://github.com/rasbt/mlxtend/pull/595)
 
 
 

--- a/mlxtend/data/tests/test_iris.py
+++ b/mlxtend/data/tests/test_iris.py
@@ -33,4 +33,4 @@ def test_iris_data_r():
 def test_iris_invalid_choice():
     with pytest.raises(TypeError) as excinfo:
         iris_data()
-        assert excinfo.value.message == ('wrong-choice')
+        assert excinfo.value.message == "version must be 'uci' or 'corrected'."

--- a/mlxtend/data/tests/test_iris.py
+++ b/mlxtend/data/tests/test_iris.py
@@ -32,5 +32,5 @@ def test_iris_data_r():
 
 def test_iris_invalid_choice():
     with pytest.raises(TypeError) as excinfo:
-        iris_data()
+        iris_data(version='bla')
         assert excinfo.value.message == "version must be 'uci' or 'corrected'."

--- a/mlxtend/data/tests/test_iris.py
+++ b/mlxtend/data/tests/test_iris.py
@@ -31,6 +31,6 @@ def test_iris_data_r():
 
 
 def test_iris_invalid_choice():
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         iris_data(version='bla')
         assert excinfo.value.message == "version must be 'uci' or 'corrected'."

--- a/mlxtend/feature_extraction/principal_component_analysis.py
+++ b/mlxtend/feature_extraction/principal_component_analysis.py
@@ -159,7 +159,7 @@ class PrincipalComponentAnalysis(_BaseModel):
             mat_centered = mat - mat.mean(axis=0)
             u, s, v = np.linalg.svd(mat_centered.T)
             e_vecs, e_vals = u, s
-            e_vals = e_vals ** 2 / n_samples
+            e_vals = e_vals ** 2 / (n_samples-1)
             if e_vals.shape[0] < e_vecs.shape[1]:
                 new_e_vals = np.zeros(e_vecs.shape[1])
                 new_e_vals[:e_vals.shape[0]] = e_vals

--- a/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
+++ b/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
@@ -59,11 +59,13 @@ def test_evals():
 
     pca = PCA(n_components=2, solver='eigen')
     pca.fit(X_std)
-    assert_almost_equal(pca.e_vals_, [2.9, 0.9, 0.2, 0.02], decimal=1)
+
+    expected = [2.93035378, 0.92740362, 0.14834223, 0.02074601]
+    assert_almost_equal(pca.e_vals_, expected, decimal=5)
 
     pca = PCA(n_components=2, solver='svd')
     pca.fit(X_std)
-    assert_almost_equal(pca.e_vals_, [2.9, 0.9, 0.2, 0.02], decimal=1)
+    assert_almost_equal(pca.e_vals_, expected, decimal=5)
 
 
 def test_loadings():


### PR DESCRIPTION
### Description

The `svd` mode of `mlxtend.feature_extraction.PrincipalComponentAnalysis` now also *n-1* degrees of freedom instead of *n* d.o.f. when computing the eigenvalues to match the behavior of `eigen`.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->



### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`




<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
