### PR TITLE
Refactor bias_variance_decomposition test.

### DIFF
--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -58,7 +58,7 @@ def test_01_loss_bagging():
     )
 
     tree = DecisionTreeClassifier(random_state=123)
-    bag = BaggingClassifier(base_estimator=tree, random_state=123)
+    bag = BaggingClassifier(estimator=tree, random_state=123)
     avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(
         bag, X_train, y_train, X_test, y_test, loss="0-1_loss", random_seed=123
     )
@@ -91,7 +91,7 @@ def test_mse_bagging():
     )
 
     tree = DecisionTreeRegressor(random_state=123)
-    bag = BaggingRegressor(base_estimator=tree, n_estimators=10, random_state=123)
+    bag = BaggingRegressor(estimator=tree, n_estimators=10, random_state=123)
 
     avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(
         bag, X_train, y_train, X_test, y_test, loss="mse", random_seed=123


### PR DESCRIPTION
### Description

Refactors two tests in `evaluate/tests/test_bias_variance_decomp.py` (change `base_estimator` to `estimator`). This fixes two failing unit tests.

### Related issues or pull requests

None.

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`

