### PR TITLE
Sklearn normalize depreciation fix

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -806,6 +806,7 @@ imput arrays via `transform` and `fit_transform`
 - Sequential Feature Selection algorithms were unified into a single `SequentialFeatureSelector` class with parameters to enable floating selection and toggle between forward and backward selection.
 - Stratified sampling of MNIST (now 500x random samples from each of the 10 digit categories)
 - Renaming `mlxtend.plotting` to `mlxtend.general_plotting` in order to distinguish general plotting function from specialized utility function such as `evaluate.plot_decision_regions`
+- Changing the signature of the `LinearRegression` model of sklearn and removing `normalize` parameter as it is depreciated.
 
 ### Version 0.2.9 (2015-07-14)
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -19,7 +19,7 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- ...
+- Changed the signature of the `LinearRegression` model of sklearn in the test removing the `normalize` parameter as it is deprecated. ([#1036](https://github.com/rasbt/mlxtend/issues/1036))
 
 ##### New Features and Enhancements
 
@@ -806,7 +806,6 @@ imput arrays via `transform` and `fit_transform`
 - Sequential Feature Selection algorithms were unified into a single `SequentialFeatureSelector` class with parameters to enable floating selection and toggle between forward and backward selection.
 - Stratified sampling of MNIST (now 500x random samples from each of the 10 digit categories)
 - Renaming `mlxtend.plotting` to `mlxtend.general_plotting` in order to distinguish general plotting function from specialized utility function such as `evaluate.plot_decision_regions`
-- Changing the signature of the `LinearRegression` model of sklearn and removing `normalize` parameter as it is depreciated.
 
 ### Version 0.2.9 (2015-07-14)
 

--- a/mlxtend/regressor/tests/test_stacking_cv_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_cv_regression.py
@@ -84,7 +84,7 @@ def test_multivariate():
 def test_multivariate_class():
     lr = LinearRegression()
     ridge = Ridge(random_state=1)
-    meta = LinearRegression(normalize=True)
+    meta = LinearRegression()
     stregr = StackingCVRegressor(
         regressors=[lr, ridge], meta_regressor=meta, multi_output=True, random_state=0
     )

--- a/mlxtend/regressor/tests/test_stacking_regression.py
+++ b/mlxtend/regressor/tests/test_stacking_regression.py
@@ -58,7 +58,7 @@ def test_multivariate():
 def test_multivariate_class():
     lr = LinearRegression()
     ridge = Ridge(random_state=1)
-    meta = LinearRegression(normalize=True)
+    meta = LinearRegression()
     stregr = StackingRegressor(
         regressors=[lr, ridge], meta_regressor=meta, multi_output=True
     )


### PR DESCRIPTION

### Description

The new version of sklearn's LinearRegression does not allow `normalize` paramter which is depreciated in the newer versions. So I fixed that.

### Related issues or pull requests

`Fixes Arg normalize to sklearn.linear_model.LinearRegression has been removed in version 1.2 #1035`

### Pull Request Checklist



- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`

