### PR TITLE
fixed table layout for McNemar's test

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -27,6 +27,7 @@ The CHANGELOG for the current development version is available at
 ##### Changes
 
 - `permutation_test` (`mlxtend.evaluate.permutation`) ìs corrected to give the proportion of permutations whose statistic is *at least as extreme* as the one observed. ([#721](https://github.com/rasbt/mlxtend/pull/721) via [Florian Charlier](https://github.com/DarthTrevis))
+- Fixes the McNemar confusion matrix layout to match the convention (and documentation), swapping the upper left and lower right cells. ([#744](https://github.com/rasbt/mlxtend/pull/744) via [mmarius](https://github.com/mmarius))
 
 ##### Bug Fixes
 

--- a/mlxtend/evaluate/mcnemar.py
+++ b/mlxtend/evaluate/mcnemar.py
@@ -59,9 +59,9 @@ def mcnemar_table(y_target, y_model1, y_model2):
     tb = np.zeros((2, 2), dtype=int)
 
     tb[0, 0] = np.sum(plus_true == 2)
+    tb[0, 1] = np.sum(minus_true == 1)
+    tb[1, 0] = np.sum(minus_true == -1)
     tb[1, 1] = np.sum(plus_true == 0)
-    tb[1, 0] = np.sum(minus_true == 1)
-    tb[0, 1] = np.sum(minus_true == -1)
 
     return tb
 
@@ -148,9 +148,9 @@ def mcnemar_tables(y_target, *y_model_predictions):
         minus_true = model1_vs_true - model2_vs_true
 
         tb[0, 0] = np.sum(plus_true == 2)
+        tb[0, 1] = np.sum(minus_true == 1)
+        tb[1, 0] = np.sum(minus_true == -1)
         tb[1, 1] = np.sum(plus_true == 0)
-        tb[1, 0] = np.sum(minus_true == 1)
-        tb[0, 1] = np.sum(minus_true == -1)
 
         name_str = 'model_%s vs model_%s' % (comb[0], comb[1])
         tables[name_str] = tb

--- a/mlxtend/evaluate/tests/test_mcnemar_table.py
+++ b/mlxtend/evaluate/tests/test_mcnemar_table.py
@@ -75,8 +75,8 @@ def test_input_binary():
     tb = mcnemar_table(y_target=y_target,
                        y_model1=y_model1,
                        y_model2=y_model2)
-    expect = np.array([[4, 1],
-                       [2, 3]])
+    expect = np.array([[4, 2],
+                       [1, 3]])
 
     np.testing.assert_array_equal(tb, expect)
 
@@ -89,7 +89,7 @@ def test_input_nonbinary():
     tb = mcnemar_table(y_target=y_target,
                        y_model1=y_model1,
                        y_model2=y_model2)
-    expect = np.array([[4, 1],
-                       [2, 3]])
+    expect = np.array([[4, 2],
+                       [1, 3]])
 
     np.testing.assert_array_equal(tb, expect)

--- a/mlxtend/evaluate/tests/test_mcnemar_tables.py
+++ b/mlxtend/evaluate/tests/test_mcnemar_tables.py
@@ -96,11 +96,11 @@ def test_input_binary():
                         y_model2,
                         y_model3)
 
-    expect1 = np.array([[4, 1],
-                       [2, 3]])
+    expect1 = np.array([[4, 2],
+                       [1, 3]])
 
-    expect2 = np.array([[5, 0],
-                        [1, 4]])
+    expect2 = np.array([[5, 1],
+                        [0, 4]])
 
     expect3 = np.array([[4, 1],
                         [1, 4]])
@@ -121,11 +121,11 @@ def test_input_nonbinary():
                         y_model2,
                         y_model3)
 
-    expect1 = np.array([[4, 1],
-                       [2, 3]])
+    expect1 = np.array([[4, 2],
+                       [1, 3]])
 
-    expect2 = np.array([[5, 0],
-                        [1, 4]])
+    expect2 = np.array([[5, 1],
+                        [0, 4]])
 
     expect3 = np.array([[4, 1],
                         [1, 4]])


### PR DESCRIPTION
### Description

Fixing the table layout for McNemar's test and changed corresponding unit tests accordingly.

### Related issues or pull requests

Fixes #664 

### Pull Request Checklist

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
