### PR TITLE
SFS finalize_fit() support for numpy >= 2.0

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,6 +24,7 @@ Files updated:
   - ['mlxtend.frequent_patterns.fpgrowth'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpgrowth/)
   - ['mlxtend.frequent_patterns.fpmax'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpmax/)
   - [`mlxtend.feature_selection.SequentialFeatureSelector`](https://github.com/rasbt/mlxtend/blob/master/mlxtend/feature_selection/sequential_feature_selector.py)
+    - Updated negative infinity constant to be compatible with old and new (>=2.0) `numpy` versions
   - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
     - Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
   - Integrated scikit-learn's `set_output` method into `TransactionEncoder` ([#1087](https://github.com/rasbt/mlxtend/issues/1087) via [it176131](https://github.com/it176131))

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -24,8 +24,10 @@ Files updated:
   - ['mlxtend.frequent_patterns.fpgrowth'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpgrowth/)
   - ['mlxtend.frequent_patterns.fpmax'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpmax/)
   - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
-- [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
-- Integrated scikit-learn's `set_output` method into `TransactionEncoder` ([#1087](https://github.com/rasbt/mlxtend/issues/1087) via[it176131](https://github.com/it176131))
+  - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
+  - [`mlxtend.feature_selection.SequentialFeatureSelector`](https://github.com/rasbt/mlxtend/blob/master/mlxtend/feature_selection/sequential_feature_selector.py)
+  - Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
+  - Integrated scikit-learn's `set_output` method into `TransactionEncoder` ([#1087](https://github.com/rasbt/mlxtend/issues/1087) via [it176131](https://github.com/it176131))
 
 ##### Changes
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -23,10 +23,9 @@ Files updated:
   - ['mlxtend.frequent_patterns.fpcommon']
   - ['mlxtend.frequent_patterns.fpgrowth'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpgrowth/)
   - ['mlxtend.frequent_patterns.fpmax'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpmax/)
-  - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
-  - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
   - [`mlxtend.feature_selection.SequentialFeatureSelector`](https://github.com/rasbt/mlxtend/blob/master/mlxtend/feature_selection/sequential_feature_selector.py)
-  - Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
+  - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
+    - Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
   - Integrated scikit-learn's `set_output` method into `TransactionEncoder` ([#1087](https://github.com/rasbt/mlxtend/issues/1087) via [it176131](https://github.com/it176131))
 
 ##### Changes

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -654,7 +654,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         if np.__version__ < '2.0':
             ninf = np.NINF
         else:
-            ninf = -np.inf        
+            ninf = -np.inf
         max_score = ninf
         for k in self.subsets_:
             if (

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -654,8 +654,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         if np.__version__ < '2.0':
             ninf = np.NINF
         else:
-            ninf = -np.inf
-        
+            ninf = -np.inf        
         max_score = ninf
         for k in self.subsets_:
             if (

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -651,7 +651,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         return self
 
     def finalize_fit(self):
-        if np.__version__ < '2.0':
+        if np.__version__ < "2.0":
             ninf = np.NINF
         else:
             ninf = -np.inf

--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -651,7 +651,12 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         return self
 
     def finalize_fit(self):
-        max_score = np.NINF
+        if np.__version__ < '2.0':
+            ninf = np.NINF
+        else:
+            ninf = -np.inf
+        
+        max_score = ninf
         for k in self.subsets_:
             if (
                 k >= self.min_k
@@ -662,7 +667,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
                 best_subset = k
 
         k_score = max_score
-        if k_score == np.NINF:
+        if k_score == ninf:
             # i.e. all keys of self.subsets_ are not in interval `[self.min_k, self.max_k]`
             # this happens if KeyboardInterrupt happens
             keys = list(self.subsets_.keys())


### PR DESCRIPTION
### Description

Update numpy negative infinity constant for version compatibility for the sequential feature selector (SFS)

- Add version check to handle different numpy versions
- Use `np.NINF` for numpy <2.0 and `-np.inf` for numpy >=2.0
- Replace direct `np.NINF` usage with version-aware variable
- Maintain backward compatibility while supporting newer numpy versions

This change ensures the code works correctly across different numpy versions
while maintaining the same functionality.

### Related issues or pull requests

fixes #1100 related issue
#1104 similar but incomplete PR

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
