### PR TITLE
Add fixed dlib, imageio, scikit-image versions to travis

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,8 @@ build: false
 
 environment:
   matrix:
-    - PYTHON_VERSION: 3.8
-      MINICONDA: C:/Miniconda36-x64
+    - PYTHON_VERSION: 3.7
+      MINICONDA: C:/Miniconda37-x64
 init:
   - ECHO %PYTHON_VERSION% %MINICONDA%
   - ECHO conda --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn pandas joblib pytest
   - activate test-environment
-  - conda install -c conda-forge dlib=19.4
+  - conda install -c conda-forge dlib=19.17
   - pip install imageio
   - pip install scikit-image
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn pandas joblib pytest
   - activate test-environment
-  - pip install dlib
+  - conda install -c conda-forge dlib=19.4
   - pip install imageio
   - pip install scikit-image
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - os: linux
           sudo: required
           python: 3.8
-          env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.16.2" SCIPY_VERSION="1.2.1" SKLEARN_VERSION="0.20.3" JOBLIB_VERSION=0.13.1 PANDAS_VERSION="0.24.2"  MINICONDA_PYTHON_VERSION=3.7
+          env: LATEST="false" IMAGE="true" COVERAGE="false" NUMPY_VERSION="1.16.2" SCIPY_VERSION="1.2.1" SKLEARN_VERSION="0.20.3" JOBLIB_VERSION=0.13.1 PANDAS_VERSION="0.24.2" IMAGEIO_VERSION="2.5.0" SKIMAGE_VERSION="0.15.0" DLIB_VERSION="19.17.0" MINICONDA_PYTHON_VERSION=3.7
         - os: linux
           python: 3.8
           env: LATEST="true" IMAGE="true" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -52,6 +52,7 @@ if [ "${IMAGE}" = "true" ]; then
         pip install dlib=="$DLIB_VERSION"
         pip install imageio=="$IMAGEIO_VERSION"
         pip install scikit-image=="$DLIB_VERSION"
+    fi
 fi
 
 if [ "${COVERAGE}" = "true" ]; then

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -51,7 +51,7 @@ if [ "${IMAGE}" = "true" ]; then
     else
         pip install dlib=="$DLIB_VERSION"
         pip install imageio=="$IMAGEIO_VERSION"
-        pip install scikit-image=="$DLIB_VERSION"
+        pip install scikit-image=="$SKIMAGE_VERSION"
     fi
 fi
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -43,9 +43,15 @@ conda install pytest
 
 
 if [ "${IMAGE}" = "true" ]; then
-    pip install dlib
-    pip install imageio
-    pip install scikit-image
+
+    if [ "${LATEST}" = "true" ]; then
+        pip install dlib
+        pip install imageio
+        pip install scikit-image
+    else
+        pip install dlib=="$DLIB_VERSION"
+        pip install imageio=="$IMAGEIO_VERSION"
+        pip install scikit-image=="$DLIB_VERSION"
 fi
 
 if [ "${COVERAGE}" = "true" ]; then


### PR DESCRIPTION
### Description

Fixes versions of dlib, imageio, scikit-image  for some tests in travis.

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request here. E.g.,   
Fixes #366
-->

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
