### PR TITLE
Use raw strings in regex

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,6 +24,7 @@ The CHANGELOG for the current development version is available at
 ##### Changes
 
 - Implemented both `use_clones` and `fit_base_estimators` (previously `refit` in `EnsembleVoteClassifier`) for `EnsembleVoteClassifier` and `StackingClassifier`. ([#670](https://github.com/rasbt/mlxtend/pull/670) via [Katrina Ni](https://github.com/nilichen))
+- Switched to using raw strings for regex in `mlxtend.text` to prevent deprecation warning in Python 3.8 ([#688](https://github.com/rasbt/mlxtend/pull/688))
 
 ##### Bug Fixes
 

--- a/mlxtend/text/names.py
+++ b/mlxtend/text/names.py
@@ -83,7 +83,7 @@ def generalize_names(name, output_sep=' ', firstname_output_letters=1):
                    if x in string.ascii_letters + ' ')
 
     # get first and last name if applicable
-    m = re.match('(?P<first>\w+)\W+(?P<last>\w+)', name)
+    m = re.match(r'(?P<first>\w+)\W+(?P<last>\w+)', name)
     if m:
         output = '%s%s%s' % (m.group(last),
                              output_sep,

--- a/mlxtend/text/tokenizer.py
+++ b/mlxtend/text/tokenizer.py
@@ -21,9 +21,9 @@ def tokenizer_words_and_emoticons(text):
     http://rasbt.github.io/mlxtend/user_guide/text/tokenizer_words_and_emoticons/
 
     """
-    text = re.sub('<[^>]*>', '', text)
-    emoticons = re.findall('(?::|;|=)(?:-)?(?:\)|\(|D|P)', text)
-    text = re.sub('[\W]+', ' ', text.lower()) + ' '.join(emoticons)
+    text = re.sub(r'<[^>]*>', '', text)
+    emoticons = re.findall(r'(?::|;|=)(?:-)?(?:\)|\(|D|P)', text)
+    text = re.sub(r'[\W]+', ' ', text.lower()) + ' '.join(emoticons)
     return text.split()
 
 
@@ -39,6 +39,6 @@ def tokenizer_emoticons(text):
     http://rasbt.github.io/mlxtend/user_guide/text/tokenizer_emoticons/
 
     """
-    text = re.sub('<[^>]*>', '', text)
-    emoticons = re.findall('(?::|;|=)(?:-)?(?:\)|\(|D|P)', text)
+    text = re.sub(r'<[^>]*>', '', text)
+    emoticons = re.findall(r'(?::|;|=)(?:-)?(?:\)|\(|D|P)', text)
     return emoticons


### PR DESCRIPTION
### Description

Switched to using raw strings for regex in `mlxtend.text` to prevent deprecation warning in Python 3.8

### Related issues or pull requests

Fixes #681


### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
