### PR TITLE
Forward slection reduce mem copy

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,6 +25,7 @@ The CHANGELOG for the current development version is available at
 
 - Implemented both `use_clones` and `fit_base_estimators` (previously `refit` in `EnsembleVoteClassifier`) for `EnsembleVoteClassifier` and `StackingClassifier`. ([#670](https://github.com/rasbt/mlxtend/pull/670) via [Katrina Ni](https://github.com/nilichen))
 - Switched to using raw strings for regex in `mlxtend.text` to prevent deprecation warning in Python 3.8 ([#688](https://github.com/rasbt/mlxtend/pull/688))
+- Slice data in sequential forward selection before sending to parallel backend, reducing memory consumption.
 
 ##### Bug Fixes
 

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -398,7 +398,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
             if self.fixed_features is not None:
                 k_idx = self.fixed_features_
                 k = len(k_idx)
-                k_idx, k_score = _calc_score(self, X[:, k_idx], y, k_idx,
+                k_idx, k_score = _calc_score(self, X_[:, k_idx], y, k_idx,
                                              groups=groups, **fit_params)
                 self.subsets_[k] = {
                     'feature_idx': k_idx,
@@ -414,7 +414,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
                 k_to_select = min_k
             k_idx = tuple(orig_set)
             k = len(k_idx)
-            k_idx, k_score = _calc_score(self, X[:, k_idx], y, k_idx,
+            k_idx, k_score = _calc_score(self, X_[:, k_idx], y, k_idx,
                                          groups=groups, **fit_params)
             self.subsets_[k] = {
                 'feature_idx': k_idx,


### PR DESCRIPTION
### Description

Implements slicing the features from the data before copying it to the subprocess.

### Related issues or pull requests

Fixes #704

### Pull Request Checklist

- [x ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x ] Checked for style issues by running `flake8 ./mlxtend`
