### PR TITLE
Raise error on empty frequent itemset to association_rules

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -28,6 +28,7 @@ The CHANGELOG for the current development version is available at
 - Adds a `title_fontsize` parameter to `plot_learning_curves` for controlling the title font size; also the plot style is now the matplotlib default. ([#818](https://github.com/rasbt/mlxtend/pull/818))
 - Internal change using `'c': 'none'` instead of `'c': ''` in `mlxtend.plotting.plot_decision_regions`'s scatterplot highlights to stay compatible with Matplotlib 3.4 and newer. ([#822](https://github.com/rasbt/mlxtend/pull/822))
 - Adds a `fontcolor_threshold` parameter to the `mlxtend.plotting.plot_confusion_matrix` function as an additional option for determining the font color cut-off manually. ([#825](https://github.com/rasbt/mlxtend/pull/825))
+- The `frequent_patterns.association_rules` now raises a `ValueError` if an empty frequent itemset DataFrame is passed. ([#842](https://github.com/rasbt/mlxtend/pull/842))
 
 ##### Bug Fixes
 

--- a/mlxtend/frequent_patterns/association_rules.py
+++ b/mlxtend/frequent_patterns/association_rules.py
@@ -76,6 +76,8 @@ def association_rules(df, metric="confidence",
     http://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/
 
     """
+    if not df.shape[0]:
+        raise ValueError('The input DataFrame `df` containing the frequent itemsets is empty.')
 
     # check for mandatory columns
     if not all(col in df.columns for col in ["support", "itemsets"]):

--- a/mlxtend/frequent_patterns/association_rules.py
+++ b/mlxtend/frequent_patterns/association_rules.py
@@ -77,7 +77,8 @@ def association_rules(df, metric="confidence",
 
     """
     if not df.shape[0]:
-        raise ValueError('The input DataFrame `df` containing the frequent itemsets is empty.')
+        raise ValueError('The input DataFrame `df` containing '
+                         'the frequent itemsets is empty.')
 
     # check for mandatory columns
     if not all(col in df.columns for col in ["support", "itemsets"]):

--- a/mlxtend/frequent_patterns/tests/test_association_rules.py
+++ b/mlxtend/frequent_patterns/tests/test_association_rules.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from mlxtend.frequent_patterns import apriori, association_rules
 from numpy.testing import assert_raises as numpy_assert_raises
 
@@ -224,3 +225,9 @@ def test_on_df_with_missing_entries_support_only():
 
     assert df_result['support'].shape == (18,)
     assert int(np.isnan(df_result['support'].values).any()) != 1
+
+
+def test_with_empty_dataframe():
+    df = df_freq_items_with_colnames.iloc[:0]
+    with pytest.raises(ValueError):
+        association_rules(df) 

--- a/mlxtend/frequent_patterns/tests/test_association_rules.py
+++ b/mlxtend/frequent_patterns/tests/test_association_rules.py
@@ -230,4 +230,4 @@ def test_on_df_with_missing_entries_support_only():
 def test_with_empty_dataframe():
     df = df_freq_items_with_colnames.iloc[:0]
     with pytest.raises(ValueError):
-        association_rules(df) 
+        association_rules(df)


### PR DESCRIPTION
The `frequent_patterns.association_rules` now raises a `ValueError` if an empty frequent itemset DataFrame is passed. 

Fixes #496 