### PR TITLE
Use scipy's decompositions in PCA.

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -31,7 +31,8 @@ The CHANGELOG for the current development version is available at
 
 ##### Changes
 
-- Add `n_classes_` attribute to stacking classifiers for compatibility with scikit-learn 1.3 ([#1091](https://github.com/rasbt/mlxtend/issues/1091)
+- Add `n_classes_` attribute to stacking classifiers for compatibility with scikit-learn 1.3 ([#1091](https://github.com/rasbt/mlxtend/issues/1091))
+- Use Scipy's instead of NumPy's decompositions in PCA for improved accuracy in edge cases ([#1080](https://github.com/rasbt/mlxtend/issues/1080) via [[fkdosilovic](https://github.com/rasbt/mlxtend/issues?q=is%3Apr+is%3Aopen+author%3Afkdosilovic)])
 
 
 

--- a/mlxtend/feature_extraction/principal_component_analysis.py
+++ b/mlxtend/feature_extraction/principal_component_analysis.py
@@ -7,6 +7,7 @@
 # License: BSD 3 clause
 
 import numpy as np
+import scipy as sp
 
 from .._base import _BaseModel
 
@@ -152,14 +153,14 @@ class PrincipalComponentAnalysis(_BaseModel):
 
     def _decomposition(self, mat, n_samples):
         if self.solver == "eigen":
-            e_vals, e_vecs = np.linalg.eig(mat)
+            e_vals, e_vecs = sp.linalg.eig(mat)
         elif self.solver == "svd":
             # Only SVD on mean centered data is equivalent to
             # PCA via covariance matrix (note that computing
-            # the covariance matrix will implicitely center
+            # the covariance matrix will implicitly center
             # the data)
             mat_centered = mat - mat.mean(axis=0)
-            u, s, v = np.linalg.svd(mat_centered.T)
+            u, s, _ = sp.linalg.svd(mat_centered.T, lapack_driver="gesvd")
             e_vecs, e_vals = u, s
             e_vals = e_vals**2 / (n_samples - 1)
             if e_vals.shape[0] < e_vecs.shape[1]:


### PR DESCRIPTION
### Description

Use scipy's decompositions in PCA.

### Related issues or pull requests

Fixes https://github.com/rasbt/mlxtend/issues/1078

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
