### PR TITLE
Fix small typo in Fpmax user guide

### DIFF
--- a/docs/sources/user_guide/frequent_patterns/fpmax.ipynb
+++ b/docs/sources/user_guide/frequent_patterns/fpmax.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [Apriori algorithm](./apriori.md) is among the first and most popular algorithms for frequent itemset generation (frequent itemsets are then used for association rule mining). However, the runtime of Apriori can be quite small, especially for datasets with a large number of unique items, as the runtime grows exponentially depending on the number of unique items. \n",
+    "The [Apriori algorithm](./apriori.md) is among the first and most popular algorithms for frequent itemset generation (frequent itemsets are then used for association rule mining). However, the runtime of Apriori can be quite large, especially for datasets with a large number of unique items, as the runtime grows exponentially depending on the number of unique items. \n",
     "\n",
     "In contrast to Apriori, [FP-Growth](./fpgrowth.md) is a frequent pattern generation algorithm that inserts items into a pattern search tree, which allows it to have a linear increase in runtime with respect to the number of unique items or entries.\n",
     "\n",


### PR DESCRIPTION
Change 

"However, the runtime of Apriori can be quite small" 
to 
"However, the runtime of Apriori can be quite large"

"small" to "large" as I think that might be how it was meant to originally read.

