### PR TITLE
Use chain.from_iterable in exhaustive_feature_selector.py

### DIFF
--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -239,7 +239,7 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
             raise AttributeError('min_features must be <= max_features')
 
         candidates = chain.from_iterable(
-            combinations(range(X_.shape[1]), r=i) for i in 
+            combinations(range(X_.shape[1]), r=i) for i in
             range(self.min_features, self.max_features + 1)
         )
 

--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -238,9 +238,10 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         if self.max_features < self.min_features:
             raise AttributeError('min_features must be <= max_features')
 
-        candidates = chain(*((combinations(range(X_.shape[1]), r=i))
-                           for i in range(self.min_features,
-                                          self.max_features + 1)))
+        candidates = chain.from_iterable(
+            combinations(range(X_.shape[1]), r=i) for i in 
+            range(self.min_features, self.max_features + 1)
+        )
 
         def ncr(n, r):
             """Return the number of combinations of length r from n items.


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.