### PR TITLE
include 1st weight in L2 loss

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -30,7 +30,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- -
+- The loss in `LogisticRegression` for logging purposes didn't include the L2 penalty for the first weight in the weight vector (this is not the bias unit). However, since this loss function was only used for logging purposes, and the gradient remains correct, this does not have an effect on the main code. ([#741](https://github.com/rasbt/mlxtend/pull/741))
 
 
 ### Version 0.17.3 (07-27-2020)

--- a/mlxtend/classifier/logistic_regression.py
+++ b/mlxtend/classifier/logistic_regression.py
@@ -146,7 +146,7 @@ class LogisticRegression(_BaseModel, _IterativeModel, _Classifier):
     def _logit_cost(self, y, y_val):
         logit = -y.dot(np.log(y_val)) - ((1 - y).dot(np.log(1 - y_val)))
         if self.l2_lambda:
-            l2 = self.l2_lambda / 2.0 * np.sum(self.w_[1:]**2)
+            l2 = self.l2_lambda / 2.0 * np.sum(self.w_**2)
             logit += l2
         return logit
 


### PR DESCRIPTION
### Description

The loss in `LogisticRegression` for logging purposes didn't include the L2 penalty for the first weight in the weight vector (this is not the bias unit). However, since this loss function was only used for logging purposes, and the gradient remains correct, this does not have an effect on the main code.
