### PR TITLE
mcnemar(tb, exact=True) returns None as chi2

### DIFF
--- a/mlxtend/evaluate/mcnemar.py
+++ b/mlxtend/evaluate/mcnemar.py
@@ -215,6 +215,7 @@ def mcnemar(ary, corrected=True, exact=False):
     else:
         chi2 = min(b, c)
         p = min(scipy.stats.binom.cdf(chi2, b + c, 0.5) * 2.0, 1.0)
+        chi2 = None
 
         # this is equivalent to the following code:
         #

--- a/mlxtend/evaluate/mcnemar.py
+++ b/mlxtend/evaluate/mcnemar.py
@@ -213,9 +213,8 @@ def mcnemar(ary, corrected=True, exact=False):
         p = scipy.stats.distributions.chi2.sf(chi2, 1)
 
     else:
-        chi2 = min(b, c)
-        p = min(scipy.stats.binom.cdf(chi2, b + c, 0.5) * 2.0, 1.0)
         chi2 = None
+        p = min(scipy.stats.binom.cdf(min(b, c), b + c, 0.5) * 2.0, 1.0)
 
         # this is equivalent to the following code:
         #

--- a/mlxtend/evaluate/tests/test_mcnemar_test.py
+++ b/mlxtend/evaluate/tests/test_mcnemar_test.py
@@ -41,7 +41,7 @@ def test_exact():
     chi2, p = (None, 4.4344492637555101e-06)
     chi2p, pp = mcnemar(tb, exact=True)
 
-    assert chi2 is None
+    assert chi2p is None
     assert_almost_equal(p, pp, decimal=7)
     assert p < 4.45e-06
 
@@ -52,6 +52,6 @@ def test_exact_corrected():
     chi2, p = (None, 4.4344492637555101e-06)
     chi2p, pp = mcnemar(tb, exact=True, corrected=False)
 
-    assert chi2 is None
+    assert chi2p is None
     assert_almost_equal(p, pp, decimal=7)
     assert p < 4.45e-06

--- a/mlxtend/evaluate/tests/test_mcnemar_test.py
+++ b/mlxtend/evaluate/tests/test_mcnemar_test.py
@@ -38,7 +38,7 @@ def test_corrected_false():
 def test_exact():
     tb = np.array([[101, 121], [59, 33]])
 
-    chi2, p = (None, 4.4344492637555101e-06)
+    p = 4.4344492637555101e-06
     chi2p, pp = mcnemar(tb, exact=True)
 
     assert chi2p is None
@@ -49,7 +49,7 @@ def test_exact():
 def test_exact_corrected():
     tb = np.array([[101, 121], [59, 33]])
 
-    chi2, p = (None, 4.4344492637555101e-06)
+    p = 4.4344492637555101e-06
     chi2p, pp = mcnemar(tb, exact=True, corrected=False)
 
     assert chi2p is None


### PR DESCRIPTION
### Code of Conduct

<!-- 
If this is your first Pull Request for the MLxtend repository, please review
the code of conduct, which is available at http://rasbt.github.io/mlxtend/Code-of-Conduct/. 
-->


### Description

<!--  
Please insert a brief description of the Pull request below.
-->

`mlxtend.evaluate.mcnemar` returns `None` as `chi2` when `exact=True`.

### Related issues or pull requests

Fixes #989 

<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
