### PR TITLE
Fix fpmax for sparse matrices

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,7 +25,7 @@ Version 0.22.0dev (TBD)
 ##### New Features and Enhancements
 
 - The `mlxtend.frequent_patterns.association_rules` function has a new metric - Zhangs Metric, which measures both association and dissociation. ([#980](https://github.com/rasbt/mlxtend/pull/980))
-
+- Internal `fpmax` code improvement that avoids casting a sparse DataFrame into a dense NumPy array. ([#1000](https://github.com/rasbt/mlxtend/pull/1000) via [Tim Kellogg](https://github.com/tkellogg))
 
 ### Version 0.21.0 (09/17/2022)
 

--- a/mlxtend/frequent_patterns/fpmax.py
+++ b/mlxtend/frequent_patterns/fpmax.py
@@ -87,10 +87,10 @@ def fpmax(df, min_support=0.5, use_colnames=False, max_len=None, verbose=0):
 
     tree, rank = fpc.setup_fptree(df, min_support)
 
-    minsup = math.ceil(min_support * len(df.values))  # min support as count
+    minsup = math.ceil(min_support * len(df))  # min support as count
     generator = fpmax_step(tree, minsup, MFITree(rank), colname_map, max_len, verbose)
 
-    return fpc.generate_itemsets(generator, len(df.values), colname_map)
+    return fpc.generate_itemsets(generator, len(df), colname_map)
 
 
 def fpmax_step(tree, minsup, mfit, colnames, max_len, verbose):


### PR DESCRIPTION
### Description

While the current functionality supports sparse matrices on an API level, it calls `pd.DataFrame.values` in order to get the number of rows in the DataFrame. Unfortunately, `.values` forces the entire DataFrame to be converted into a non-sparse 2D numpy array. So using sparse matrices to fix an OOM doesn't actually make the OOM go away. 

This fix is semantically identical, in Pandas terms, except that it doesn't materialize a dense array just to find it's length.

### Related issues or pull requests

N/A

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
    * NOTE: 5 tests don't pass, but that's consistent with the state prior to this change.
- [x] Checked for style issues by running `flake8 ./mlxtend`

