### PR TITLE
rename "per-class accuracy" to "average per-class accuracy"

### DIFF
--- a/docs/sources/user_guide/evaluate/scoring.ipynb
+++ b/docs/sources/user_guide/evaluate/scoring.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -264,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -292,9 +290,9 @@
       "    Performance metric:\n",
       "    'accuracy': (TP + TN)/(FP + FN + TP + TN) = 1-ERR\n",
       "\n",
-      "    'per-class accuracy': Average per-class accuracy\n",
+      "    'average per-class accuracy': Average per-class accuracy\n",
       "\n",
-      "    'per-class error':  Average per-class error\n",
+      "    'average per-class error':  Average per-class error\n",
       "\n",
       "    'error': (TP + TN)/(FP+ FN + TP + TN) = 1-ACC\n",
       "\n",
@@ -369,7 +367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.1"
   },
   "toc": {
    "nav_menu": {},
@@ -385,5 +383,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/mlxtend/evaluate/scoring.py
+++ b/mlxtend/evaluate/scoring.py
@@ -39,8 +39,8 @@ def scoring(y_target, y_predicted, metric='error',
     metric : str (default: 'error')
         Performance metric:
         'accuracy': (TP + TN)/(FP + FN + TP + TN) = 1-ERR\n
-        'per-class accuracy': Average per-class accuracy\n
-        'per-class error':  Average per-class error\n
+        'average per-class accuracy': Average per-class accuracy\n
+        'average per-class error':  Average per-class error\n
         'error': (TP + TN)/(FP+ FN + TP + TN) = 1-ACC\n
         'false_positive_rate': FP/N = FP/(FP + TN)\n
         'true_positive_rate': TP/P = TP/(FN + TP)\n
@@ -74,8 +74,8 @@ def scoring(y_target, y_predicted, metric='error',
     """
     implemented = {'error',
                    'accuracy',
-                   'per-class accuracy',
-                   'per-class error',
+                   'average per-class accuracy',
+                   'average per-class error',
                    'false_positive_rate',
                    'true_positive_rate',
                    'true_negative_rate',
@@ -110,12 +110,12 @@ def scoring(y_target, y_predicted, metric='error',
         res = _accuracy(targ_tmp, pred_tmp)
     elif metric == 'error':
         res = _error(targ_tmp, pred_tmp)
-    elif metric == 'per-class accuracy':
+    elif metric == 'average per-class accuracy':
         res = _macro(targ_tmp,
                      pred_tmp,
                      func=_accuracy,
                      unique_labels=unique_labels)
-    elif metric == 'per-class error':
+    elif metric == 'average per-class error':
         res = _macro(targ_tmp,
                      pred_tmp,
                      func=_error,

--- a/mlxtend/evaluate/tests/test_scoring.py
+++ b/mlxtend/evaluate/tests/test_scoring.py
@@ -120,7 +120,7 @@ def test_avg_perclass_accuracy():
     y_pred = np.array([0, 1, 1, 0, 1, 1, 2, 2, 2, 2])
     res = scoring(y_target=y_targ,
                   y_predicted=y_pred,
-                  metric='per-class accuracy')
+                  metric='average per-class accuracy')
     assert round(res, 3) == 0.667, res
 
 
@@ -129,5 +129,5 @@ def test_avg_perclass_error():
     y_pred = np.array([0, 1, 1, 0, 1, 1, 2, 2, 2, 2])
     res = scoring(y_target=y_targ,
                   y_predicted=y_pred,
-                  metric='per-class error')
+                  metric='average per-class error')
     assert round(res, 3) == 0.333, res


### PR DESCRIPTION
### Description

- Changed `'per-class accuracy'` and `'per-class error'` to `average 'per-class accuracy'` and `average 'per-class error'`, respectively, to improve clarity.
### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->

Fixes #616 

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
