### PR TITLE
Permutations

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -23,7 +23,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- -
+- `permutation_test` (`mlxtend.evaluate.permutation`) ìs corrected to give the proportion of permutations whose statistic is *at least as extreme* as the one observed. ([#721](https://github.com/rasbt/mlxtend/pull/721) via [Florian Charlier](https://github.com/DarthTrevis))
 
 ##### Bug Fixes
 

--- a/docs/sources/user_guide/evaluate/permutation_test.ipynb
+++ b/docs/sources/user_guide/evaluate/permutation_test.ipynb
@@ -43,13 +43,13 @@
     "4. Divide the permuted dataset into two datasets x' and y' of size *n* and *m*, respectively\n",
     "5. Compute the difference (here: mean) of sample x' and sample y' and record this difference\n",
     "6. Repeat steps 3-5 until all permutations are evaluated\n",
-    "7. Return the p-value as the number of times the recorded differences were more extreme than the original difference from 1. and divide this number by the total number of permutations\n",
+    "7. Return the p-value as the number of times the recorded differences were at least as extreme as the original difference from 1. and divide this number by the total number of permutations\n",
     "\n",
     "Here, the p-value is defined as the probability, given the null hypothesis (no difference between the samples) is true, that we obtain results that are at least as extreme as the results we observed (i.e., the sample difference from 1.).\n",
     "\n",
-    "More formally, we can express the computation of the p-value as follows ([2]):\n",
+    "More formally, we can express the computation of the p-value as follows (adapted from [2]):\n",
     "\n",
-    "$$p(t > t_0) = \\frac{1}{(n+m)!} \\sum^{(n+m)!}_{j=1} I(t_j > t_0),$$\n",
+    "$$p(t \\geq t_0) = \\frac{1}{(n+m)!} \\sum^{(n+m)!}_{j=1} I(t_j \\geq t_0),$$\n",
     "\n",
     "where $t_0$ is the observed value of the test statistic (1. in the list above), and $t$ is the t-value, the statistic computed from the resamples (5.) $t(x'_1, x'_2, ..., x'_n, y'_1, y'_2, ..., x'_m) = |\\bar{x'} - \\bar{y'}|$, and *I* is the indicator function.\n",
     "\n",
@@ -114,7 +114,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.0066\n"
+      "0.0066993300669933005\n"
      ]
     }
    ],
