### PR TITLE
Clarifies how bootstrapping is used in the `bias_variance_decomposition`

### DIFF
--- a/docs/sources/user_guide/evaluate/bias_variance_decomp.ipynb
+++ b/docs/sources/user_guide/evaluate/bias_variance_decomp.ipynb
@@ -320,9 +320,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average expected loss: 31.756\n",
-      "Average bias: 13.856\n",
-      "Average variance: 17.900\n"
+      "Average expected loss: 31.536\n",
+      "Average bias: 14.096\n",
+      "Average variance: 17.440\n"
      ]
     }
    ],
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -554,8 +554,9 @@
       "\n",
       "- `num_rounds` : int (default=200)\n",
       "\n",
-      "    Number of bootstrap rounds for performing the bias-variance\n",
-      "    decomposition.\n",
+      "    Number of bootstrap rounds (sampling from the training set)\n",
+      "    for performing the bias-variance decomposition. Each bootstrap\n",
+      "    sample has the same size as the original training set.\n",
       "\n",
       "\n",
       "- `random_seed` : int (default=None)\n",
@@ -590,13 +591,6 @@
     "    s = f.read() \n",
     "print(s)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -45,8 +45,9 @@ def bias_variance_decomp(estimator, X_train, y_train, X_test, y_test,
         Currently allowed values are '0-1_loss' and 'mse'.
 
     num_rounds : int (default=200)
-        Number of bootstrap rounds for performing the bias-variance
-        decomposition.
+        Number of bootstrap rounds (sampling from the training set)
+        for performing the bias-variance decomposition. Each bootstrap
+        sample has the same size as the original training set.
 
     random_seed : int (default=None)
         Random seed for the bootstrap sampling used for the


### PR DESCRIPTION
Clarifies how bootstrapping is used in the `bias_variance_decomposition` (#786)