### PR TITLE
Clarify fit_params docs for SFS

### DIFF
--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -297,7 +297,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
             Group labels for the samples used while splitting the dataset into
             train/test set. Passed to the fit method of the cross-validator.
         fit_params : various, optional
-            Additional parameters that are being passed to the estimator. 
+            Additional parameters that are being passed to the estimator.
             For example, `sample_weights=weights`.
 
         Returns
@@ -690,7 +690,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
             Group labels for the samples used while splitting the dataset into
             train/test set. Passed to the fit method of the cross-validator.
         fit_params : various, optional
-            Additional parameters that are being passed to the estimator. 
+            Additional parameters that are being passed to the estimator.
             For example, `sample_weights=weights`.
 
         Returns

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -296,8 +296,9 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
             train/test set. Passed to the fit method of the cross-validator.
-        fit_params : dict of string -> object, optional
-            Parameters to pass to to the fit method of classifier.
+        fit_params : various, optional
+            Additional parameters that are being passed to the estimator. 
+            For example, `sample_weights=weights`.
 
         Returns
         -------
@@ -688,8 +689,9 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
             train/test set. Passed to the fit method of the cross-validator.
-        fit_params : dict of string -> object, optional
-            Parameters to pass to to the fit method of classifier.
+        fit_params : various, optional
+            Additional parameters that are being passed to the estimator. 
+            For example, `sample_weights=weights`.
 
         Returns
         -------


### PR DESCRIPTION
Clarifies the use of `fit_params` in SFS docstring as discussed on the mailing list at https://groups.google.com/g/mlxtend/c/Xn3FWaVzLTc/m/qXPlq3GHCAAJ