### PR TITLE
Make loadlocal_mnist docs compatible with windows

### DIFF
--- a/docs/sources/user_guide/data/loadlocal_mnist.ipynb
+++ b/docs/sources/user_guide/data/loadlocal_mnist.ipynb
@@ -101,29 +101,34 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mlxtend.data import loadlocal_mnist\n",
+    "import platform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not platform.system() == 'Windows':\n",
+    "    X, y = loadlocal_mnist(\n",
+    "            images_path='train-images-idx3-ubyte', \n",
+    "            labels_path='train-labels-idx1-ubyte')\n",
+    "\n",
+    "else:\n",
+    "    X, y = loadlocal_mnist(\n",
+    "            images_path='train-images.idx3-ubyte', \n",
+    "            labels_path='train-labels.idx1-ubyte')"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from mlxtend.data import loadlocal_mnist"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "\n",
-    "X, y = loadlocal_mnist(\n",
-    "        images_path='/Users/Sebastian/Desktop/train-images-idx3-ubyte', \n",
-    "        labels_path='/Users/Sebastian/Desktop/train-labels-idx1-ubyte')\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -186,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -216,15 +221,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "np.savetxt(fname='/Users/Sebastian/Desktop/images.csv', \n",
+    "np.savetxt(fname='images.csv', \n",
     "           X=X, delimiter=',', fmt='%d')\n",
-    "np.savetxt(fname='/Users/Sebastian/Desktop/labels.csv', \n",
+    "np.savetxt(fname='labels.csv', \n",
     "           X=y, delimiter=',', fmt='%d')"
    ]
   },
@@ -237,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -318,5 +321,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Adds a small modification that considers the different file naming scheme after unzipping on Windows.