### PR TITLE
Replaced np.int and np.bool

### DIFF
--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -144,7 +144,7 @@ def bias_variance_decomp(
         var = np.zeros(pred.shape)
 
         for pred in all_pred:
-            var += (pred != main_predictions).astype(np.int)
+            var += (pred != main_predictions).astype(np.int_)
         var /= num_rounds
 
         avg_var = var.sum() / y_test.shape[0]

--- a/mlxtend/evaluate/holdout.py
+++ b/mlxtend/evaluate/holdout.py
@@ -164,7 +164,7 @@ class PredefinedHoldoutSplit(object):
         """
 
         ind = np.arange(X.shape[0])
-        train_mask = np.ones(X.shape[0], dtype=np.bool)
+        train_mask = np.ones(X.shape[0], dtype=np.bool_)
         train_mask[self.valid_indices] = False
         valid_mask = np.where(train_mask, False, True)
 


### PR DESCRIPTION

### Description

As in the issue `Leftover use of np.int and np.bool #1034` I have replaced the `np.int` and `np.bool`  with `np.int_` and `np.bool_` in the `bias_variance_decomp.py` and `holdout.py` files.

### Related issues or pull requests

Fixes Leftover use of np.int and np.bool #1034

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://rasbt.github.io/mlxtend/contributing/.
-->


- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


