### PR TITLE
joaozanlorensi/fixDocsTypo

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -31,7 +31,8 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- - 
+- Fixes a typo in the SequentialFeatureSelector documentation ([Issue #835](https://github.com/rasbt/mlxtend/issues/835) via [João Pedro Zanlorensi Cardoso](https://github.com/joaozanlorensi))
+
 
 ### Version 0.18.0 (11/25/2020)
 

--- a/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
+++ b/docs/sources/user_guide/feature_selection/SequentialFeatureSelector.ipynb
@@ -199,7 +199,7 @@
     "*Go to Step 2*  \n",
     "\n",
     "- In this step, we remove a feature, $x^-$ from our feature subset $X_k$.\n",
-    "- $x^-$ is the feature that maximizes our criterion function upon re,oval, that is, the feature that is associated with the best classifier performance if it is removed from $X_k$.\n",
+    "- $x^-$ is the feature that maximizes our criterion function upon removal, that is, the feature that is associated with the best classifier performance if it is removed from $X_k$.\n",
     "\n",
     "\n",
     "**Step 2 (Conditional Inclusion):**  \n",


### PR DESCRIPTION
### Description

This Pull Request aims to close issue [#835](https://github.com/rasbt/mlxtend/issues/835). It consists of a small typo correction in the excellent documentation about the SequentialFeatureSelector.

### Related issues or pull requests

Fixes #835.

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`