### PR TITLE
Fixed `_calc_score` for *scikit-learn* version compatibility

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -31,7 +31,6 @@ Files updated:
     - Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
   - Integrated scikit-learn's `set_output` method into `TransactionEncoder` ([#1087](https://github.com/rasbt/mlxtend/issues/1087) via [it176131](https://github.com/it176131))
 
-
 ##### Changes
 
 - [`mlxtend.frequent_patterns.fpcommon`] Added the null_values parameter in valid_input_check signature to check in case the input also includes null values. Changes the returns statements and function signatures for setup_fptree and generated_itemsets respectively to return the disabled array created and to include it as a parameter. Added code in [`mlxtend.frequent_patterns.fpcommon`] and [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/) to implement the algorithms in case null values exist when null_values is True.

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -23,11 +23,14 @@ Files updated:
   - ['mlxtend.frequent_patterns.fpcommon']
   - ['mlxtend.frequent_patterns.fpgrowth'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpgrowth/)
   - ['mlxtend.frequent_patterns.fpmax'](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/fpmax/)
+  - ['mlxtend/feature_selection/utilities.py'](https://github.com/rasbt/mlxtend/blob/master/mlxtend/feature_selection/utilities.py)
+      - Modified `_calc_score` function to ensure compatibility with *scikit-learn* versions 1.4 and above by dynamically selecting between `fit_params` and `params` in `cross_val_score`.
   - [`mlxtend.feature_selection.SequentialFeatureSelector`](https://github.com/rasbt/mlxtend/blob/master/mlxtend/feature_selection/sequential_feature_selector.py)
     - Updated negative infinity constant to be compatible with old and new (>=2.0) `numpy` versions
   - [`mlxtend.frequent_patterns.association_rules`](https://rasbt.github.io/mlxtend/user_guide/frequent_patterns/association_rules/)
     - Implemented three new metrics: Jaccard, Certainty, and Kulczynski. ([#1096](https://github.com/rasbt/mlxtend/issues/1096))
   - Integrated scikit-learn's `set_output` method into `TransactionEncoder` ([#1087](https://github.com/rasbt/mlxtend/issues/1087) via [it176131](https://github.com/it176131))
+
 
 ##### Changes
 

--- a/mlxtend/feature_selection/utilities.py
+++ b/mlxtend/feature_selection/utilities.py
@@ -94,7 +94,7 @@ def _calc_score(
 
     IDX = _merge_lists(feature_groups, indices)
 
-    param_name = 'fit_params' if sklearn_version < '1.4' else 'params'
+    param_name = "fit_params" if sklearn_version < "1.4" else "params"
 
     if selector.cv:
         scores = cross_val_score(

--- a/mlxtend/feature_selection/utilities.py
+++ b/mlxtend/feature_selection/utilities.py
@@ -1,7 +1,6 @@
-from copy import deepcopy
-
 import numpy as np
 from sklearn.model_selection import cross_val_score
+from sklearn import __version__ as sklearn_version
 
 
 def _merge_lists(nested_list, high_level_indices=None):
@@ -94,6 +93,9 @@ def _calc_score(
         feature_groups = [[i] for i in range(X.shape[1])]
 
     IDX = _merge_lists(feature_groups, indices)
+
+    param_name = 'fit_params' if sklearn_version < '1.4' else 'params'
+
     if selector.cv:
         scores = cross_val_score(
             selector.est_,
@@ -104,7 +106,7 @@ def _calc_score(
             scoring=selector.scorer,
             n_jobs=1,
             pre_dispatch=selector.pre_dispatch,
-            fit_params=fit_params,
+            **{param_name: fit_params}
         )
     else:
         selector.est_.fit(X[:, IDX], y, **fit_params)

--- a/mlxtend/feature_selection/utilities.py
+++ b/mlxtend/feature_selection/utilities.py
@@ -106,7 +106,7 @@ def _calc_score(
             scoring=selector.scorer,
             n_jobs=1,
             pre_dispatch=selector.pre_dispatch,
-            **{param_name: fit_params}
+            **{param_name: fit_params},
         )
     else:
         selector.est_.fit(X[:, IDX], y, **fit_params)

--- a/mlxtend/feature_selection/utilities.py
+++ b/mlxtend/feature_selection/utilities.py
@@ -1,6 +1,6 @@
 import numpy as np
-from sklearn.model_selection import cross_val_score
 from sklearn import __version__ as sklearn_version
+from sklearn.model_selection import cross_val_score
 
 
 def _merge_lists(nested_list, high_level_indices=None):


### PR DESCRIPTION
### Description

Refactor `_calc_score'` to accommodate scikit-learn versioning

- Updated `_calc_score` to dynamically select the appropriate parameter name (`'fit_params'` or `'params'`) for `cross_val_score` based on the *scikit-learn* version.
- Ensures compatibility with both older versions (below 1.4) and newer versions (1.4 and above) of *scikit-learn*

### Related issues or pull requests

fixes #1082 

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`