### PR TITLE
Set cv_score to `-np.inf` if OLS fit fails

### DIFF
--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -32,7 +32,8 @@ def _calc_score(selector, X, y, indices, groups=None, **fit_params):
                                  scoring=selector.scorer,
                                  n_jobs=1,
                                  pre_dispatch=selector.pre_dispatch,
-                                 fit_params=fit_params)
+                                 fit_params=fit_params,
+                                 error_score=-np.inf)
     else:
         selector.est_.fit(X[:, indices], y, **fit_params)
         scores = np.array([selector.scorer(selector.est_, X[:, indices], y)])


### PR DESCRIPTION
### Description
This PR will automatically set the cross-validation score of an ordinary least-squares fit to `-np.inf` whenever the fit fails during sequential feature selection.
This ensures that whenever a least-squares fit fails, it does not fail the entire regression process, but simply goes to the next one (after all, if a fit fails, it simply means that that fit is terrible and should never be used, not that no fit ever will work).

Also, I made the modification in `master`, simply because it is a one-liner and I will be deleting the fork anyways afterward.
I can add the change to the `CHANGELOG` is required of course.

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`
