### PR TITLE
Notify users about about pandas dataframe use in bias_variance_decomp

### DIFF
--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -74,6 +74,14 @@ def bias_variance_decomp(estimator, X_train, y_train, X_test, y_test,
         raise NotImplementedError('loss must be one of the following: %s' %
                                   supported)
 
+    for ary in (X_train, y_train, X_test, y_test):
+        if hasattr(ary, 'loc'):
+            raise ValueError('The bias_variance_decomp does not support pandas DataFrames yet. '
+                             'Please check the inputs to X_train, y_train, X_test, y_test. '
+                             'If e.g., X_train is a pandas DataFrame, try passing it as NumPy array via '
+                             'X_train=X_train.values.')
+
+
     rng = np.random.RandomState(random_seed)
 
     if loss == '0-1_loss':

--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -76,18 +76,20 @@ def bias_variance_decomp(estimator, X_train, y_train, X_test, y_test,
 
     for ary in (X_train, y_train, X_test, y_test):
         if hasattr(ary, 'loc'):
-            raise ValueError('The bias_variance_decomp does not support pandas DataFrames yet. '
-                             'Please check the inputs to X_train, y_train, X_test, y_test. '
-                             'If e.g., X_train is a pandas DataFrame, try passing it as NumPy array via '
+            raise ValueError('The bias_variance_decomp does not '
+                             'support pandas DataFrames yet. '
+                             'Please check the inputs to '
+                             'X_train, y_train, X_test, y_test. '
+                             'If e.g., X_train is a pandas '
+                             'DataFrame, try passing it as NumPy array via '
                              'X_train=X_train.values.')
-
 
     rng = np.random.RandomState(random_seed)
 
     if loss == '0-1_loss':
-        dtype = np.int
+        dtype = np.int64
     elif loss == 'mse':
-        dtype = np.float
+        dtype = np.float64
 
     all_pred = np.zeros((num_rounds, y_test.shape[0]), dtype=dtype)
 

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -18,6 +18,25 @@ from mlxtend.data import iris_data
 from mlxtend.data import boston_housing_data
 from sklearn.model_selection import train_test_split
 
+def pandas_input_fail():
+
+    X, y = iris_data()
+    X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                        test_size=0.3,
+                                                        random_state=123,
+                                                        shuffle=True,
+                                                        stratify=y)
+
+    X_train = pd.DataFrame(X_train)
+
+    tree = DecisionTreeClassifier(random_state=123)
+
+    with pytest.raises(ValueError):
+        avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(
+                tree, X_train, y_train, X_test, y_test,
+                loss='0-1_loss',
+                random_seed=123)
+
 
 def test_01_loss_tree():
 

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -8,6 +8,7 @@
 
 
 import os
+import pandas as pd
 import pytest
 from mlxtend.evaluate import bias_variance_decomp
 from sklearn.tree import DecisionTreeClassifier
@@ -17,6 +18,7 @@ from sklearn.ensemble import BaggingRegressor
 from mlxtend.data import iris_data
 from mlxtend.data import boston_housing_data
 from sklearn.model_selection import train_test_split
+
 
 def pandas_input_fail():
 


### PR DESCRIPTION
Raises a more descriptive `ValueError` if user uses a pandas DataFrame in the `bias_variance_decomp` func where it is currently not explicitly supported yet