### PR TITLE
Fix for bug 690, where fpmax returned incorrect support values

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -30,6 +30,7 @@ The CHANGELOG for the current development version is available at
 
 - Fixes axis DeprecationWarning in matplotlib v3.1.0 and newer. ([#673](https://github.com/rasbt/mlxtend/pull/673))
 - Fixes an issue with using `meshgrid` in `no_information_rate` function used by the `bootstrap_point632_score` function for the .632+ estimate. ([#688](https://github.com/rasbt/mlxtend/pull/688))
+- Fixes an issue in `fpmax` that could lead to incorrect support values. ([#692](https://github.com/rasbt/mlxtend/pull/692) via [Steve Harenberg](https://github.com/harenbergsd))
 
 ### Version 0.17.2 (02-24-2020)
 

--- a/mlxtend/frequent_patterns/fpmax.py
+++ b/mlxtend/frequent_patterns/fpmax.py
@@ -100,6 +100,8 @@ def fpmax_step(tree, minsup, mfit, colnames, max_len, verbose):
             mfit.insert_itemset(largest_set)
             if max_len is None or len(largest_set) <= max_len:
                 support = tree.root.count
+                if len(items) > 0:
+                    support = min([tree.nodes[i][0].count for i in items])
                 yield support, largest_set
 
     if verbose:

--- a/mlxtend/frequent_patterns/tests/test_fpmax.py
+++ b/mlxtend/frequent_patterns/tests/test_fpmax.py
@@ -74,3 +74,18 @@ class TestEx2(unittest.TestCase, FPTestEx2):
 class TestEx3(unittest.TestCase, FPTestEx3All):
     def setUp(self):
         FPTestEx3All.setUp(self, fpmax)
+
+
+class TestEx4(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame(
+            [[1, 1, 0], [1, 0, 1], [0, 0, 1]], columns=['a', 'b', 'c'])
+        self.fpalgo = fpmax
+
+    def test_output(self):
+        res_df = self.fpalgo(self.df, min_support=0.01, use_colnames=True)
+        expect = pd.DataFrame([[0.3333333333333333, frozenset(['a', 'b'])],
+                               [0.3333333333333333, frozenset(['a', 'c'])]],
+                              columns=['support', 'itemsets'])
+
+        compare_dataframes(res_df, expect)


### PR DESCRIPTION
### Description

Fixes #690 

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
