### PR TITLE
Contingency typo fix

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -9,6 +9,10 @@ The CHANGELOG for the current development version is available at
 
 ### Version 0.20.0 (TBD)
 
+#### New Features and Enhancements
+
+- Fix various typos in McNemar guides
+
 ##### Downloads
 
 - [Source code (zip)](https://github.com/rasbt/mlxtend/archive/v0.20.0.zip)

--- a/docs/sources/user_guide/evaluate/mcnemar.ipynb
+++ b/docs/sources/user_guide/evaluate/mcnemar.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "McNemar's Test [1] (sometimes also called \"within-subjects chi-squared test\") is a statistical test for paired nominal data. In context of machine learning (or statistical) models, we can use McNemar's Test to compare the predictive accuracy of two models. McNemar's test is based on a 2 times 2 contigency table of the two model's predictions."
+    "McNemar's Test [1] (sometimes also called \"within-subjects chi-squared test\") is a statistical test for paired nominal data. In context of machine learning (or statistical) models, we can use McNemar's Test to compare the predictive accuracy of two models. McNemar's test is based on a 2 times 2 contingency table of the two model's predictions."
    ]
   },
   {
@@ -113,7 +113,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For instance, given that 2 models have a accuracy of with a 99.7% and 99.6% a 2x2 contigency table can provide further insights for model selection.\n",
+    "For instance, given that 2 models have a accuracy of with a 99.7% and 99.6% a 2x2 contingency table can provide further insights for model selection.\n",
     "\n",
     "\n",
     "![](./mcnemar_table_files/mcnemar_contingency_table_ex1.png)\n",
@@ -143,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1 - Creating 2x2 Contigency tables"
+    "## Example 1 - Creating 2x2 contingency tables"
    ]
   },
   {
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Such a contigency matrix can be created by using the `mcnemar_table` function from `mlxtend.evaluate`. For example:"
+    "Such a contingency matrix can be created by using the `mcnemar_table` function from `mlxtend.evaluate`. For example:"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "No, let us continue with the example mentioned in the overview section and assume that we already computed the 2x2 contigency table:\n",
+    "No, let us continue with the example mentioned in the overview section and assume that we already computed the 2x2 contingency table:\n",
     "\n",
     "![](./mcnemar_files/mcnemar_scenario_b.png)"
    ]
@@ -350,7 +350,7 @@
       "\n",
       "- `ary` : array-like, shape=[2, 2]\n",
       "\n",
-      "    2 x 2 contigency table (as returned by evaluate.mcnemar_table),\n",
+      "    2 x 2 contingency table (as returned by evaluate.mcnemar_table),\n",
       "    where\n",
       "    a: ary[0, 0]: # of samples that both models predicted correctly\n",
       "    b: ary[0, 1]: # of samples that model 1 got right and model 2 got wrong\n",

--- a/docs/sources/user_guide/evaluate/mcnemar_table.ipynb
+++ b/docs/sources/user_guide/evaluate/mcnemar_table.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Contigency Table for McNemar's Test"
+    "# contingency Table for McNemar's Test"
    ]
   },
   {
@@ -43,14 +43,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  Contigency Table for McNemar's Test"
+    "###  contingency Table for McNemar's Test"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A 2x2 contigency table as being used in a McNemar's Test ([`mlxtend.evaluate.mcnemar`](mcnemar.md)) is a useful aid for comparing two different models. In contrast to a typical confusion matrix, this table compares two models to each other rather than showing the false positives, true positives, false negatives, and true negatives of a single model's predictions:"
+    "A 2x2 contingency table as being used in a McNemar's Test ([`mlxtend.evaluate.mcnemar`](mcnemar.md)) is a useful aid for comparing two different models. In contrast to a typical confusion matrix, this table compares two models to each other rather than showing the false positives, true positives, false negatives, and true negatives of a single model's predictions:"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For instance, given that 2 models have a accuracy of with a 99.7% and 99.6% a 2x2 contigency table can provide further insights for model selection.\n",
+    "For instance, given that 2 models have a accuracy of with a 99.7% and 99.6% a 2x2 contingency table can provide further insights for model selection.\n",
     "\n",
     "\n",
     "![](./mcnemar_table_files/mcnemar_contingency_table_ex1.png)\n",
@@ -92,7 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 2 - 2x2 Contigency Table"
+    "## Example 2 - 2x2 contingency Table"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To visualize (and better interpret) the contigency table via matplotlib, we can use the `checkerboard_plot` function:"
+    "To visualize (and better interpret) the contingency table via matplotlib, we can use the `checkerboard_plot` function:"
    ]
   },
   {
@@ -183,7 +183,7 @@
       "\n",
       "*mcnemar_table(y_target, y_model1, y_model2)*\n",
       "\n",
-      "Compute a 2x2 contigency table for McNemar's test.\n",
+      "Compute a 2x2 contingency table for McNemar's test.\n",
       "\n",
       "**Parameters**\n",
       "\n",

--- a/docs/sources/user_guide/evaluate/mcnemar_tables.ipynb
+++ b/docs/sources/user_guide/evaluate/mcnemar_tables.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Contigency Tables for McNemar's Test and Cochran's Q Test"
+    "# contingency Tables for McNemar's Test and Cochran's Q Test"
    ]
   },
   {
@@ -41,14 +41,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  Contigency Tables"
+    "###  contingency Tables"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A 2x2 contigency table as being used in a McNemar's Test ([`mlxtend.evaluate.mcnemar`](mcnemar.md)) is a useful aid for comparing two different models. In contrast to a typical confusion matrix, this table compares two models to each other rather than showing the false positives, true positives, false negatives, and true negatives of a single model's predictions:"
+    "A 2x2 contingency table as being used in a McNemar's Test ([`mlxtend.evaluate.mcnemar`](mcnemar.md)) is a useful aid for comparing two different models. In contrast to a typical confusion matrix, this table compares two models to each other rather than showing the false positives, true positives, false negatives, and true negatives of a single model's predictions:"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For instance, given that 2 models have a accuracy of with a 99.7% and 99.6% a 2x2 contigency table can provide further insights for model selection.\n",
+    "For instance, given that 2 models have a accuracy of with a 99.7% and 99.6% a 2x2 contingency table can provide further insights for model selection.\n",
     "\n",
     "\n",
     "![](./mcnemar_table_files/mcnemar_contingency_table_ex1.png)\n",
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1 - Single 2x2 Contigency Table"
+    "## Example 1 - Single 2x2 contingency Table"
    ]
   },
   {
@@ -130,7 +130,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To visualize (and better interpret) the contigency table via matplotlib, we can use the `checkerboard_plot` function:"
+    "To visualize (and better interpret) the contingency table via matplotlib, we can use the `checkerboard_plot` function:"
    ]
   },
   {
@@ -165,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 2 - Multiple 2x2 Contigency Tables"
+    "## Example 2 - Multiple 2x2 contingency Tables"
    ]
   },
   {
@@ -238,7 +238,7 @@
       "\n",
       "*mcnemar_tables(y_target, *y_model_predictions)*\n",
       "\n",
-      "Compute multiple 2x2 contigency tables for McNemar's\n",
+      "Compute multiple 2x2 contingency tables for McNemar's\n",
       "test or Cochran's Q test.\n",
       "\n",
       "**Parameters**\n",


### PR DESCRIPTION
This PR only fix some typos in McNemar guides where `contingency` was written `contigency`.