### PR TITLE
Improve performance of apriori

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -21,7 +21,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- -
+- Improve the runtime performance for the `apriori` frequent itemset generating function when `low_memory=True`. Setting `low_memory=False` (default) is still faster for small itemsets, but `low_memory=True` can be much faster for large itemsets and requires less memory.  Also, input validation for  `apriori`, ̀ fpgrowth` and `fpmax` takes a significant amount of time when input pandas DataFrame is large; this is now dramatically reduced when input contains boolean values (and not zeros/ones), which is the case when using `TransactionEncoder`. ([#619](https://github.com/rasbt/mlxtend/pull/619) via [Denis Barbier](https://github.com/dbarbier))
 
 ##### Bug Fixes
 - Fixes a bug in `mlxtend.plotting.plot_pca_correlation_graph` that caused the explaind variances not summing up to 1. Also, improves the runtime performance of the correlation computation and adds a missing function argument for the explained variances (eigenvalues) if users provide their own principal components. ([#593](https://github.com/rasbt/mlxtend/issues/593) via [Gabriel Azevedo Ferreira](https://github.com/Gabriel-Azevedo-Ferreira))

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -44,11 +44,11 @@ def generate_new_combinations(old_combinations):
 
     items_types_in_previous_step = np.unique(old_combinations.flatten())
     for old_combination in old_combinations:
-        max_combination = max(old_combination)
-        for item in items_types_in_previous_step:
-            if item > max_combination:
-                res = tuple(old_combination) + (item,)
-                yield res
+        max_combination = old_combination[-1]
+        valid_items = items_types_in_previous_step[items_types_in_previous_step > max_combination]
+        old_tuple = tuple(old_combination)
+        for item in valid_items:
+            yield old_tuple + (item,)
 
 
 def apriori(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0,

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import pandas as pd
+from ..frequent_patterns import fpcommon as fpc
 
 
 def generate_new_combinations(old_combinations):
@@ -227,21 +228,10 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0,
                          'number within the interval `(0, 1]`. '
                          'Got %s.' % min_support)
 
-    idxs = np.where((df.values != 1) & (df.values != 0))
-    if len(idxs[0]) > 0:
-        val = df.values[idxs[0][0], idxs[1][0]]
-        s = ('The allowed values for a DataFrame'
-             ' are True, False, 0, 1. Found value %s' % (val))
-        raise ValueError(s)
+    fpc.valid_input_check(df)
 
     is_sparse = hasattr(df, "to_coo")
     if is_sparse:
-        if not isinstance(df.columns[0], str) and df.columns[0] != 0:
-            raise ValueError('Due to current limitations in Pandas, '
-                             'if the SparseDataFrame has integer column names,'
-                             'names, please make sure they either start '
-                             'with `0` or cast them as string column names: '
-                             '`df.columns = [str(i) for i in df.columns`].')
         X = df.to_coo().tocsc()
     else:
         X = df.values

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -76,14 +76,14 @@ def generate_new_combinations_low_memory(old_combinations, X, min_support,
       For example,
 
     ```
-        0      1     0     1     1     0     1
-        1      1     0     1     0     0     1
-        2      1     0     1     0     0     0
-        3      1     1     0     0     0     0
-        4      0     0     1     1     1     1
-        5      0     0     1     0     1     1
-        6      0     0     1     0     1     0
-        7      1     1     0     0     0     0
+        0     True False  True  True False  True
+        1     True False  True False False  True
+        2     True False  True False False False
+        3     True  True False False False False
+        4    False False  True  True  True  True
+        5    False False  True False  True  True
+        6    False False  True False  True False
+        7     True  True False False False False
     ```
 
     min_support : float (default: 0.5)
@@ -143,15 +143,15 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0,
       For example,
 
     ```
-             Apple  Bananas  Beer  Chicken  Milk  Rice
-        0      1        0     1        1     0     1
-        1      1        0     1        0     0     1
-        2      1        0     1        0     0     0
-        3      1        1     0        0     0     0
-        4      0        0     1        1     1     1
-        5      0        0     1        0     1     1
-        6      0        0     1        0     1     0
-        7      1        1     0        0     0     0
+             Apple  Bananas   Beer  Chicken   Milk   Rice
+        0     True    False   True     True  False   True
+        1     True    False   True    False  False   True
+        2     True    False   True    False  False  False
+        3     True     True  False    False  False  False
+        4    False    False   True     True   True   True
+        5    False    False   True    False   True   True
+        6    False    False   True    False   True  False
+        7     True     True  False    False  False  False
     ```
 
     min_support : float (default: 0.5)

--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -30,10 +30,7 @@ def generate_new_combinations(old_combinations):
     Returns
     -----------
     Generator of all combinations from the last step x items
-    from the previous step. Every combination is a tuple
-    of item type ids in the ascending order.
-    No combination other than generated
-    do not have a chance to get enough support
+    from the previous step.
 
     Examples
     -----------
@@ -48,7 +45,8 @@ def generate_new_combinations(old_combinations):
         valid_items = items_types_in_previous_step[items_types_in_previous_step > max_combination]
         old_tuple = tuple(old_combination)
         for item in valid_items:
-            yield old_tuple + (item,)
+            yield from old_tuple
+            yield item
 
 
 def apriori(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0,
@@ -189,7 +187,7 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0,
             frequent_items_support = []
             if is_sparse:
                 all_ones = np.ones((X.shape[0], next_max_itemset))
-            for c in combin:
+            for c in zip(*[iter(combin)] * next_max_itemset):
                 if verbose:
                     iter_count += 1
                     print('\rIteration: %d | Sampling itemset size %d' %
@@ -211,7 +209,8 @@ def apriori(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0,
             else:
                 break
         else:
-            combin = np.array(list(combin))
+            combin = generate_new_combinations(itemset_dict[max_itemset])
+            combin = np.fromiter(combin, dtype=int).reshape(-1, next_max_itemset)
 
             if combin.size == 0:
                 break

--- a/mlxtend/frequent_patterns/fpcommon.py
+++ b/mlxtend/frequent_patterns/fpcommon.py
@@ -48,13 +48,15 @@ def generate_itemsets(generator, num_itemsets, colname_map):
 
 
 def valid_input_check(df):
-    # Pandas is much slower than numpy, so use df.values instead of df here
-    idxs = np.where((df.values != 1) & (df.values != 0))
-    if len(idxs[0]) > 0:
-        val = df.values[idxs[0][0], idxs[1][0]]
-        s = ('The allowed values for a DataFrame'
-             ' are True, False, 0, 1. Found value %s' % (val))
-        raise ValueError(s)
+    # Fast path: if all columns are boolean, there is nothing to check
+    if not (df.dtypes == bool).all():
+        # Pandas is much slower than numpy, so use df.values instead of df here
+        idxs = np.where((df.values != 1) & (df.values != 0))
+        if len(idxs[0]) > 0:
+            val = df.values[idxs[0][0], idxs[1][0]]
+            s = ('The allowed values for a DataFrame'
+                 ' are True, False, 0, 1. Found value %s' % (val))
+            raise ValueError(s)
 
     is_sparse = hasattr(df, "to_coo")
     if is_sparse:

--- a/mlxtend/frequent_patterns/fpgrowth.py
+++ b/mlxtend/frequent_patterns/fpgrowth.py
@@ -19,15 +19,15 @@ def fpgrowth(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0):
       For example,
 
     ```
-             Apple  Bananas  Beer  Chicken  Milk  Rice
-        0      1        0     1        1     0     1
-        1      1        0     1        0     0     1
-        2      1        0     1        0     0     0
-        3      1        1     0        0     0     0
-        4      0        0     1        1     1     1
-        5      0        0     1        0     1     1
-        6      0        0     1        0     1     0
-        7      1        1     0        0     0     0
+           Apple  Bananas   Beer  Chicken   Milk   Rice
+        0   True    False   True     True  False   True
+        1   True    False   True    False  False   True
+        2   True    False   True    False  False  False
+        3   True     True  False    False  False  False
+        4  False    False   True     True   True   True
+        5  False    False   True    False   True   True
+        6  False    False   True    False   True  False
+        7   True     True  False    False  False  False
     ```
 
     min_support : float (default: 0.5)

--- a/mlxtend/frequent_patterns/fpmax.py
+++ b/mlxtend/frequent_patterns/fpmax.py
@@ -19,15 +19,15 @@ def fpmax(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0):
       For example,
 
     ```
-             Apple  Bananas  Beer  Chicken  Milk  Rice
-        0      1        0     1        1     0     1
-        1      1        0     1        0     0     1
-        2      1        0     1        0     0     0
-        3      1        1     0        0     0     0
-        4      0        0     1        1     1     1
-        5      0        0     1        0     1     1
-        6      0        0     1        0     1     0
-        7      1        1     0        0     0     0
+           Apple  Bananas   Beer  Chicken   Milk   Rice
+        0   True    False   True     True  False   True
+        1   True    False   True    False  False   True
+        2   True    False   True    False  False  False
+        3   True     True  False    False  False  False
+        4  False    False   True     True   True   True
+        5  False    False   True    False   True   True
+        6  False    False   True    False   True  False
+        7   True     True  False    False  False  False
     ```
 
     min_support : float (default: 0.5)

--- a/mlxtend/frequent_patterns/tests/test_fpbase.py
+++ b/mlxtend/frequent_patterns/tests/test_fpbase.py
@@ -187,7 +187,7 @@ class FPTestEx1All(FPTestEx1):
                 _ = self.fpalgo(self.df, low_memory=True, verbose=1)
 
             # Only get the last value of the stream to reduce test noise
-            expect = 'Processing 4 valid combinations | Sampling itemset size 3\n'
+            expect = 'Processing 4 combinations | Sampling itemset size 3\n'
             out = out.getvalue().split('\r')[-1]
             assert out == expect
         else:

--- a/mlxtend/frequent_patterns/tests/test_fpbase.py
+++ b/mlxtend/frequent_patterns/tests/test_fpbase.py
@@ -187,7 +187,7 @@ class FPTestEx1All(FPTestEx1):
                 _ = self.fpalgo(self.df, low_memory=True, verbose=1)
 
             # Only get the last value of the stream to reduce test noise
-            expect = 'Iteration: 17 | Sampling itemset size 3\n'
+            expect = 'Processing 4 valid combinations | Sampling itemset size 3\n'
             out = out.getvalue().split('\r')[-1]
             assert out == expect
         else:


### PR DESCRIPTION
### Description

This PR improves performance of apriori for medium to large datasets, in particular with low_memory=True.  Situation is less clear for very small datasets.

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [X] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [X] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
