### PR TITLE
Replace np.NINF with -np.inf

### DIFF
--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -651,7 +651,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         return self
 
     def finalize_fit(self):
-        max_score = np.NINF
+        max_score = -np.inf
         for k in self.subsets_:
             if (
                 k >= self.min_k
@@ -662,7 +662,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
                 best_subset = k
 
         k_score = max_score
-        if k_score == np.NINF:
+        if k_score == -np.inf:
             # i.e. all keys of self.subsets_ are not in interval `[self.min_k, self.max_k]`
             # this happens if KeyboardInterrupt happens
             keys = list(self.subsets_.keys())


### PR DESCRIPTION
### Description

This pull request addresses the issue #1100, where the `np.NINF` constant was removed in the NumPy 2.0 release, causing an `AttributeError`. The solution is to replace `np.NINF` with `-np.inf` in the `SequentialFeatureSelector` class to ensure compatibility with NumPy 2.0 and later versions.

### Code Change

- **Old line (causing error):**
  ```python
  max_score = np.NINF

 if k_score == np.NINF
  ```

- **New line (fix):**
  ```python
  max_score = -np.inf

   if k_score == -np.inf
  ```

### Related Issues or Pull Requests

- Fixes #1100

### Pull Request Checklist

- [x] Added a note about the modification to the `./docs/sources/CHANGELOG.md` file (if applicable).
- [x] Added appropriate unit tests in the `./mlxtend/*/tests` directories (if applicable).
- [x] Updated documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable).
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and ensured that all unit tests pass.
- [x] Checked for style issues by running `flake8 ./mlxtend`.

### Code of Conduct

- [x] I have reviewed and adhered to the [MLxtend Code of Conduct](https://rasbt.github.io/mlxtend/Code-of-Conduct/).
