### PR TITLE
Disable input checking in StackingCVClassifier to support pipelines

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -29,7 +29,7 @@ The CHANGELOG for the current development version is available at
 - `fpmax` returns an empty data frame now instead of raising an error if the frequent itemset set is empty. ([#573](https://github.com/rasbt/mlxtend/pull/573) via [Steve Harenberg](https://github.com/harenbergsd))
 - Fixes and issue in `mlxtend.plotting.plot_confusion_matrix`, where the font-color choice for medium-dark cells was not ideal and hard to read. [#588](https://github.com/rasbt/mlxtend/pull/588) via [sohrabtowfighi](https://github.com/sohrabtowfighi))
 - The `svd` mode of `mlxtend.feature_extraction.PrincipalComponentAnalysis` now also *n-1* degrees of freedom instead of *n* d.o.f. when computing the eigenvalues to match the behavior of `eigen`. [#595](https://github.com/rasbt/mlxtend/pull/595)
-
+- Disable input validation for `StackingCVClassifier` because it causes issues if pipelines are used as input. [#606](https://github.com/rasbt/mlxtend/pull/606)
 
 
 

--- a/mlxtend/classifier/stacking_cv_classification.py
+++ b/mlxtend/classifier/stacking_cv_classification.py
@@ -19,7 +19,7 @@ from sklearn.base import TransformerMixin
 from sklearn.base import clone
 from sklearn.model_selection import cross_val_predict
 from sklearn.model_selection._split import check_cv
-from sklearn.utils import check_X_y
+# from sklearn.utils import check_X_y
 
 
 class StackingCVClassifier(_BaseXComposition, ClassifierMixin,
@@ -207,8 +207,11 @@ class StackingCVClassifier(_BaseXComposition, ClassifierMixin,
             final_cv.shuffle = self.shuffle
             final_cv.random_state = self.random_state
 
-        # Input validation.
-        X, y = check_X_y(X, y, accept_sparse=['csc', 'csr'], dtype=None)
+        # Disable global input validation, because it causes issue when
+        # pipelines are used that perform preprocessing on X. I.e., X may
+        # not be directly passed to the classifiers, which is why this code
+        # would raise unecessary errors at this point.
+        # X, y = check_X_y(X, y, accept_sparse=['csc', 'csr'], dtype=None)
 
         if sample_weight is None:
             fit_params = None


### PR DESCRIPTION
### Description

Disables input validation for `StackingCVClassifier` because it causes issues if pipelines are used as input.

### Related issues or pull requests

Fixes #605 

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
