### PR TITLE
Don't include tests in built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,12 @@ platforms = ["any"]
 version = {attr = "mlxtend.__version__"}
 dependencies = {file = "requirements.txt"}
 
+[tool.setuptools.packages.find]
+include = ["mlxtend", "mlxtend.*"]
+namespaces = false
+
 [tool.setuptools.package-data]
-"*" = ["LICENSE-BSD3.txt", "LICENSE-CC-BY.txt", "README.md", "requirements.txt"]
+mlxtend = ["LICENSE-BSD3.txt", "LICENSE-CC-BY.txt", "README.md", "requirements.txt", "mlxtend/data/data/*"]
 
 [tool.pytest.ini_options]
 norecursedirs = [


### PR DESCRIPTION
Tests should be included in the source distribution but there is no reason to include them in the built wheel.

Disable implicit packages (directories without an `__init__.py` file) altogether by setting the following in `pyproject.toml`:

```toml
[tool.setuptools.packages.find]
include = ["mlxtend", "mlxtend.*"]
namespaces = false
```

I assume the files in `mlxtend/data/data` are still needed so I've modified the package data to include files in that directory.

Build log extract from master:

```sh
$ git clean -fdx && python -m build --wheel --no-isolation
Removing build/
Removing dist/
Removing mlxtend.egg-info/
* Getting build dependencies for wheel...
validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
validate_pyproject.api.load_builtin_plugin defines `tool.setuptools` schema
No `packages` or `py_modules` configuration, performing automatic discovery.
`flat-layout` detected -- analysing .
discovered packages -- ['mlxtend', 'mlxtend.classifier', 'mlxtend.math', 'mlxtend.cluster', 'mlxtend.externals', 'mlxtend._base', 'mlxtend.preprocessing', 'mlxtend.frequent_patterns', 'mlxtend.utils', 'mlxtend.text', 'mlxtend.file_io', 'mlxtend.evaluate', 'mlxtend.data', 'mlxtend.feature_extraction', 'mlxtend.feature_selection', 'mlxtend.regressor', 'mlxtend.plotting', 'mlxtend.classifier.tests', 'mlxtend.math.tests', 'mlxtend.cluster.tests', 'mlxtend.externals.pyprind', 'mlxtend._base.tests', 'mlxtend.preprocessing.tests', 'mlxtend.frequent_patterns.tests', 'mlxtend.utils.tests', 'mlxtend.text.tests', 'mlxtend.evaluate.tests', 'mlxtend.data.tests', 'mlxtend.data.data', 'mlxtend.feature_extraction.tests', 'mlxtend.feature_selection.tests', 'mlxtend.regressor.tests', 'mlxtend.plotting.tests', 'mlxtend.plotting.tests.data']
running egg_info
creating mlxtend.egg-info
writing mlxtend.egg-info/PKG-INFO
writing dependency_links to mlxtend.egg-info/dependency_links.txt
writing requirements to mlxtend.egg-info/requires.txt
writing top-level names to mlxtend.egg-info/top_level.txt
writing manifest file 'mlxtend.egg-info/SOURCES.txt'
reading manifest file 'mlxtend.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*.txt' under directory 'mlxtend/data'
adding license file 'LICENSE-BSD3.txt'
adding license file 'LICENSE-CC-BY.txt'
writing manifest file 'mlxtend.egg-info/SOURCES.txt'
* Building wheel...
validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
validate_pyproject.api.load_builtin_plugin defines `tool.setuptools` schema
No `packages` or `py_modules` configuration, performing automatic discovery.
`flat-layout` detected -- analysing .
discovered packages -- ['mlxtend', 'mlxtend.classifier', 'mlxtend.math', 'mlxtend.cluster', 'mlxtend.externals', 'mlxtend._base', 'mlxtend.preprocessing', 'mlxtend.frequent_patterns', 'mlxtend.utils', 'mlxtend.text', 'mlxtend.file_io', 'mlxtend.evaluate', 'mlxtend.data', 'mlxtend.feature_extraction', 'mlxtend.feature_selection', 'mlxtend.regressor', 'mlxtend.plotting', 'mlxtend.classifier.tests', 'mlxtend.math.tests', 'mlxtend.cluster.tests', 'mlxtend.externals.pyprind', 'mlxtend._base.tests', 'mlxtend.preprocessing.tests', 'mlxtend.frequent_patterns.tests', 'mlxtend.utils.tests', 'mlxtend.text.tests', 'mlxtend.evaluate.tests', 'mlxtend.data.tests', 'mlxtend.data.data', 'mlxtend.feature_extraction.tests', 'mlxtend.feature_selection.tests', 'mlxtend.regressor.tests', 'mlxtend.plotting.tests', 'mlxtend.plotting.tests.data']
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/mlxtend
...
adding 'mlxtend/utils/__init__.py'
adding 'mlxtend/utils/base_compostion.py'
adding 'mlxtend/utils/checking.py'
adding 'mlxtend/utils/counter.py'
adding 'mlxtend/utils/testing.py'
adding 'mlxtend/utils/tests/test_checking_inputs.py'
adding 'mlxtend/utils/tests/test_counter.py'
adding 'mlxtend/utils/tests/test_testing.py'
adding 'mlxtend-0.23.1.dist-info/LICENSE-BSD3.txt'
adding 'mlxtend-0.23.1.dist-info/LICENSE-CC-BY.txt'
adding 'mlxtend-0.23.1.dist-info/METADATA'
adding 'mlxtend-0.23.1.dist-info/WHEEL'
adding 'mlxtend-0.23.1.dist-info/top_level.txt'
adding 'mlxtend-0.23.1.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built mlxtend-0.23.1-py3-none-any.whl
```

Build log extract after my changes:

```sh
$ git clean -fdx && python -m build --wheel --no-isolation
Removing build/
Removing dist/
Removing mlxtend.egg-info/
* Getting build dependencies for wheel...
validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
validate_pyproject.api.load_builtin_plugin defines `tool.setuptools` schema
running egg_info
creating mlxtend.egg-info
writing mlxtend.egg-info/PKG-INFO
writing dependency_links to mlxtend.egg-info/dependency_links.txt
writing requirements to mlxtend.egg-info/requires.txt
writing top-level names to mlxtend.egg-info/top_level.txt
writing manifest file 'mlxtend.egg-info/SOURCES.txt'
reading manifest file 'mlxtend.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*.txt' under directory 'mlxtend/data'
adding license file 'LICENSE-BSD3.txt'
adding license file 'LICENSE-CC-BY.txt'
writing manifest file 'mlxtend.egg-info/SOURCES.txt'
* Building wheel...
validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
validate_pyproject.api.load_builtin_plugin defines `tool.setuptools` schema
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/mlxtend
...
adding 'mlxtend/utils/__init__.py'
adding 'mlxtend/utils/base_compostion.py'
adding 'mlxtend/utils/checking.py'
adding 'mlxtend/utils/counter.py'
adding 'mlxtend/utils/testing.py'
adding 'mlxtend-0.23.1.dist-info/LICENSE-BSD3.txt'
adding 'mlxtend-0.23.1.dist-info/LICENSE-CC-BY.txt'
adding 'mlxtend-0.23.1.dist-info/METADATA'
adding 'mlxtend-0.23.1.dist-info/WHEEL'
adding 'mlxtend-0.23.1.dist-info/top_level.txt'
adding 'mlxtend-0.23.1.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built mlxtend-0.23.1-py3-none-any.whl
```