### PR TITLE
replace deprecated `np.float` dtype with `float`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: Format imports
         args: ["--project", "mlxtend", "--line-length", " 88", "--multi-line", "3", "--py", "39", "--profile", "black", "mlxtend/*black"]
         
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
         name: Format code
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         name: Check PEP8

--- a/docs/ipynb2markdown.py
+++ b/docs/ipynb2markdown.py
@@ -67,7 +67,6 @@ def ipynb_to_md(ipynb_path):
 
 
 if __name__ == "__main__":
-
     import argparse
 
     parser = argparse.ArgumentParser(

--- a/docs/make_api.py
+++ b/docs/make_api.py
@@ -260,7 +260,6 @@ def generate_api_docs(
     # get subpackages
     api_docs = {}
     for importer, pkg_name, is_pkg in pkgutil.iter_modules(package.__path__, prefix):
-
         if ignore_packages is not None and pkg_name in ignore_packages:
             if printlog:
                 print("ignored %s" % pkg_name)
@@ -372,7 +371,6 @@ def summarize_methdods_and_functions(
             new_output.append(str_above_header)
         for p in sorted(module_paths):
             with open(p, "r") as r:
-
                 new_output.extend(r.readlines())
                 new_output.extend(["\n", "\n", "\n"])
 
@@ -397,7 +395,6 @@ def summarize_methdods_and_functions(
 
 
 if __name__ == "__main__":
-
     import argparse
 
     parser = argparse.ArgumentParser(

--- a/docs/md2pdf.py
+++ b/docs/md2pdf.py
@@ -84,7 +84,6 @@ header-includes:
         with open(md_path, "r") as f_in:
             content = f_in.readlines()
             if md.startswith("user_guide"):
-
                 title = gen_title(md)
                 f_out.write(title + "\n")
                 if content[0].startswith("# "):

--- a/docs/mdx_math.py
+++ b/docs/mdx_math.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Math extension for Python-Markdown
 ==================================
@@ -80,7 +78,7 @@ class MathExtension(Extension):
                 return _wrap_node(node, "".join(m.group(2, 3, 4)), "div")
 
         inlinemathpatterns = (
-            Pattern(r"(?<!\\|\$)(\$)([^\$]+)(\$)"),  #  $...$
+            Pattern(r"(?<!\\|\$)(\$)([^\$]+)(\$)"),  # $...$
             Pattern(r"(?<!\\)(\\\()(.+?)(\\\))"),  # \(...\)
         )
         mathpatterns = (

--- a/mlxtend/_base/_base_model.py
+++ b/mlxtend/_base/_base_model.py
@@ -27,7 +27,7 @@ class _BaseModel(object):
         try:
             if y is None:
                 return
-        except (AttributeError):
+        except AttributeError:
             if not len(y.shape) == 1:
                 raise ValueError("y must be a 1D array.")
 

--- a/mlxtend/_base/tests/test_classifier.py
+++ b/mlxtend/_base/tests/test_classifier.py
@@ -44,7 +44,6 @@ def test_check_labels_not_ok_1():
     y = np.array([1, 3, 2])
     cl = BlankClassifier(print_progress=0, random_seed=1)
     with pytest.raises(AttributeError) as excinfo:
-
         cl._check_target_array(y, {(0, 1), (1, 2)})
         assert excinfo.value.message == (
             "Labels not in {(1, 2), (0, 1)}" ".\nFound (1, 2, 3)"

--- a/mlxtend/classifier/adaline.py
+++ b/mlxtend/classifier/adaline.py
@@ -62,7 +62,6 @@ class Adaline(_BaseModel, _IterativeModel, _Classifier):
     def __init__(
         self, eta=0.01, epochs=50, minibatches=None, random_seed=None, print_progress=0
     ):
-
         _BaseModel.__init__(self)
         _IterativeModel.__init__(self)
         _Classifier.__init__(self)
@@ -94,11 +93,9 @@ class Adaline(_BaseModel, _IterativeModel, _Classifier):
             self.init_time_ = time()
             rgen = np.random.RandomState(self.random_seed)
             for i in range(self.epochs):
-
                 for idx in self._yield_minibatches_idx(
                     rgen=rgen, n_batches=self.minibatches, data_ary=y_data, shuffle=True
                 ):
-
                     y_val = self._net_input(X[idx])
                     errors = y_data[idx] - y_val
                     self.w_ += self.eta * X[idx].T.dot(errors).reshape(self.w_.shape)

--- a/mlxtend/classifier/ensemble_vote.py
+++ b/mlxtend/classifier/ensemble_vote.py
@@ -117,7 +117,6 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
         use_clones=True,
         fit_base_estimators=True,
     ):
-
         self.clfs = clfs
         self.named_clfs = {key: value for key, value in _name_estimators(clfs)}
         self.voting = voting
@@ -185,7 +184,6 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
                 print("Fitting %d classifiers..." % (len(self.clfs)))
 
             for clf in self.clfs_:
-
                 if self.verbose > 0:
                     i = self.clfs_.index(clf) + 1
                     print(
@@ -227,7 +225,6 @@ class EnsembleVoteClassifier(BaseEstimator, ClassifierMixin, TransformerMixin):
             )
 
         if self.voting == "soft":
-
             maj = np.argmax(self.predict_proba(X), axis=1)
 
         else:  # 'hard' voting

--- a/mlxtend/classifier/logistic_regression.py
+++ b/mlxtend/classifier/logistic_regression.py
@@ -78,7 +78,6 @@ class LogisticRegression(_BaseModel, _IterativeModel, _Classifier):
         random_seed=None,
         print_progress=0,
     ):
-
         _BaseModel.__init__(self)
         _IterativeModel.__init__(self)
         _Classifier.__init__(self)
@@ -103,7 +102,6 @@ class LogisticRegression(_BaseModel, _IterativeModel, _Classifier):
         return grad_loss_wrt_w, grad_loss_wrt_b
 
     def _fit(self, X, y, init_params=True):
-
         self._check_target_array(y, allowed={(0, 1)})
 
         if init_params:
@@ -117,11 +115,9 @@ class LogisticRegression(_BaseModel, _IterativeModel, _Classifier):
         self.init_time_ = time()
         rgen = np.random.RandomState(self.random_seed)
         for i in range(self.epochs):
-
             for idx in self._yield_minibatches_idx(
                 rgen=rgen, n_batches=self.minibatches, data_ary=y, shuffle=True
             ):
-
                 y_val = self._forward(X[idx])
                 grad_loss_wrt_w, grad_loss_wrt_b = self._backward(
                     X[idx], y_true=y[idx], y_probas=y_val

--- a/mlxtend/classifier/multilayerperceptron.py
+++ b/mlxtend/classifier/multilayerperceptron.py
@@ -94,7 +94,6 @@ class MultiLayerPerceptron(
         random_seed=None,
         print_progress=0,
     ):
-
         _BaseModel.__init__(self)
         _Classifier.__init__(self)
         _IterativeModel.__init__(self)
@@ -117,7 +116,6 @@ class MultiLayerPerceptron(
         self._is_fitted = False
 
     def _fit(self, X, y, init_params=True):
-
         self._check_target_array(y)
 
         if init_params:
@@ -155,7 +153,6 @@ class MultiLayerPerceptron(
             for idx in self._yield_minibatches_idx(
                 rgen=rgen, n_batches=self.minibatches, data_ary=y, shuffle=True
             ):
-
                 net_1, act_1, net_out, act_out = self._feedforward(X[idx])
 
                 # GRADIENTS VIA BACKPROPAGATION
@@ -225,7 +222,6 @@ class MultiLayerPerceptron(
         return self
 
     def _feedforward(self, X):
-
         # [n_samples, n_features] dot [n_features, n_hidden]
         # -> [n_samples, n_hidden]
         net_1 = np.dot(X, self.w_["1"]) + self.b_["1"]

--- a/mlxtend/classifier/oner.py
+++ b/mlxtend/classifier/oner.py
@@ -59,7 +59,6 @@ class OneRClassifier(BaseEstimator, ClassifierMixin):
     """
 
     def __init__(self, resolve_ties="first"):
-
         allowed = {"first", "chi-squared"}
         if resolve_ties not in allowed:
             raise ValueError(
@@ -106,10 +105,8 @@ class OneRClassifier(BaseEstimator, ClassifierMixin):
 
         # iterate over features
         for feature_index in np.arange(X.shape[1]):
-
             # iterate over each possible value per feature
             for feature_value in np.unique(X[:, feature_index]):
-
                 class_counts = compute_class_counts(X, y, feature_index, feature_value)
                 most_frequent_class = np.argmax(class_counts)
                 self.class_labels_ = np.unique(y)
@@ -142,7 +139,6 @@ class OneRClassifier(BaseEstimator, ClassifierMixin):
                     best_idx[-1] = i
 
             if self.resolve_ties == "chi-squared":
-
                 # collect duplicates
                 for i in prediction_dict:
                     if i == best_idx[-1]:
@@ -152,7 +148,6 @@ class OneRClassifier(BaseEstimator, ClassifierMixin):
 
                 p_values = []
                 for feature_idx in best_idx:
-
                     rules = prediction_dict[feature_idx]["rules (value: class)"]
 
                     # contingency table for a given feature

--- a/mlxtend/classifier/perceptron.py
+++ b/mlxtend/classifier/perceptron.py
@@ -53,7 +53,6 @@ class Perceptron(_BaseModel, _IterativeModel, _Classifier):
     """
 
     def __init__(self, eta=0.1, epochs=50, random_seed=None, print_progress=0):
-
         _BaseModel.__init__(self)
         _IterativeModel.__init__(self)
         _Classifier.__init__(self)
@@ -84,7 +83,6 @@ class Perceptron(_BaseModel, _IterativeModel, _Classifier):
             for idx in self._yield_minibatches_idx(
                 rgen=rgen, n_batches=y_data.shape[0], data_ary=y_data, shuffle=True
             ):
-
                 update = self.eta * (y_data[idx] - self._to_classlabels(X[idx]))
                 self.w_ += (update * X[idx]).reshape(self.w_.shape)
                 self.b_ += update

--- a/mlxtend/classifier/softmax_regression.py
+++ b/mlxtend/classifier/softmax_regression.py
@@ -82,7 +82,6 @@ class SoftmaxRegression(_BaseModel, _IterativeModel, _Classifier, _MultiClass):
         random_seed=None,
         print_progress=0,
     ):
-
         _BaseModel.__init__(self)
         _IterativeModel.__init__(self)
         _Classifier.__init__(self)
@@ -123,7 +122,6 @@ class SoftmaxRegression(_BaseModel, _IterativeModel, _Classifier, _MultiClass):
         return a
 
     def _backward(self, X, y_true, y_probas):
-
         grad_loss_wrt_out = y_true - y_probas
         # gradient -> n_features x n_classes
         grad_loss_wrt_w = -np.dot(X.T, grad_loss_wrt_out)
@@ -152,7 +150,6 @@ class SoftmaxRegression(_BaseModel, _IterativeModel, _Classifier, _MultiClass):
             for idx in self._yield_minibatches_idx(
                 rgen=rgen, n_batches=self.minibatches, data_ary=y, shuffle=True
             ):
-
                 # net_input, softmax and diff -> n_samples x n_classes:
                 y_probas = self._forward(X[idx])
 

--- a/mlxtend/classifier/stacking_classification.py
+++ b/mlxtend/classifier/stacking_classification.py
@@ -120,7 +120,6 @@ class StackingClassifier(_BaseXComposition, _BaseStackingClassifier, Transformer
         use_clones=True,
         fit_base_estimators=True,
     ):
-
         self.classifiers = classifiers
         self.meta_classifier = meta_classifier
         self.use_probas = use_probas
@@ -182,7 +181,6 @@ class StackingClassifier(_BaseXComposition, _BaseStackingClassifier, Transformer
                 print("Fitting %d classifiers..." % (len(self.classifiers)))
 
             for clf in self.clfs_:
-
                 if self.verbose > 0:
                     i = self.clfs_.index(clf) + 1
                     print(

--- a/mlxtend/classifier/stacking_cv_classification.py
+++ b/mlxtend/classifier/stacking_cv_classification.py
@@ -159,7 +159,6 @@ class StackingCVClassifier(
         n_jobs=None,
         pre_dispatch="2*n_jobs",
     ):
-
         self.classifiers = classifiers
         self.meta_classifier = meta_classifier
         self.use_probas = use_probas
@@ -243,7 +242,6 @@ class StackingCVClassifier(
         meta_features = None
 
         for n, model in enumerate(self.clfs_):
-
             if self.verbose > 0:
                 i = self.clfs_.index(model) + 1
                 print(

--- a/mlxtend/classifier/tests/test_ensemble_vote_classifier.py
+++ b/mlxtend/classifier/tests/test_ensemble_vote_classifier.py
@@ -27,7 +27,6 @@ X = X[:, 1:3]
 
 
 def test_EnsembleVoteClassifier():
-
     np.random.seed(123)
     clf1 = LogisticRegression(solver="liblinear", multi_class="ovr")
     clf2 = RandomForestClassifier(n_estimators=10)
@@ -164,7 +163,6 @@ def test_1model_probas():
 
 
 def test_EnsembleVoteClassifier_weights():
-
     np.random.seed(123)
     clf1 = LogisticRegression(solver="liblinear", multi_class="ovr")
     clf2 = RandomForestClassifier(n_estimators=10)
@@ -179,7 +177,6 @@ def test_EnsembleVoteClassifier_weights():
 
 
 def test_EnsembleVoteClassifier_gridsearch():
-
     clf1 = LogisticRegression(solver="liblinear", multi_class="ovr", random_state=1)
     clf2 = RandomForestClassifier(random_state=1)
     clf3 = GaussianNB()
@@ -204,7 +201,6 @@ def test_EnsembleVoteClassifier_gridsearch():
 
 
 def test_EnsembleVoteClassifier_gridsearch_enumerate_names():
-
     clf1 = LogisticRegression(solver="liblinear", multi_class="ovr", random_state=1)
     clf2 = RandomForestClassifier(random_state=1)
     eclf = EnsembleVoteClassifier(clfs=[clf1, clf1, clf2])
@@ -300,7 +296,6 @@ def test_string_labels_python_list():
 
 
 def test_clone():
-
     clf1 = LogisticRegression(solver="liblinear", multi_class="ovr")
     clf2 = RandomForestClassifier(n_estimators=10)
     clf3 = GaussianNB()

--- a/mlxtend/classifier/tests/test_multilayerperceptron.py
+++ b/mlxtend/classifier/tests/test_multilayerperceptron.py
@@ -163,7 +163,6 @@ def test_retrain():
 
 
 def test_clone():
-
     mlp = MLP(epochs=5, eta=0.05, hidden_layers=[10], minibatches=len(y), random_seed=1)
 
     clone(mlp)

--- a/mlxtend/classifier/tests/test_stacking_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_classifier.py
@@ -162,7 +162,6 @@ def test_weight_unsupported_no_weight():
 
 
 def test_StackingClassifier_proba_avg_1():
-
     np.random.seed(123)
     meta = LogisticRegression(solver="liblinear", multi_class="ovr", random_state=1)
     clf1 = RandomForestClassifier(n_estimators=10)
@@ -177,7 +176,6 @@ def test_StackingClassifier_proba_avg_1():
 
 
 def test_StackingClassifier_proba_concat_1():
-
     np.random.seed(123)
     meta = LogisticRegression(solver="liblinear", multi_class="ovr")
     clf1 = RandomForestClassifier(n_estimators=10)

--- a/mlxtend/classifier/tests/test_stacking_cv_classifier.py
+++ b/mlxtend/classifier/tests/test_stacking_cv_classifier.py
@@ -172,7 +172,6 @@ def test_no_weight_support_with_no_weight():
 
 
 def test_StackingClassifier_proba():
-
     np.random.seed(12)
     meta = LogisticRegression(multi_class="ovr", solver="liblinear")
     clf1 = RandomForestClassifier(n_estimators=10)

--- a/mlxtend/cluster/kmeans.py
+++ b/mlxtend/cluster/kmeans.py
@@ -67,7 +67,6 @@ class Kmeans(_BaseModel, _Cluster, _IterativeModel):
         random_seed=None,
         print_progress=0,
     ):
-
         _BaseModel.__init__(self)
         _Cluster.__init__(self)
         _IterativeModel.__init__(self)

--- a/mlxtend/data/multiplexer.py
+++ b/mlxtend/data/multiplexer.py
@@ -97,7 +97,6 @@ def make_multiplexer_dataset(
         return all_bits, class_label
 
     while len(y_pos) < n_positives or len(y_neg) < n_negatives:
-
         all_bits, class_label = gen_randsample()
 
         if class_label and len(y_pos) < n_positives:

--- a/mlxtend/data/tests/test_multiplexer.py
+++ b/mlxtend/data/tests/test_multiplexer.py
@@ -15,7 +15,6 @@ from mlxtend.utils import assert_raises
 
 
 def test_defaults():
-
     X, y = make_multiplexer_dataset()
 
     assert X.shape == (100, 6), X.shape
@@ -25,7 +24,6 @@ def test_defaults():
 
 
 def test_invalid_address_bits():
-
     msg_1 = "address_bits must be an integer. Got <class 'float'>."
 
     # for Python 2.7:

--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -107,7 +107,6 @@ def bias_variance_decomp(
 
         # Keras support
         if estimator.__class__.__name__ in ["Sequential", "Functional"]:
-
             # reset model
             for ix, layer in enumerate(estimator.layers):
                 if hasattr(estimator.layers[ix], "kernel_initializer") and hasattr(

--- a/mlxtend/evaluate/bootstrap_point632.py
+++ b/mlxtend/evaluate/bootstrap_point632.py
@@ -201,7 +201,7 @@ def bootstrap_point632_score(
         predict_func = cloned_est.predict_proba
 
     oob = BootstrapOutOfBag(n_splits=n_splits, random_seed=random_seed)
-    scores = np.empty(dtype=np.float, shape=(n_splits,))
+    scores = np.empty(dtype=float, shape=(n_splits,))
     cnt = 0
 
     for train, test in oob.split(X):

--- a/mlxtend/evaluate/bootstrap_point632.py
+++ b/mlxtend/evaluate/bootstrap_point632.py
@@ -22,7 +22,7 @@ def _check_arrays(X, y=None):
     try:
         if y is None:
             return
-    except (AttributeError):
+    except AttributeError:
         if not len(y.shape) == 1:
             raise ValueError("y must be a 1D array.")
 

--- a/mlxtend/evaluate/counterfactual.py
+++ b/mlxtend/evaluate/counterfactual.py
@@ -20,7 +20,6 @@ def create_counterfactual(
     lammbda=0.1,
     random_seed=None,
 ):
-
     """
     Implementation of the counterfactual method by Wachter et al. 2017
 
@@ -100,7 +99,6 @@ def create_counterfactual(
         return np.sum(numerator / mad)
 
     def loss(x_counterfact, lammbda):
-
         if use_proba:
             y_predict = model.predict_proba(x_counterfact.reshape(1, -1)).flatten()[
                 y_desired

--- a/mlxtend/evaluate/f_test.py
+++ b/mlxtend/evaluate/f_test.py
@@ -184,7 +184,6 @@ def combined_ftest_5x2cv(estimator1, estimator2, X, y, scoring=None, random_seed
     differences = []
 
     def score_diff(X_1, X_2, y_1, y_2):
-
         estimator1.fit(X_1, y_1)
         estimator2.fit(X_1, y_1)
         est1_score = scorer(estimator1, X_2, y_2)
@@ -193,7 +192,6 @@ def combined_ftest_5x2cv(estimator1, estimator2, X, y, scoring=None, random_seed
         return score_diff
 
     for i in range(5):
-
         randint = rng.randint(low=0, high=32767)
         X_1, X_2, y_1, y_2 = train_test_split(X, y, test_size=0.5, random_state=randint)
 

--- a/mlxtend/evaluate/mcnemar.py
+++ b/mlxtend/evaluate/mcnemar.py
@@ -144,7 +144,6 @@ def mcnemar_tables(y_target, *y_model_predictions):
     tables = {}
 
     for comb in combinations(range(num_models), 2):
-
         tb = np.zeros((2, 2))
         model1_vs_true = (y_target == y_model_predictions[comb[0]]).astype(int)
         model2_vs_true = (y_target == y_model_predictions[comb[1]]).astype(int)

--- a/mlxtend/evaluate/permutation.py
+++ b/mlxtend/evaluate/permutation.py
@@ -91,7 +91,6 @@ def permutation_test(
         )
 
     if isinstance(func, str):
-
         if func not in ("x_mean != y_mean", "x_mean > y_mean", "x_mean < y_mean"):
             raise AttributeError(
                 "Provide a custom function"
@@ -146,7 +145,6 @@ def permutation_test(
     # time
 
     if method == "exact":
-
         if paired:
             for flip in product([True, False], repeat=m):
                 for i, f in enumerate(flip):

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -20,7 +20,6 @@ from mlxtend.evaluate import bias_variance_decomp
 
 
 def pandas_input_fail():
-
     X, y = iris_data()
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123, shuffle=True, stratify=y
@@ -37,7 +36,6 @@ def pandas_input_fail():
 
 
 def test_01_loss_tree():
-
     X, y = iris_data()
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123, shuffle=True, stratify=y
@@ -54,7 +52,6 @@ def test_01_loss_tree():
 
 
 def test_01_loss_bagging():
-
     X, y = iris_data()
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123, shuffle=True, stratify=y
@@ -72,7 +69,6 @@ def test_01_loss_bagging():
 
 
 def test_mse_tree():
-
     X, y = boston_housing_data()
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123, shuffle=True
@@ -89,7 +85,6 @@ def test_mse_tree():
 
 
 def test_mse_bagging():
-
     X, y = boston_housing_data()
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123, shuffle=True
@@ -120,7 +115,6 @@ else:
 
 @pytest.mark.skipif(TRAVIS or APPVEYOR, reason="TensorFlow dependency")
 def test_keras():
-
     import tensorflow as tf
 
     X, y = boston_housing_data()

--- a/mlxtend/evaluate/tests/test_cochran_q.py
+++ b/mlxtend/evaluate/tests/test_cochran_q.py
@@ -493,7 +493,6 @@ def test_on_dataset():
 
 
 def test_compare_to_mcnemar_on_2_models():
-
     y_true = np.array(
         [
             0,

--- a/mlxtend/evaluate/tests/test_feature_importance.py
+++ b/mlxtend/evaluate/tests/test_feature_importance.py
@@ -62,7 +62,6 @@ def test_metric_wrong():
 
 
 def test_classification():
-
     X, y = make_classification(
         n_samples=1000,
         n_features=6,
@@ -99,7 +98,6 @@ def test_classification():
 
 
 def test_regression():
-
     X, y = make_regression(
         n_samples=1000,
         n_features=5,
@@ -133,7 +131,6 @@ def test_regression():
 
 
 def test_regression_custom_r2():
-
     X, y = make_regression(
         n_samples=1000,
         n_features=5,
@@ -167,7 +164,6 @@ def test_regression_custom_r2():
 
 
 def test_regression_custom_mse():
-
     X, y = make_regression(
         n_samples=1000,
         n_features=5,
@@ -201,7 +197,6 @@ def test_regression_custom_mse():
 
 
 def test_n_rounds():
-
     X, y = make_classification(
         n_samples=1000,
         n_features=6,

--- a/mlxtend/evaluate/tests/test_lift_score.py
+++ b/mlxtend/evaluate/tests/test_lift_score.py
@@ -34,7 +34,6 @@ def test_multiclass_with_false_binary():
 
 
 def test_binary_with_numpy():
-
     y_targ = np.array([1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0])
     y_pred = np.array([1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0])
     x = 1.25

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -47,7 +47,6 @@ class GroupTimeSeriesSplit:
         shift_size=1,
         window_type="rolling",
     ):
-
         if (train_size is None) and (n_splits is None):
             raise ValueError("Either train_size or n_splits should be defined")
 

--- a/mlxtend/evaluate/ttest.py
+++ b/mlxtend/evaluate/ttest.py
@@ -103,7 +103,6 @@ def paired_ttest_resampled(
 
     score_diff = []
     for i in range(num_rounds):
-
         randint = rng.randint(low=0, high=32767)
 
         X_train, X_test, y_train, y_test = train_test_split(
@@ -305,7 +304,6 @@ def paired_ttest_5x2cv(estimator1, estimator2, X, y, scoring=None, random_seed=N
     first_diff = None
 
     def score_diff(X_1, X_2, y_1, y_2):
-
         estimator1.fit(X_1, y_1)
         estimator2.fit(X_1, y_1)
         est1_score = scorer(estimator1, X_2, y_2)
@@ -314,7 +312,6 @@ def paired_ttest_5x2cv(estimator1, estimator2, X, y, scoring=None, random_seed=N
         return score_diff
 
     for i in range(5):
-
         randint = rng.randint(low=0, high=32767)
         X_1, X_2, y_1, y_2 = train_test_split(X, y, test_size=0.5, random_state=randint)
 

--- a/mlxtend/externals/pyprind/prog_class.py
+++ b/mlxtend/externals/pyprind/prog_class.py
@@ -92,14 +92,13 @@ class Prog:
     def _check_stream(self):
         """Determines which output stream (stdout, stderr, or custom) to use"""
         if self.stream:
-
             try:
                 supported = "PYCHARM_HOSTED" in os.environ or os.isatty(
                     sys.stdout.fileno()
                 )
 
             # a fix for IPython notebook "IOStream has no fileno."
-            except (UnsupportedOperation):
+            except UnsupportedOperation:
                 supported = True
 
             else:

--- a/mlxtend/externals/pyprind/progbar.py
+++ b/mlxtend/externals/pyprind/progbar.py
@@ -98,7 +98,6 @@ class ProgBar(Prog):
             do_update = progress > self.last_progress
 
         if do_update and self.active:
-
             self._cache_progress_bar(progress)
             if self.track:
                 self._cache_eta()

--- a/mlxtend/externals/signature_py27.py
+++ b/mlxtend/externals/signature_py27.py
@@ -239,7 +239,6 @@ class Parameter(object):
     def __init__(
         self, name, kind, default=_empty, annotation=_empty, _partial_kwarg=False
     ):
-
         if kind not in (
             _POSITIONAL_ONLY,
             _POSITIONAL_OR_KEYWORD,

--- a/mlxtend/feature_extraction/base.py
+++ b/mlxtend/feature_extraction/base.py
@@ -23,7 +23,7 @@ class _BaseFeatureExtractor(object):
         try:
             if y is None:
                 return
-        except (AttributeError):
+        except AttributeError:
             if not len(y.shape) == 1:
                 raise ValueError("y must be a 1D array.")
 

--- a/mlxtend/feature_extraction/linear_discriminant_analysis.py
+++ b/mlxtend/feature_extraction/linear_discriminant_analysis.py
@@ -69,7 +69,6 @@ class LinearDiscriminantAnalysis(_BaseModel):
         return self
 
     def _fit(self, X, y, n_classes=None):
-
         if self.n_discriminants is None or self.n_discriminants > X.shape[1]:
             n_discriminants = X.shape[1]
         else:

--- a/mlxtend/feature_extraction/rbf_kernel_pca.py
+++ b/mlxtend/feature_extraction/rbf_kernel_pca.py
@@ -117,7 +117,6 @@ class RBFKernelPCA(_BaseModel):
         return K.T.dot(e_vecs / self.e_vals_[: e_vecs.shape[1]])
 
     def _kernel_matrix(self, X, gamma):
-
         # Calculating the squared Euclidean distances for every pair of points
         # in the MxN dimensional dataset.
         sq_dists = distance.pdist(X, "sqeuclidean")

--- a/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
+++ b/mlxtend/feature_extraction/tests/test_principal_component_analysis.py
@@ -53,7 +53,6 @@ def test_default_components_zero():
 
 
 def test_evals():
-
     pca = PCA(n_components=2, solver="eigen")
     pca.fit(X_std)
 
@@ -66,7 +65,6 @@ def test_evals():
 
 
 def test_loadings():
-
     expect = np.array(
         [
             [0.9, -0.4, -0.3, 0.0],

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -198,7 +198,6 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         fixed_features=None,
         feature_groups=None,
     ):
-
         self.estimator = estimator
         self.k_features = k_features
         self.forward = forward
@@ -589,7 +588,11 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
                                 new_feature_idx
                             }
 
-                        (k_idx_c, k_score_c, cv_scores_c,) = self._feature_selector(
+                        (
+                            k_idx_c,
+                            k_score_c,
+                            cv_scores_c,
+                        ) = self._feature_selector(
                             search_set,
                             must_include_set,
                             X=X_,

--- a/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
@@ -353,7 +353,6 @@ def test_regression():
 def test_clone_params_fail():
     class Perceptron(object):
         def __init__(self, eta=0.1, epochs=50, random_seed=None, print_progress=0):
-
             self.eta = eta
             self.epochs = epochs
             self.random_seed = random_seed
@@ -379,7 +378,6 @@ def test_clone_params_fail():
                 for idx in self._yield_minibatches_idx(
                     rgen=rgen, n_batches=y_data.shape[0], data_ary=y_data, shuffle=True
                 ):
-
                     update = self.eta * (y_data[idx] - self._to_classlabels(X[idx]))
                     self.w_ += (update * X[idx]).reshape(self.w_.shape)
                     self.b_ += update
@@ -499,7 +497,6 @@ def test_get_metric_dict_not_fitted():
 
 
 def test_check_pandas_dataframe_fit():
-
     knn = KNeighborsClassifier(n_neighbors=4)
     iris = load_iris()
     X = iris.data

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -501,7 +501,6 @@ def test_regression_in_range():
 def test_clone_params_fail():
     class Perceptron(object):
         def __init__(self, eta=0.1, epochs=50, random_seed=None, print_progress=0):
-
             self.eta = eta
             self.epochs = epochs
             self.random_seed = random_seed
@@ -527,7 +526,6 @@ def test_clone_params_fail():
                 for idx in self._yield_minibatches_idx(
                     rgen=rgen, n_batches=y_data.shape[0], data_ary=y_data, shuffle=True
                 ):
-
                     update = self.eta * (y_data[idx] - self._to_classlabels(X[idx]))
                     self.w_ += (update * X[idx]).reshape(self.w_.shape)
                     self.b_ += update
@@ -896,7 +894,6 @@ def test_invalid_estimator():
 
 
 def test_invalid_k_features():
-
     iris = load_iris()
     X = iris.data
     y = iris.target
@@ -912,7 +909,6 @@ def test_invalid_k_features():
 
 
 def test_verbose():
-
     iris = load_iris()
     X = iris.data
     y = iris.target

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector_fixed_features.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector_fixed_features.py
@@ -146,7 +146,6 @@ def test_run_floating_backward_with_range():
 
 
 def test_pandas():
-
     X_df = pd.DataFrame(
         X_iris, columns=["sepal length", "sepal width", "petal width", "petal width"]
     )

--- a/mlxtend/frequent_patterns/fpcommon.py
+++ b/mlxtend/frequent_patterns/fpcommon.py
@@ -80,7 +80,6 @@ def generate_itemsets(generator, num_itemsets, colname_map):
 
 
 def valid_input_check(df):
-
     if f"{type(df)}" == "<class 'pandas.core.frame.SparseDataFrame'>":
         msg = (
             "SparseDataFrame support has been deprecated in pandas 1.0,"

--- a/mlxtend/frequent_patterns/tests/test_association_rules.py
+++ b/mlxtend/frequent_patterns/tests/test_association_rules.py
@@ -193,7 +193,6 @@ def test_frozenset_selection():
 
 
 def test_override_metric_with_support():
-
     res_df = association_rules(df_freq_items_with_colnames, min_threshold=0.8)
     # default metric is confidence
     assert res_df.values.shape[0] == 9

--- a/mlxtend/frequent_patterns/tests/test_fpbase.py
+++ b/mlxtend/frequent_patterns/tests/test_fpbase.py
@@ -198,7 +198,6 @@ class FPTestEx1(object):
 
     def test_sparse_with_zero(self):
         if Version(pandas_version) < Version("1.2"):
-
             # needs to be revisited in future when pandas bug
             # in https://github.com/pandas-dev/pandas/issues/29814
             # is fixed

--- a/mlxtend/plotting/checkerboard.py
+++ b/mlxtend/plotting/checkerboard.py
@@ -76,7 +76,6 @@ def checkerboard_plot(
     width, height = 1.0 / n_cols, 1.0 / n_rows
 
     for (row_idx, col_idx), cell_val in np.ndenumerate(ary):
-
         idx = (col_idx + row_idx) % 2
         tb.add_cell(
             row_idx,

--- a/mlxtend/plotting/heatmap.py
+++ b/mlxtend/plotting/heatmap.py
@@ -85,7 +85,6 @@ def heatmap(
         )
 
     if column_names is not None and len(column_names) != matrix.shape[1]:
-
         raise AssertionError(
             f"len(column_names)"
             " (got {len(column_names)})"

--- a/mlxtend/plotting/plot_linear_regression.py
+++ b/mlxtend/plotting/plot_linear_regression.py
@@ -62,9 +62,9 @@ def plot_linear_regression(
 
     """
     if isinstance(X, list):
-        X = np.asarray(X, dtype=np.float)
+        X = np.asarray(X, dtype=float)
     if isinstance(y, list):
-        y = np.asarray(y, dtype=np.float)
+        y = np.asarray(y, dtype=float)
     if len(X.shape) == 1:
         X = X[:, np.newaxis]
 

--- a/mlxtend/plotting/scatter.py
+++ b/mlxtend/plotting/scatter.py
@@ -79,7 +79,6 @@ def category_scatter(
         raise ValueError("df must be pandas.DataFrame or numpy.ndarray object")
 
     for lab in labels:
-
         if frame:
             x_dat = data.loc[data.loc[:, label_col] == lab, x]
             y_dat = data.loc[data.loc[:, label_col] == lab, y]

--- a/mlxtend/plotting/stacked_barplot.py
+++ b/mlxtend/plotting/stacked_barplot.py
@@ -79,7 +79,6 @@ def stacked_barplot(
     )
 
     for i, c in enumerate(df.columns[1:]):
-
         bar_pos = [p + width * (i + 1) for p in pos]
         label_pos.append(bar_pos)
         plt.bar(

--- a/mlxtend/plotting/tests/test_checkerboard.py
+++ b/mlxtend/plotting/tests/test_checkerboard.py
@@ -13,7 +13,6 @@ plt.switch_backend("agg")
 
 
 def test_runs():
-
     ary = np.random.random((6, 4))
     checkerboard_plot(
         ary,

--- a/mlxtend/plotting/tests/test_ecdf.py
+++ b/mlxtend/plotting/tests/test_ecdf.py
@@ -9,7 +9,6 @@ from mlxtend.plotting import ecdf
 
 
 def test_threshold():
-
     X, y = iris_data()
     ax, threshold, count = ecdf(x=X[:, 0], x_label="sepal length (cm)", percentile=0.8)
     assert threshold == 6.5

--- a/mlxtend/plotting/tests/test_heatmap.py
+++ b/mlxtend/plotting/tests/test_heatmap.py
@@ -18,9 +18,7 @@ def test_defaults():
 
 
 def test_wrong_column_name_number():
-
     with pytest.raises(AssertionError) as excinfo:
-
         heatmap(np.random.random((10, 5)), column_names=["a", "b", "c"])
         assert excinfo.value.message == (
             "len(column_names) (got 3)"
@@ -32,7 +30,6 @@ def test_wrong_column_name_number():
 
 def test_wrong_row_name_number():
     with pytest.raises(AssertionError) as excinfo:
-
         heatmap(np.random.random((10, 5)), row_names=["a", "b", "c"])
         assert excinfo.value.message == (
             "len(column_names) (got 3)"

--- a/mlxtend/plotting/tests/test_learning_curves.py
+++ b/mlxtend/plotting/tests/test_learning_curves.py
@@ -13,7 +13,6 @@ from mlxtend.plotting import plot_learning_curves
 
 
 def test_training_size():
-
     iris = datasets.load_iris()
     X = iris.data
     y = iris.target

--- a/mlxtend/plotting/tests/test_pca_corr_graph.py
+++ b/mlxtend/plotting/tests/test_pca_corr_graph.py
@@ -33,7 +33,6 @@ def test_X_PCA_but_no_explained_variance():
         match="If `X_pca` is not None, the `explained variance` "
         "values should not be `None`.",
     ):
-
         X, y = iris_data()
         pca = PCA(n_components=2)
         X_pca = pca.fit_transform(X)
@@ -52,7 +51,6 @@ def test_no_X_PCA_but_explained_variance():
         match="If `explained variance` is not None, the "
         "`X_pca` values should not be `None`.",
     ):
-
         X, y = iris_data()
         pca = PCA(n_components=2)
         pca.fit(X)
@@ -72,7 +70,6 @@ def test_not_enough_components():
         " of eigenvalues. Got 2 != 1"
     )
     with pytest.raises(ValueError, match=s):
-
         X, y = iris_data()
         pca = PCA(n_components=2)
         X_pca = pca.fit_transform(X)

--- a/mlxtend/preprocessing/tests/test_transactionencoder.py
+++ b/mlxtend/preprocessing/tests/test_transactionencoder.py
@@ -84,7 +84,6 @@ def test_inverse_transform():
 
 
 def test_cloning():
-
     oht = TransactionEncoder()
     oht.fit(dataset)
     oht2 = clone(oht)

--- a/mlxtend/regressor/linear_regression.py
+++ b/mlxtend/regressor/linear_regression.py
@@ -76,7 +76,6 @@ class LinearRegression(_BaseModel, _IterativeModel, _Regressor):
         random_seed=None,
         print_progress=0,
     ):
-
         _BaseModel.__init__(self)
         _IterativeModel.__init__(self)
         _Regressor.__init__(self)
@@ -104,7 +103,6 @@ class LinearRegression(_BaseModel, _IterativeModel, _Regressor):
             )
 
     def _fit(self, X, y, init_params=True):
-
         if init_params:
             self.b_, self.w_ = self._init_params(
                 weights_shape=(X.shape[1], 1),
@@ -121,11 +119,9 @@ class LinearRegression(_BaseModel, _IterativeModel, _Regressor):
             self.init_time_ = time()
             rgen = np.random.RandomState(self.random_seed)
             for i in range(self.epochs):
-
                 for idx in self._yield_minibatches_idx(
                     rgen=rgen, n_batches=self.minibatches, data_ary=y, shuffle=True
                 ):
-
                     y_val = self._net_input(X[idx])
                     errors = y[idx] - y_val
                     self.w_ += self.eta * X[idx].T.dot(errors).reshape(self.w_.shape)

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -137,7 +137,6 @@ class StackingCVRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
         pre_dispatch="2*n_jobs",
         multi_output=False,
     ):
-
         self.regressors = regressors
         self.meta_regressor = meta_regressor
         self.cv = cv

--- a/mlxtend/regressor/stacking_regression.py
+++ b/mlxtend/regressor/stacking_regression.py
@@ -104,7 +104,6 @@ class StackingRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
         refit=True,
         multi_output=False,
     ):
-
         self.regressors = regressors
         self.meta_regressor = meta_regressor
         self.verbose = verbose
@@ -160,7 +159,6 @@ class StackingRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
             print("Fitting %d regressors..." % (len(self.regressors)))
 
         for regr in self.regr_:
-
             if self.verbose > 0:
                 i = self.regr_.index(regr) + 1
                 print(

--- a/mlxtend/text/tests/test_generalize_names.py
+++ b/mlxtend/text/tests/test_generalize_names.py
@@ -9,7 +9,6 @@ from mlxtend.text import generalize_names
 
 
 def test_generalize_names():
-
     assert generalize_names("Samuel Eto'o") == "etoo s"
     assert generalize_names("Eto'o, Samuel") == "etoo s"
     assert generalize_names("Eto'o, Samuel") == "etoo s"

--- a/mlxtend/text/tests/test_generalize_names_duplcheck.py
+++ b/mlxtend/text/tests/test_generalize_names_duplcheck.py
@@ -14,7 +14,6 @@ from mlxtend.text import generalize_names, generalize_names_duplcheck
 
 
 def test_generalize_names_duplcheck():
-
     df = pd.read_csv(StringIO(csv))
 
     # duplicates before

--- a/mlxtend/utils/checking.py
+++ b/mlxtend/utils/checking.py
@@ -10,7 +10,6 @@ import numpy as np
 
 
 def check_Xy(X, y, y_int=True):
-
     # check types
     if not isinstance(X, np.ndarray):
         raise ValueError("X must be a NumPy array. Found %s" % type(X))

--- a/mlxtend/utils/tests/test_checking_inputs.py
+++ b/mlxtend/utils/tests/test_checking_inputs.py
@@ -56,7 +56,6 @@ def test_check_Xy_invalid_dtype_X():
 
 
 def test_check_Xy_invalid_dtype_y():
-
     if sys.version_info > (3, 0):
         expect = (
             "y must be an integer array. Found <U1. "


### PR DESCRIPTION
### Description

`np.float` is deprecated since numpy 1.20.0.
I replaced `np.float` with `float` (as suggested in the Numpy docs).

### Related issues or pull requests

Fixes #1016 

### Pull Request Checklist

- [ ] ~~Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)~~
- [ ] ~~Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)~~
- [ ] ~~Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)~~
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
