### PR TITLE
Improved `plot_splits` for time series splits

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -7,6 +7,19 @@ The CHANGELOG for the current development version is available at
 
 ---
 
+### Version 0.23.3  (tbd)
+
+##### Downloads
+...
+
+##### New Features and Enhancements
+
+Files updated:
+  - ['mlxtend.evaluate.time_series.plot_splits'](https://github.com/rasbt/mlxtend/blob/master/mlxtend/evaluate/time_series.py)
+    - Fixed and improved `plot_splits`
+
+##### Changes
+...
 
 ### Version 0.23.2  (5 Nov 2024)
 

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -16,7 +16,7 @@ The CHANGELOG for the current development version is available at
 
 Files updated:
   - ['mlxtend.evaluate.time_series.plot_splits'](https://github.com/rasbt/mlxtend/blob/master/mlxtend/evaluate/time_series.py)
-    - Fixed and improved `plot_splits`
+    - Fixed `test_end_idx` and improved `plot_splits`
 
 ##### Changes
 ...

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -16,7 +16,7 @@ The CHANGELOG for the current development version is available at
 
 Files updated:
   - ['mlxtend.evaluate.time_series.plot_splits'](https://github.com/rasbt/mlxtend/blob/master/mlxtend/evaluate/time_series.py)
-    - Fixed `test_end_idx` and improved `plot_splits`
+    - Improved `plot_splits` for better visualization of time series splits
 
 ##### Changes
 ...

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -129,7 +129,7 @@ class GroupTimeSeriesSplit:
                 test_idx = np.r_[
                     slice(
                         groups_dict[group_names[test_start_idx]],
-                        groups_dict[group_names[test_end_idx]] - 1,
+                        groups_dict[group_names[test_end_idx]],
                     )
                 ]
             else:

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -302,6 +302,7 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
     ax.legend(
         [Patch(color=cmap_cv(0.2)), Patch(color=cmap_cv(0.8))],
         ["Training set", "Testing set"],
+        title="Data Splits",
         loc=(1.02, 0.8),
         fontsize=13,
     )

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -308,6 +308,7 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
     )
 
     ax.set_title("{}\n{}".format(type(cv).__name__, cv_args), fontsize=15)
+    ax.set_xlim(0, len(X))
     ax.xaxis.set_major_locator(MaxNLocator(integer=True))
     ax.set_xlabel(xlabel="Sample index", fontsize=13)
     ax.set_ylabel(ylabel="CV iteration", fontsize=13)

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -308,13 +308,11 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
     )
 
     ax.set_title("{}\n{}".format(type(cv).__name__, cv_args), fontsize=15)
-    ax.xaxis.set_major_locator(MaxNLocator(min_n_ticks=len(X), integer=True))
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
     ax.set_xlabel(xlabel="Sample index", fontsize=13)
     ax.set_ylabel(ylabel="CV iteration", fontsize=13)
     ax.tick_params(axis="both", which="major", labelsize=13)
     ax.tick_params(axis="both", which="minor", labelsize=13)
-
-    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
 
     plt.tight_layout()
 

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -314,6 +314,8 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
     ax.tick_params(axis="both", which="major", labelsize=13)
     ax.tick_params(axis="both", which="minor", labelsize=13)
 
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+
     plt.tight_layout()
 
     if image_file_path:

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -299,11 +299,31 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
         xlim=[-0.5, len(indices) - 0.5],
     )
 
-    ax.legend(
+    legend_splits = ax.legend(
         [Patch(color=cmap_cv(0.2)), Patch(color=cmap_cv(0.8))],
         ["Training set", "Testing set"],
         title="Data Splits",
-        loc=(1.02, 0.8),
+        loc="upper right",
+        fontsize=13,
+    )
+
+    ax.add_artist(legend_splits)
+
+    group_labels = [f"{group}" for group in groups]
+    cmap = plt.cm.get_cmap("tab20", len(group_labels))
+
+    unique_patches = {}
+    for i in range(len(group_labels)):
+        if group_labels[i] not in unique_patches:
+            unique_patches[group_labels[i]] = Patch(
+                color=cmap(i), label=group_labels[i]
+            )
+
+    ax.legend(
+        handles=list(unique_patches.values()),
+        title="Groups",
+        loc="center left",
+        bbox_to_anchor=(1.02, 0.5),
         fontsize=13,
     )
 

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -290,7 +290,7 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
         s=marker_size,
     )
 
-    yticklabels = list(range(n_splits)) + ["group"]
+    yticklabels = list(range(1, n_splits + 1)) + ["group"]
     ax.set(
         yticks=np.arange(n_splits + 1) + 0.5,
         yticklabels=yticklabels,

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -129,7 +129,7 @@ class GroupTimeSeriesSplit:
                 test_idx = np.r_[
                     slice(
                         groups_dict[group_names[test_start_idx]],
-                        groups_dict[group_names[test_end_idx]],
+                        groups_dict[group_names[test_end_idx]] - 1,
                     )
                 ]
             else:

--- a/mlxtend/evaluate/time_series.py
+++ b/mlxtend/evaluate/time_series.py
@@ -309,15 +309,12 @@ def plot_split_indices(cv, cv_args, X, y, groups, n_splits, image_file_path=None
 
     ax.add_artist(legend_splits)
 
-    group_labels = [f"{group}" for group in groups]
+    group_labels = [f"{group}" for group in np.unique(groups)]
     cmap = plt.cm.get_cmap("tab20", len(group_labels))
 
     unique_patches = {}
-    for i in range(len(group_labels)):
-        if group_labels[i] not in unique_patches:
-            unique_patches[group_labels[i]] = Patch(
-                color=cmap(i), label=group_labels[i]
-            )
+    for i, group in enumerate(np.unique(groups)):
+        unique_patches[group] = Patch(color=cmap(i), label=f"{group}")
 
     ax.legend(
         handles=list(unique_patches.values()),


### PR DESCRIPTION
### Description

* added title to legend
* adjusted xticklabels for Sample Index not to intersect with each other anymore
* added legend for groups (setting it as xtick with xticklabels would be quite time-intense because the scale on the x-axis changes depending depending on the `window_type` (`'expanding'` or `'rolling'`).

![grafik](https://github.com/user-attachments/assets/e734c445-1264-49c4-8e13-e4db26e13879)

### Related issues or pull requests

fixes #1094 

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
