### PR TITLE
Removed unnecessary warnings as described in #941

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -20,8 +20,11 @@ Version 0.22.0dev (TBD)
 ##### Changes
 
 - When `ExhaustiveFeatureSelector` is run with `n_jobs == 1`, joblib is now disabled, which enables more immediate (live) feedback when the `verbose` mode is enabled. [#985](https://github.com/rasbt/mlxtend/pull/985) via [Nima Sarajpoor]
+- Disabled unnecessary warning in EnsembleVoteClassifier [#941](https://github.com/rasbt/mlxtend/issues/941)
 
+##### New Features and Enhancements
 
+- The `mlxtend.frequent_patterns.association_rules` function has a new metric - Zhangs Metric, which measures both association and dissociation. ([#980](https://github.com/rasbt/mlxtend/pull/980))
 
 
 ### Version 0.21.0 (09/17/2022)
@@ -37,7 +40,6 @@ Version 0.22.0dev (TBD)
 
 ##### New Features and Enhancements
 
-- The `mlxtend.frequent_patterns.association_rules` function has a new metric - Zhangs Metric, which measures both association and dissociation. ([#980](https://github.com/rasbt/mlxtend/pull/980))
 - The `mlxtend.evaluate.feature_importance_permutation` function has a new `feature_groups` argument to treat user-specified feature groups as single features, which is useful for one-hot encoded features. ([#955](https://github.com/rasbt/mlxtend/pull/955))
 - The `mlxtend.feature_selection.ExhaustiveFeatureSelector` and `SequentialFeatureSelector` also gained support for `feature_groups` with a behavior similar to the one described above.  ([#957](https://github.com/rasbt/mlxtend/pull/957) and [#965](https://github.com/rasbt/mlxtend/pull/965) via [Nima Sarajpoor](https://github.com/NimaSarajpoor))
 

--- a/mlxtend/classifier/ensemble_vote.py
+++ b/mlxtend/classifier/ensemble_vote.py
@@ -169,7 +169,7 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         self.le_.fit(y)
         self.classes_ = self.le_.classes_
 
-        if not self.fit_base_estimators:
+        if not self.fit_base_estimators and self.use_clones:
             warnings.warn(
                 "fit_base_estimators=False " "enforces use_clones to be `False`"
             )


### PR DESCRIPTION
### Description

What was done:
* Fixes #941 (Disable unnecessary warning in EnsembleVoteClassifier)
* Added it to changlog
* #980 'Enhancement: Zhangs metric' was placed in the wrong section in the change-log (was put under new features section of version **v0.20.0**, I moved it in to the right section (under new features section of **v0.21.0**)



### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