@@ -159,7 +159,7 @@
      "output_type": "stream",
      "text": [
       "Observed pearson R: 0.81\n",
-      "P value: 0.09\n"
+      "P value: 0.10\n"
      ]
     }
    ],
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.5"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/evaluate/permutation.py
+++ b/mlxtend/evaluate/permutation.py
@@ -97,7 +97,7 @@ def permutation_test(x, y, func='x_mean != y_mean', method='exact',
     m, n = len(x), len(y)
     combined = np.hstack((x, y))
 
-    more_extreme = 0.
+    at_least_as_extreme = 0.
     reference_stat = func(x, y)
 
     # Note that whether we compute the combinations or permutations
@@ -120,15 +120,21 @@ def permutation_test(x, y, func='x_mean != y_mean', method='exact',
             indices_y = [i for i in range(m + n) if i not in indices_x]
             diff = func(combined[list(indices_x)], combined[indices_y])
 
-            if diff > reference_stat:
-                more_extreme += 1.
+            if diff > reference_stat or np.isclose(diff, reference_stat):
+                at_least_as_extreme += 1.
 
         num_rounds = factorial(m + n) / (factorial(m)*factorial(n))
 
     else:
         for i in range(num_rounds):
             rng.shuffle(combined)
-            if func(combined[:m], combined[m:]) > reference_stat:
-                more_extreme += 1.
+            diff = func(combined[:m], combined[m:])
 
-    return more_extreme / num_rounds
+            if diff > reference_stat or np.isclose(diff, reference_stat):
+                at_least_as_extreme += 1.
+
+        # To cover the actual experiment results
+        at_least_as_extreme += 1
+        num_rounds += 1
+
+    return at_least_as_extreme / num_rounds

--- a/mlxtend/evaluate/tests/test_permutation.py
+++ b/mlxtend/evaluate/tests/test_permutation.py
@@ -16,36 +16,36 @@ control = [657, 623, 652, 654, 658, 660, 670, 620]
 def test_one_sided_x_greater_y():
     p = permutation_test(treatment, control,
                          func=lambda x, y: np.mean(x) - np.mean(y))
-    assert round(p, 4) == 0.0274, p
+    assert round(p, 4) == 0.0301, p
 
     p = permutation_test(treatment, control,
                          func="x_mean > y_mean")
-    assert round(p, 4) == 0.0274, p
+    assert round(p, 4) == 0.0301, p
 
 
 def test_one_sided_y_greater_x():
     p = permutation_test(treatment, control,
                          func=lambda x, y: np.mean(y) - np.mean(x))
-    assert round(p, 3) == 1 - 0.03, p
+    assert round(p, 3) == 0.973, p
 
     p = permutation_test(treatment, control,
                          func="x_mean < y_mean")
-    assert round(p, 3) == 1 - 0.03, p
+    assert round(p, 3) == 0.973, p
 
 
 def test_two_sided():
     p = permutation_test(treatment, control,
                          func=lambda x, y: np.abs(np.mean(x) - np.mean(y)))
-    assert round(p, 3) == 0.055, p
+    assert round(p, 3) == 0.060, p
 
     p = permutation_test(treatment, control,
                          func="x_mean != y_mean")
-    assert round(p, 3) == 0.055, p
+    assert round(p, 3) == 0.060, p
 
 
 def test_default():
     p = permutation_test(treatment, control)
-    assert round(p, 3) == 0.055, p
+    assert round(p, 3) == 0.060, p
 
 
 def test_approximateone_sided_x_greater_y():
@@ -55,7 +55,7 @@ def test_approximateone_sided_x_greater_y():
                          method='approximate',
                          num_rounds=5000,
                          seed=123)
-    assert round(p, 3) == 0.028, p
+    assert round(p, 3) == 0.031, p
 
 
 def test_invalid_method():

--- a/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
+++ b/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
@@ -108,7 +108,7 @@ def test_fail_array_dimension_2():
 def test_variance_explained_ratio():
     pca = PCA()
     pca.fit(X_std)
-    assert np.sum(pca.e_vals_normalized_) == 1.
+    assert_almost_equal(np.sum(pca.e_vals_normalized_), 1.)
     assert np.sum(pca.e_vals_normalized_ < 0.) == 0
 
 


### PR DESCRIPTION
### Code of Conduct

<!-- 
If this is your first Pull Request for the MLxtend repository, please review
the code of conduct, which is available at http://rasbt.github.io/mlxtend/Code-of-Conduct/. 
-->


### Description
Permutation tests (`mlxtend.evaluate.permutation.py`) should return as p-value the proportion of permutations for which the calculated statistic is *at least as extreme* as the one observed in the experiment. (See in particular reference [3] of Wikipedia [p-value](https://en.wikipedia.org/wiki/P-value) page).
The current code only takes into account *more* extreme values.

In cases of approximation running a series of permutations but not all, it is also common to include the actual experiment as one additional permutation, avoiding the possible p-value of 0 and also closer to the exact p-value when the number of rounds is close to the number of possible combinations, as explained in detail in this [paper](https://pubmed.ncbi.nlm.nih.gov/21044043/):

> Phipson B, Smyth GK. Permutation P-values should never be zero: calculating exact P-values when permutations are randomly drawn. Stat Appl Genet Mol Biol. 2010;9:Article39. doi:10.2202/1544-6115.1585

The function could raise a warning if the user wants to run a number of simulations that is close (> 50% ?) to the total number of possible combinations, so that they can switch to the exact method in that case. I have **not** implemented this here but I could if it is found useful. 

Finally, I ran across a test failure in `mlxtend.feature_extraction.test_principal_analysis.py` where `test_variance_explained_ratio` expects a float to be exactly `1.` where on my machine it was `1.0000000000000002`.
Fixed with `assert_almost_equal`.

### Related issues or pull requests
Fixes #718 
<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
