### PR TITLE
Fixed incorrect test codes.

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,7 +27,9 @@ jobs:
         conda env update --file environment.yml --name base
     - name: Test with pytest
       run: |
+        conda update conda -y -q
         conda config --add channels conda-forge
+        conda update conda -y -q
         conda install scikit-learn=1.0.2 pandas=1.3.5  -y -q
         conda install tensorflow joblib pytest -y -q
         conda install imageio scikit-image -y -q

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/mlxtend/frequent_patterns/tests/test_fpbase.py
+++ b/mlxtend/frequent_patterns/tests/test_fpbase.py
@@ -104,12 +104,12 @@ class FPTestErrors(object):
         test_with_dataframe(sdf)
 
     def test_sparsedataframe_notzero_column(self):
-        dfs = self.df.astype(pd.SparseDtype("int", np.nan))
+        dfs = self.df.astype(pd.SparseDtype("int", 0))
 
         dfs.columns = [i for i in range(len(dfs.columns))]
         self.fpalgo(dfs)
 
-        dfs = self.df.astype(pd.SparseDtype("int", np.nan))
+        dfs = self.df.astype(pd.SparseDtype("int", 0))
 
         dfs.columns = [i + 1 for i in range(len(dfs.columns))]
         assert_raises(
@@ -334,5 +334,10 @@ def compare_dataframes(df1, df2):
     rows1 = sorted(zip(itemsets1, df1["support"]))
     rows2 = sorted(zip(itemsets2, df2["support"]))
 
-    for r1, r2 in zip(rows1, rows2):
-        assert_array_equal(r1, r2)
+    for row1, row2 in zip(rows1, rows2):
+        if row1[0] != row2[0]:
+            msg = f"Expected different frequent itemsets\nx:{row1[0]}\ny:{row2[0]}"
+            raise AssertionError(msg)
+        elif row1[1] != row2[1]:
+            msg = f"Expected different support\nx:{row1[1]}\ny:{row2[1]}"
+            raise AssertionError(msg)

--- a/mlxtend/frequent_patterns/tests/test_hmine.py
+++ b/mlxtend/frequent_patterns/tests/test_hmine.py
@@ -13,6 +13,7 @@ from test_fpbase import (
     FPTestEx1All,
     FPTestEx2All,
     FPTestEx3All,
+    compare_dataframes,
 )
 
 from mlxtend.frequent_patterns import apriori, fpgrowth, hmine
@@ -176,23 +177,9 @@ class TestCorrect(unittest.TestCase):
         for algo in algorithms.keys():
             self.setUp()
             res_df = algo(self.df, min_support=0.6)
-            compare_df(res_df, expect)
+            compare_dataframes(res_df, expect)
             algorithms[algo] = res_df
 
-        compare_df(algorithms[hmine], algorithms[fpgrowth])
-        compare_df(algorithms[hmine], algorithms[apriori])
-        compare_df(algorithms[fpgrowth], algorithms[apriori])
-
-
-def compare_df(df1, df2):
-    itemsets1 = [sorted(list(i)) for i in df1["itemsets"]]
-    itemsets2 = [sorted(list(i)) for i in df2["itemsets"]]
-    rows1 = sorted(zip(itemsets1, df1["support"]))
-    rows2 = sorted(zip(itemsets2, df2["support"]))
-    for row1, row2 in zip(rows1, rows2):
-        if row1[0] != row2[0]:
-            msg = f"Expected different frequent itemsets\nx:{row1[0]}\ny:{row2[0]}"
-            raise AssertionError(msg)
-        elif row1[1] != row2[1]:
-            msg = f"Expected different support\nx:{row1[1]}\ny:{row2[1]}"
-            raise AssertionError(msg)
+        compare_dataframes(algorithms[hmine], algorithms[fpgrowth])
+        compare_dataframes(algorithms[hmine], algorithms[apriori])
+        compare_dataframes(algorithms[fpgrowth], algorithms[apriori])


### PR DESCRIPTION
### Code of Conduct
Fix.
<!-- 
If this is your first Pull Request for the MLxtend repository, please review
the code of conduct, which is available at https://rasbt.github.io/mlxtend/Code-of-Conduct/. 
-->


### Description
Test codes with errors (or usage may have changed) have been fixed.
<!--  
Please insert a brief description of the Pull request below.
-->

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->
None
### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://rasbt.github.io/mlxtend/contributing/.
-->

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
