### PR TITLE
Remove redundant code line

### DIFF
--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -78,8 +78,6 @@ def bias_variance_decomp(estimator, X_train, y_train, X_test, y_test,
                                                axis=0,
                                                arr=all_pred)
 
-        avg_expected_loss = (main_predictions != y_test).sum()/y_test.size
-
         avg_expected_loss = np.apply_along_axis(lambda x:
                                                 (x != y_test).mean(),
                                                 axis=1,


### PR DESCRIPTION
### Description

Removes a redundant line of code in the bias-variance decomposition function.

### Related issues or pull requests

#707

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
For more information and instructions, please see http://rasbt.github.io/mlxtend/contributing/  
-->
