### PR TITLE
Feature range parameter support

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -21,7 +21,7 @@ The CHANGELOG for the current development version is available at
 
 - Address NumPy deprecations to make mlxtend compatible to NumPy 1.24 
 - Changed the signature of the `LinearRegression` model of sklearn in the test removing the `normalize` parameter as it is deprecated. ([#1036](https://github.com/rasbt/mlxtend/issues/1036))
-
+- Added a new parameter called `feature_range` in the class `ExhaustiveFeatureSelector`
 ##### New Features and Enhancements
 
 - Document how to use `SequentialFeatureSelector` and multiclass ROC AUC. 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -21,7 +21,7 @@ The CHANGELOG for the current development version is available at
 
 - Address NumPy deprecations to make mlxtend compatible to NumPy 1.24 
 - Changed the signature of the `LinearRegression` model of sklearn in the test removing the `normalize` parameter as it is deprecated. ([#1036](https://github.com/rasbt/mlxtend/issues/1036))
-- Added a new parameter called `feature_range` in the class `ExhaustiveFeatureSelector`
+
 ##### New Features and Enhancements
 
 - Document how to use `SequentialFeatureSelector` and multiclass ROC AUC. 

--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -179,7 +179,7 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         clone_estimator=True,
         fixed_features=None,
         feature_groups=None,
-        feature_range=None
+        feature_range = None
     ):
         self.estimator = estimator
         self.min_features = min_features
@@ -403,8 +403,9 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
 
         # candidates in the following lines are the non-fixed-features candidates
         # (the fixed features will be added later to each combination)
-        if self.min_features is None and self.max_features is None:
-            if self.feature_range is None:
+        
+        if self.min_features == None and self.max_features == None:
+            if self.feature_range == None:
                 min_num_candidates = 1
                 max_num_candidates = 1
             elif self.feature_range == "all":

--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -169,8 +169,8 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
     def __init__(
         self,
         estimator,
-        min_features=1,
-        max_features=1,
+        min_features=None,
+        max_features=None,
         print_progress=True,
         scoring="accuracy",
         cv=5,
@@ -179,11 +179,13 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         clone_estimator=True,
         fixed_features=None,
         feature_groups=None,
+        feature_range = None
     ):
         self.estimator = estimator
         self.min_features = min_features
         self.max_features = max_features
         self.pre_dispatch = pre_dispatch
+        self.feature_range = feature_range
         # Want to raise meaningful error message if a
         # cross-validation generator is inputted
         if isinstance(cv, types.GeneratorType):
@@ -401,8 +403,26 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
 
         # candidates in the following lines are the non-fixed-features candidates
         # (the fixed features will be added later to each combination)
-        min_num_candidates = self.min_features - len(self.fixed_features_group_set)
-        max_num_candidates = self.max_features - len(self.fixed_features_group_set)
+        
+        if self.min_features == None and self.max_features == None:
+            if self.feature_range == None:
+                min_num_candidates = 1
+                max_num_candidates = 1
+            elif self.feature_range == "all":
+                min_num_candidates = 1
+                max_num_candidates = X.shape[1]
+            else:
+                try:
+                    min_num_candidates = self.feature_range[0]
+                    max_num_candidates = self.feature_range[1]
+                except ValueError:
+                    raise ValueError(
+                        """feature_range should be of tuple type. First argument should be
+                        minimum number of feature and second argument shoulf be maximum number of feature"""
+                    )
+        else:
+            min_num_candidates = self.min_features - len(self.fixed_features_group_set)
+            max_num_candidates = self.max_features - len(self.fixed_features_group_set)
         candidates = chain.from_iterable(
             combinations(non_fixed_groups, r=i)
             for i in range(min_num_candidates, max_num_candidates + 1)

--- a/mlxtend/feature_selection/exhaustive_feature_selector.py
+++ b/mlxtend/feature_selection/exhaustive_feature_selector.py
@@ -179,7 +179,7 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
         clone_estimator=True,
         fixed_features=None,
         feature_groups=None,
-        feature_range = None
+        feature_range=None
     ):
         self.estimator = estimator
         self.min_features = min_features
@@ -403,9 +403,8 @@ class ExhaustiveFeatureSelector(BaseEstimator, MetaEstimatorMixin):
 
         # candidates in the following lines are the non-fixed-features candidates
         # (the fixed features will be added later to each combination)
-        
-        if self.min_features == None and self.max_features == None:
-            if self.feature_range == None:
+        if self.min_features is None and self.max_features is None:
+            if self.feature_range is None:
                 min_num_candidates = 1
                 max_num_candidates = 1
             elif self.feature_range == "all":


### PR DESCRIPTION

### Description

As described in the issue `Replace min_features and max_features in ExhaustiveFeatureSelector by feature_range and recipe` #260 I have added support for new parameter `feature_range` in class `ExhaustiveFeatureSelector`.  The priority of the parameters is still the same so it does not break the code base.

### Related issues or pull requests

Fixes ``Replace min_features and max_features in ExhaustiveFeatureSelector by feature_range and recipe` #260 partially. still `recipe` parameter is remaining.

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://rasbt.github.io/mlxtend/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


