### PR TITLE
Fixed #971 turned off joblib when `n_jobs == 1`

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -7,6 +7,23 @@ The CHANGELOG for the current development version is available at
 
 ---
 
+
+
+Version 0.22.0dev (TBD)
+
+##### Downloads
+
+- [Source code (zip)](https://github.com/rasbt/mlxtend/archive/v0.22.0.zip)
+
+- [Source code (tar.gz)](https://github.com/rasbt/mlxtend/archive/v0.22.0.tar.gz)
+
+##### Changes
+
+- When `ExhaustiveFeatureSelector` is run with `n_jobs == 1`, joblib is now disabled, which enables more immediate (live) feedback when the `verbose` mode is enabled. [#985](https://github.com/rasbt/mlxtend/pull/985) via [Nima Sarajpoor]
+
+
+
+
 ### Version 0.21.0 (09/17/2022)
 
 

--- a/mlxtend/__init__.py
+++ b/mlxtend/__init__.py
@@ -4,4 +4,4 @@
 #
 # License: BSD 3 clause
 
-__version__ = "0.21.0dev0"
+__version__ = "0.22.0dev0"

--- a/mlxtend/__init__.py
+++ b/mlxtend/__init__.py
@@ -4,4 +4,4 @@
 #
 # License: BSD 3 clause
 
-__version__ = "0.21.0"
+__version__ = "0.21.0dev0"


### PR DESCRIPTION
This PR fixes issue #971 

# Performance Code
```
seed = 0
X = np.random.rand(10000, 10) # 10k samples, with 10 features
y = np.random.choice([0, 1], size=10000)

lst = []
for i in range(5):
    tic = time.time()
    efs = EFS(RandomForestClassifier()).fit(X, y) # EFS: ExhaustiveFeatureSelector
    toc = time.time()
    lst.append(toc - tic)

np.mean(lst)
```

# Computing Time
* branch `main`: 103 sec
* this branch: 93 sec

