### PR TITLE
Remove depr. res from plot_decision_regions

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -22,6 +22,7 @@ The CHANGELOG for the current development version is available at
 ##### Changes
 
 - Updates unit tests for scikit-learn 0.24.1 compatibility. ([#774](https://github.com/rasbt/mlxtend/pull/774))
+- Removes deprecated `res` argument from `plot_decision_regions`. ([#803](https://github.com/rasbt/mlxtend/pull/803))
 
 ##### Bug Fixes
 

--- a/mlxtend/plotting/decision_regions.py
+++ b/mlxtend/plotting/decision_regions.py
@@ -49,7 +49,6 @@ def plot_decision_regions(X, y, clf,
                           filler_feature_ranges=None,
                           ax=None,
                           X_highlight=None,
-                          res=None,
                           zoom_factor=1.,
                           legend=1,
                           hide_spines=True,
@@ -93,13 +92,6 @@ def plot_decision_regions(X, y, clf,
         one if ax=None.
     X_highlight : array-like, shape = [n_samples, n_features] (default: None)
         An array with data points that are used to highlight samples in `X`.
-    res : float or array-like, shape = (2,) (default: None)
-        This parameter was used to define the grid width,
-        but it has been deprecated in favor of
-        determining the number of points given the figure DPI and size
-        automatically for optimal results and computational efficiency.
-        To increase the resolution, it's is recommended to use to provide
-        a `dpi argument via matplotlib, e.g., `plt.figure(dpi=600)`.
     zoom_factor : float (default: 1.0)
         Controls the scale of the x- and y-axis of the decision plot.
     hide_spines : bool (default: True)
@@ -134,13 +126,6 @@ def plot_decision_regions(X, y, clf,
 
     if ax is None:
         ax = plt.gca()
-
-    if res is not None:
-        warnings.warn("The 'res' parameter has been deprecated."
-                      "To increase the resolution, it's is recommended"
-                      "to use to provide a `dpi argument via matplotlib,"
-                      "e.g., `plt.figure(dpi=600)`.",
-                      DeprecationWarning)
 
     plot_testdata = True
     if not isinstance(X_highlight, np.ndarray):


### PR DESCRIPTION

### Description

Removes deprecates `res` (resolution) parameter from `plot_decision_regions`


### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
