### PR TITLE
fixed_features for ExhaustiveFeatureSelector #579

### DIFF
--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -115,6 +115,15 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         if False. Set to False if the estimator doesn't
         implement scikit-learn's set_params and get_params methods.
         In addition, it is required to set cv=0, and n_jobs=1.
+    fixed_features : tuple (default: None)
+        If not `None`, the feature indices provided as a tuple will be
+        regarded as fixed by the feature selector. For example, if
+        `fixed_features=(1, 3, 7)`, the 2nd, 4th, and 8th feature are
+        guaranteed to be present in the solution. Note that if
+        `fixed_features` is not `None`, make sure that the number of
+        features to be selected is greater than `min_features` and smaller
+        than 'max_features'.
+
 
     Attributes
     ----------
@@ -153,7 +162,8 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
                  print_progress=True, scoring='accuracy',
                  cv=5, n_jobs=1,
                  pre_dispatch='2*n_jobs',
-                 clone_estimator=True):
+                 clone_estimator=True,
+                 fixed_features=None):
         self.estimator = estimator
         self.min_features = min_features
         self.max_features = max_features
@@ -175,6 +185,45 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
 
         # don't mess with this unless testing
         self._TESTING_INTERRUPT_MODE = False
+
+        if fixed_features is not None:
+            if isinstance(self.min_features, int) and \
+                    self.min_features <= len(fixed_features):
+                raise ValueError('Number of features to be selected must'
+                                 ' be larger than the number of'
+                                 ' features specified via `fixed_features`.'
+                                 ' Got `min_features=%d` and'
+                                 ' `fixed_features=%d`' %
+                                 (min_features, len(fixed_features)))
+            elif isinstance(self.max_features, int) and \
+                    self.max_features >= len(fixed_features):
+                raise ValueError('The number of features to'
+                                 ' be selected must'
+                                 ' be smaller than the number of'
+                                 ' features specified via `fixed_features`.'
+                                 ' Got `max_features=%s` and '
+                                 '`len(fixed_features)=%d`' %
+                                 (max_features, len(fixed_features)))
+            elif isinstance(self.min_features, tuple) and \
+                    self.min_features[0] <= len(fixed_features):
+                raise ValueError('The minimum number of features to'
+                                 ' be selected must'
+                                 ' be larger than the number of'
+                                 ' features specified via `fixed_features`.'
+                                 ' Got `min_features=%s` and '
+                                 '`len(fixed_features)=%d`' %
+                                 (min_features, len(fixed_features)))
+            elif isinstance(self.max_features, tuple) and \
+                    self.max_features[0] >= len(fixed_features):
+                raise ValueError('The maximum number of features to'
+                                 ' be selected must'
+                                 ' be smaller than the number of'
+                                 ' features specified via `fixed_features`.'
+                                 ' Got `max_features=%s` and '
+                                 '`len(fixed_features)=%d`' %
+                                 (max_features, len(fixed_features)))
+
+        self.fixed_features = fixed_features
 
     def fit(self, X, y, custom_feature_names=None, groups=None, **fit_params):
         """Perform feature selection and learn model from training data.
@@ -212,10 +261,21 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         self.best_feature_names_ = None
         self.best_score_ = None
 
+        self.fixed_features = self.fixed_features
+        self.fixed_features_set_ = set()
+
         if hasattr(X, 'loc'):
             X_ = X.values
+            if self.fixed_features is not None:
+                self.fixed_features_ = tuple(X.columns.get_loc(c)
+                                             if isinstance(c, str) else c
+                                             for c in self.fixed_features
+                                             )
         else:
             X_ = X
+
+        if self.fixed_features is not None:
+            self.fixed_features_set_ = set(self.fixed_features_)
 
         if (custom_feature_names is not None
                 and len(custom_feature_names) != X.shape[1]):
@@ -273,7 +333,9 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         parallel = Parallel(n_jobs=n_jobs, pre_dispatch=self.pre_dispatch)
         work = enumerate(parallel(delayed(_calc_score)
                                   (self, X_, y, c, groups=groups, **fit_params)
-                                  for c in candidates))
+                                  for c in candidates)
+                                  if not fixed_feature or
+                                  fixed_feature.issubset(set(c)))
 
         try:
             for iteration, (c, cv_scores) in work:


### PR DESCRIPTION
add fixed_features

### Description

<!--  
Adds a new fixed_features parameter to Exhaustive Feature Selection for features to be forced to be included in the results.
-->

### Related issues or pull requests

<!--  #579  
Fixes #579 
https://github.com/rasbt/mlxtend/issues/579
-->

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
