### PR TITLE
Fixed load_boston test_exhaustive_feature_selector

### DIFF
--- a/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
@@ -4,7 +4,6 @@
 #
 # License: BSD 3 clause
 
-from mlxtend.data import boston_housing_data
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_almost_equal
@@ -17,6 +16,7 @@ from sklearn.model_selection import GroupKFold
 from sklearn.neighbors import KNeighborsClassifier
 
 from mlxtend.classifier import SoftmaxRegression
+from mlxtend.data import boston_housing_data
 from mlxtend.feature_selection import ExhaustiveFeatureSelector as EFS
 from mlxtend.utils import assert_raises
 

--- a/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
@@ -4,6 +4,7 @@
 #
 # License: BSD 3 clause
 
+from mlxtend.data import boston_housing_data
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_almost_equal
@@ -334,10 +335,8 @@ def test_fit_params():
 
 
 def test_regression():
-    data_url = "http://lib.stat.cmu.edu/datasets/boston"
-    raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
-    boston = raw_df.values[1::2, 2]
-    X, y = boston.data[:, [1, 2, 6, 8, 12]], boston.target
+    X, y = boston_housing_data()
+    X = X[:, [1, 2, 6, 8, 12]]
     lr = LinearRegression()
     efs_r = EFS(
         lr,

--- a/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_exhaustive_feature_selector.py
@@ -9,7 +9,7 @@ import pandas as pd
 from numpy.testing import assert_almost_equal
 from packaging.version import Version
 from sklearn import __version__ as sklearn_version
-from sklearn.datasets import load_boston, load_iris
+from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import GroupKFold
@@ -334,7 +334,9 @@ def test_fit_params():
 
 
 def test_regression():
-    boston = load_boston()
+    data_url = "http://lib.stat.cmu.edu/datasets/boston"
+    raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
+    boston = raw_df.values[1::2, 2]
     X, y = boston.data[:, [1, 2, 6, 8, 12]], boston.target
     lr = LinearRegression()
     efs_r = EFS(


### PR DESCRIPTION

### Description
I have fixed the one error in `test_exhaustive_feature_selector.py` regarding sklearn depreciation in version 1.2

### Related issues or pull requests

Fixes one of the issue of #889

### Pull Request Checklist
- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


