### PR TITLE
Fix integer bug in bias_variance_decomp

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -19,7 +19,7 @@ The CHANGELOG for the current development version is available at
 
 ##### New Features
 
-- The `bias_variance_decomp` function now supports optional `fit_params` for the estimators that are fit on bootstrap samples ([#748](https://github.com/rasbt/mlxtend/pull/748))
+- The `bias_variance_decomp` function now supports optional `fit_params` for the estimators that are fit on bootstrap samples. ([#748](https://github.com/rasbt/mlxtend/pull/748))
 - The `bias_variance_decomp` function now supports Keras estimators. ([#725](https://github.com/rasbt/mlxtend/pull/725) via [@hanzigs](https://github.com/hanzigs))
 - Adds new `mlxtend.classifier.OneRClassifier` (One Rule Classfier) class, a simple rule-based classifier that is often used as a performance baseline or simple interpretable model. ([#726](https://github.com/rasbt/mlxtend/pull/726)
 - Adds new `create_counterfactual` method for creating counterfactuals to explain model predictions.  ([#740](https://github.com/rasbt/mlxtend/pull/740))
@@ -32,6 +32,7 @@ The CHANGELOG for the current development version is available at
 ##### Bug Fixes
 
 - The loss in `LogisticRegression` for logging purposes didn't include the L2 penalty for the first weight in the weight vector (this is not the bias unit). However, since this loss function was only used for logging purposes, and the gradient remains correct, this does not have an effect on the main code. ([#741](https://github.com/rasbt/mlxtend/pull/741))
+- Fixes a bug in `bias_variance_decomp` where when the `mse` loss was used, downcasting to integers caused imprecise results for small numbers. ([#749](https://github.com/rasbt/mlxtend/pull/749))
 
 
 ### Version 0.17.3 (07-27-2020)

--- a/docs/sources/user_guide/evaluate/bias_variance_decomp.ipynb
+++ b/docs/sources/user_guide/evaluate/bias_variance_decomp.ipynb
@@ -369,9 +369,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average expected loss: 18.622\n",
-      "Average bias: 15.378\n",
-      "Average variance: 3.244\n"
+      "Average expected loss: 18.620\n",
+      "Average bias: 15.461\n",
+      "Average variance: 3.159\n"
      ]
     }
    ],
@@ -472,49 +472,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average expected loss: 32.869\n",
-      "Average bias: 27.541\n",
-      "Average variance: 5.328\n"
+      "Average expected loss: 32.740\n",
+      "Average bias: 27.474\n",
+      "Average variance: 5.265\n"
      ]
     }
    ],
    "source": [
     "np.random.seed(1)\n",
     "tf.random.set_seed(1)\n",
-    "\n",
-    "\n",
-    "avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(\n",
-    "        model, X_train, y_train, X_test, y_test, \n",
-    "        loss='mse',\n",
-    "        num_rounds=100,\n",
-    "        random_seed=123,\n",
-    "        epochs=200, # fit_param\n",
-    "        verbose=0) # fit_param\n",
-    "\n",
-    "\n",
-    "print('Average expected loss: %.3f' % avg_expected_loss)\n",
-    "print('Average bias: %.3f' % avg_bias)\n",
-    "print('Average variance: %.3f' % avg_var)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average expected loss: 33.026\n",
-      "Average bias: 28.067\n",
-      "Average variance: 4.959\n"
-     ]
-    }
-   ],
-   "source": [
-    "np.random.seed(123)\n",
-    "tf.random.set_seed(123)\n",
     "\n",
     "\n",
     "avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(\n",

--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -75,7 +75,12 @@ def bias_variance_decomp(estimator, X_train, y_train, X_test, y_test,
 
     rng = np.random.RandomState(random_seed)
 
-    all_pred = np.zeros((num_rounds, y_test.shape[0]), dtype=np.int)
+    if loss == '0-1_loss':
+        dtype = np.int
+    elif loss == 'mse':
+        dtype = np.float
+
+    all_pred = np.zeros((num_rounds, y_test.shape[0]), dtype=dtype)
 
     for i in range(num_rounds):
         X_boot, y_boot = _draw_bootstrap_sample(rng, X_train, y_train)

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -75,9 +75,9 @@ def test_mse_tree():
             loss='mse',
             random_seed=123)
 
-    assert round(avg_expected_loss, 3) == 31.756
-    assert round(avg_bias, 3) == 13.856
-    assert round(avg_var, 3) == 17.900
+    assert round(avg_expected_loss, 3) == 31.536
+    assert round(avg_bias, 3) == 14.096
+    assert round(avg_var, 3) == 17.440
 
 
 def test_mse_bagging():
@@ -98,9 +98,9 @@ def test_mse_bagging():
             loss='mse',
             random_seed=123)
 
-    assert round(avg_expected_loss, 2) == 20.22, avg_expected_loss
-    assert round(avg_bias, 2) == 15.51, avg_bias
-    assert round(avg_var, 2) == 4.71, avg_var
+    assert round(avg_expected_loss, 2) == 20.24, avg_expected_loss
+    assert round(avg_bias, 2) == 15.63, avg_bias
+    assert round(avg_var, 2) == 4.61, avg_var
 
 
 if 'TRAVIS' in os.environ or os.environ.get('TRAVIS') == 'true':


### PR DESCRIPTION
### Description

Fixes a bug in `bias_variance_decomp` where when the `mse` loss was used, downcasting to integers caused imprecise results for small numbers. 

### Related issues or pull requests

Fixes  #743 

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
