### PR TITLE
bias_variance_decomp fit_params and improved keras support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
 
 test_script:
   - set PYTHONPATH=%PYTHONPATH%;%CD%
-  - pytest -sv --ignore=mlxtend/plotting
+  - pytest -sv --ignore=mlxtend/plotting --ignore=mlxtend/evaluate/test/test_bias_variance_decomp.py
 
 notifications:
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
 
 test_script:
   - set PYTHONPATH=%PYTHONPATH%;%CD%
-  - pytest -sv --ignore=mlxtend/plotting --ignore=mlxtend/evaluate/test/test_bias_variance_decomp.py
+  - pytest -sv --ignore=mlxtend/plotting
 
 notifications:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
           env: LATEST="false" IMAGE="false" COVERAGE="false" NUMPY_VERSION="1.18.5" SCIPY_VERSION="1.5.0" SKLEARN_VERSION="0.23.1" JOBLIB_VERSION=0.15.1 PANDAS_VERSION="1.0.5" IMAGEIO_VERSION="2.8.0" SKIMAGE_VERSION="0.17.2" DLIB_VERSION="19.20.0" MINICONDA_PYTHON_VERSION=3.7
         - os: linux
           python: 3.8
-          env: LATEST="true" IMAGE="false" COVERAGE="true" NOTEBOOKS="true" MINICONDA_PYTHON_VERSION=3.7
+          env: LATEST="true" IMAGE="false" COVERAGE="true" NOTEBOOKS="false" MINICONDA_PYTHON_VERSION=3.7
         - os: linux
           sudo: required
           python: 3.8

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -19,7 +19,8 @@ The CHANGELOG for the current development version is available at
 
 ##### New Features
 
-- The `bias_variance_decomp` now supports Keras estimators. ([#725](https://github.com/rasbt/mlxtend/pull/725) via [@hanzigs](https://github.com/hanzigs))
+- The `bias_variance_decomp` function now supports optional `fit_params` for the estimators that are fit on bootstrap samples ([#748](https://github.com/rasbt/mlxtend/pull/748))
+- The `bias_variance_decomp` function now supports Keras estimators. ([#725](https://github.com/rasbt/mlxtend/pull/725) via [@hanzigs](https://github.com/hanzigs))
 - Adds new `mlxtend.classifier.OneRClassifier` (One Rule Classfier) class, a simple rule-based classifier that is often used as a performance baseline or simple interpretable model. ([#726](https://github.com/rasbt/mlxtend/pull/726)
 - Adds new `create_counterfactual` method for creating counterfactuals to explain model predictions.  ([#740](https://github.com/rasbt/mlxtend/pull/740))
 

--- a/docs/sources/user_guide/evaluate/bias_variance_decomp.ipynb
+++ b/docs/sources/user_guide/evaluate/bias_variance_decomp.ipynb
@@ -320,9 +320,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average expected loss: 31.917\n",
-      "Average bias: 13.814\n",
-      "Average variance: 18.102\n"
+      "Average expected loss: 31.756\n",
+      "Average bias: 13.856\n",
+      "Average variance: 17.900\n"
      ]
     }
    ],
@@ -369,9 +369,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average expected loss: 18.593\n",
-      "Average bias: 15.354\n",
-      "Average variance: 3.239\n"
+      "Average expected loss: 18.622\n",
+      "Average bias: 15.378\n",
+      "Average variance: 3.244\n"
      ]
     }
    ],
@@ -397,7 +397,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## API"
+    "## Example 3 -- TensorFlow/Keras Support"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since mlxtend v0.18.0, the `bias_variance_decomp` now supports Keras models. Note that the original model is reset in each round (before refitting it to the bootstrap samples)."
    ]
   },
   {
@@ -406,16 +413,147 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "text/plain": [
+       "32.69300595184836"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from mlxtend.evaluate import bias_variance_decomp\n",
+    "from mlxtend.data import boston_housing_data\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "import tensorflow as tf\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "np.random.seed(1)\n",
+    "tf.random.set_seed(1)\n",
+    "\n",
+    "\n",
+    "X, y = boston_housing_data()\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y,\n",
+    "                                                    test_size=0.3,\n",
+    "                                                    random_state=123,\n",
+    "                                                    shuffle=True)\n",
+    "\n",
+    "\n",
+    "model = tf.keras.Sequential([\n",
+    "    tf.keras.layers.Dense(32, activation=tf.nn.relu),\n",
+    "    tf.keras.layers.Dense(1)\n",
+    "  ])\n",
+    "\n",
+    "optimizer = tf.keras.optimizers.Adam()\n",
+    "model.compile(loss='mean_squared_error', optimizer=optimizer)\n",
+    "\n",
+    "model.fit(X_train, y_train, epochs=100, verbose=0)\n",
+    "\n",
+    "mean_squared_error(model.predict(X_test), y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that it is highly recommended to use the same number of training epochs that you would use on the original training set to ensure convergence:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average expected loss: 32.869\n",
+      "Average bias: 27.541\n",
+      "Average variance: 5.328\n"
+     ]
+    }
+   ],
+   "source": [
+    "np.random.seed(1)\n",
+    "tf.random.set_seed(1)\n",
+    "\n",
+    "\n",
+    "avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(\n",
+    "        model, X_train, y_train, X_test, y_test, \n",
+    "        loss='mse',\n",
+    "        num_rounds=100,\n",
+    "        random_seed=123,\n",
+    "        epochs=200, # fit_param\n",
+    "        verbose=0) # fit_param\n",
+    "\n",
+    "\n",
+    "print('Average expected loss: %.3f' % avg_expected_loss)\n",
+    "print('Average bias: %.3f' % avg_bias)\n",
+    "print('Average variance: %.3f' % avg_var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average expected loss: 33.026\n",
+      "Average bias: 28.067\n",
+      "Average variance: 4.959\n"
+     ]
+    }
+   ],
+   "source": [
+    "np.random.seed(123)\n",
+    "tf.random.set_seed(123)\n",
+    "\n",
+    "\n",
+    "avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(\n",
+    "        model, X_train, y_train, X_test, y_test, \n",
+    "        loss='mse',\n",
+    "        num_rounds=100,\n",
+    "        random_seed=123,\n",
+    "        epochs=200, # fit_param\n",
+    "        verbose=0) # fit_param\n",
+    "\n",
+    "\n",
+    "print('Average expected loss: %.3f' % avg_expected_loss)\n",
+    "print('Average bias: %.3f' % avg_bias)\n",
+    "print('Average variance: %.3f' % avg_var)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "## bias_variance_decomp\n",
       "\n",
-      "*bias_variance_decomp(estimator, X_train, y_train, X_test, y_test, loss='0-1_loss', num_rounds=200, random_seed=None)*\n",
+      "*bias_variance_decomp(estimator, X_train, y_train, X_test, y_test, loss='0-1_loss', num_rounds=200, random_seed=None, **fit_params)*\n",
       "\n",
       "estimator : object\n",
-      "A classifier or regressor object or class implementing a `fit`\n",
-      "`predict` method similar to the scikit-learn API.\n",
+      "    A classifier or regressor object or class implementing both a\n",
+      "    `fit` and `predict` method similar to the scikit-learn API.\n",
       "\n",
       "\n",
       "- `X_train` : array-like, shape=(num_examples, num_features)\n",
@@ -459,6 +597,12 @@
       "    Random seed for the bootstrap sampling used for the\n",
       "    bias-variance decomposition.\n",
       "\n",
+      "\n",
+      "- `fit_params` : additional parameters\n",
+      "\n",
+      "    Additional parameters to be passed to the .fit() function of the\n",
+      "    estimator when it is fit to the bootstrap samples.\n",
+      "\n",
       "**Returns**\n",
       "\n",
       "- `avg_expected_loss, avg_bias, avg_var` : returns the average expected\n",
@@ -469,7 +613,7 @@
       "**Examples**\n",
       "\n",
       "For usage examples, please see\n",
-      "    [http://rasbt.github.io/mlxtend/user_guide/evaluate/bias_variance_decomp/](http://rasbt.github.io/mlxtend/user_guide/evaluate/bias_variance_decomp/)\n",
+      "    http://rasbt.github.io/mlxtend/user_guide/evaluate/bias_variance_decomp/\n",
       "\n",
       "\n"
      ]
@@ -480,6 +624,13 @@
     "    s = f.read() \n",
     "print(s)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -499,7 +650,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.2"
   },
   "toc": {
    "nav_menu": {},

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -7,6 +7,8 @@
 # License: BSD 3 clause
 
 
+import os
+import pytest
 from mlxtend.evaluate import bias_variance_decomp
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.tree import DecisionTreeRegressor
@@ -88,7 +90,7 @@ def test_mse_bagging():
 
     tree = DecisionTreeRegressor(random_state=123)
     bag = BaggingRegressor(base_estimator=tree,
-                           n_estimators=100,
+                           n_estimators=10,
                            random_state=123)
 
     avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(
@@ -96,6 +98,34 @@ def test_mse_bagging():
             loss='mse',
             random_seed=123)
 
-    assert round(avg_expected_loss, 2) == 18.62
-    assert round(avg_bias, 2) == 15.38
-    assert round(avg_var, 2) == 3.24
+    assert round(avg_expected_loss, 2) == 20.22, avg_expected_loss
+    assert round(avg_bias, 2) == 15.51, avg_bias
+    assert round(avg_var, 2) == 4.71, avg_var
+
+
+if 'TRAVIS' in os.environ or os.environ.get('TRAVIS') == 'true':
+    TRAVIS = True
+else:
+    TRAVIS = False
+
+
+@pytest.mark.skipif(TRAVIS, reason="TensorFlow dependency")
+def test_keras():
+
+    import tensorflow as tf
+    X, y = boston_housing_data()
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y,
+        test_size=0.3,
+        random_state=123,
+        shuffle=True)
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(32, activation=tf.nn.relu),
+        tf.keras.layers.Dense(1)])
+
+    optimizer = tf.keras.optimizers.Adam()
+    model.compile(loss='mean_squared_error', optimizer=optimizer)
+
+    model.fit(X_train, y_train, epochs=10)
+    model.predict(X_test)

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -108,8 +108,13 @@ if 'TRAVIS' in os.environ or os.environ.get('TRAVIS') == 'true':
 else:
     TRAVIS = False
 
+if 'APPVEYOR' in os.environ or os.environ.get('APPVEYOR') == 'true':
+    APPVEYOR = True
+else:
+    APPVEYOR = False
 
-@pytest.mark.skipif(TRAVIS, reason="TensorFlow dependency")
+
+@pytest.mark.skipif(TRAVIS or APPVEYOR, reason="TensorFlow dependency")
 def test_keras():
 
     import tensorflow as tf


### PR DESCRIPTION
### Description

Improves the keras support in `bias_variance_decomp` and adds a `fit_params` parameter. Also provides documentation (Example 3).

### Related issues or pull requests

Fixes #746

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
