### PR TITLE
fix: *sklearn* version compability in `stacking_cv` params

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -7,6 +7,11 @@ The CHANGELOG for the current development version is available at
 
 ---
 
+##### Changes
+
+  - [`mlxtend/classifier/stacking_cv_classification.py`](https://github.com/rasbt/mlxtend/blob/master/mlxtend/classifier/stacking_cv_classification.py) and [`mlxtend/regressor/stacking_cv_regression.py`](https://github.com/rasbt/mlxtend/blob/master/mlxtend/regressor/stacking_cv_regression.py)
+      - Modified `meta_features` to ensure compatibility with *scikit-learn* versions 1.4 and above by dynamically selecting between `fit_params` and `params` in `cross_val_predict`.
+
 ### Version 0.24.4  (25 Nov 2025)
 
 ##### Downloads

--- a/mlxtend/classifier/stacking_cv_classification.py
+++ b/mlxtend/classifier/stacking_cv_classification.py
@@ -11,6 +11,7 @@
 
 import numpy as np
 from scipy import sparse
+from sklearn import __version__ as sklearn_version
 from sklearn.base import TransformerMixin, clone
 from sklearn.model_selection import cross_val_predict
 from sklearn.model_selection._split import check_cv
@@ -266,6 +267,7 @@ class StackingCVClassifier(
             if self.verbose > 1:
                 print(_name_estimators((model,))[0][1])
 
+            param_name = "fit_params" if sklearn_version < "1.4" else "params"
             prediction = cross_val_predict(
                 model,
                 X,
@@ -273,7 +275,7 @@ class StackingCVClassifier(
                 groups=groups,
                 cv=final_cv,
                 n_jobs=self.n_jobs,
-                fit_params=fit_params,
+                **{param_name: fit_params},
                 verbose=self.verbose,
                 pre_dispatch=self.pre_dispatch,
                 method="predict_proba" if self.use_probas else "predict",

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 from scipy import sparse
+from sklearn import __version__ as sklearn_version
 from sklearn.base import RegressorMixin, TransformerMixin, clone
 from sklearn.model_selection import cross_val_predict
 from sklearn.model_selection._split import check_cv
@@ -211,6 +212,7 @@ class StackingCVRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
             fit_params = None
         else:
             fit_params = dict(sample_weight=sample_weight)
+        param_name = "fit_params" if sklearn_version < "1.4" else "params"    
         meta_features = np.column_stack(
             [
                 cross_val_predict(
@@ -221,7 +223,7 @@ class StackingCVRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
                     cv=kfold,
                     verbose=self.verbose,
                     n_jobs=self.n_jobs,
-                    fit_params=fit_params,
+                    **{param_name: fit_params},
                     pre_dispatch=self.pre_dispatch,
                 )
                 for regr in self.regr_

--- a/mlxtend/regressor/stacking_cv_regression.py
+++ b/mlxtend/regressor/stacking_cv_regression.py
@@ -212,7 +212,7 @@ class StackingCVRegressor(_BaseXComposition, RegressorMixin, TransformerMixin):
             fit_params = None
         else:
             fit_params = dict(sample_weight=sample_weight)
-        param_name = "fit_params" if sklearn_version < "1.4" else "params"    
+        param_name = "fit_params" if sklearn_version < "1.4" else "params"
         meta_features = np.column_stack(
             [
                 cross_val_predict(


### PR DESCRIPTION
### Description

Enhances compatibility with *scikit-learn* versions 1.4 and above by adjusting parameter handling in the `stacking_cv` functions (classification, regression)

### Related issues or pull requests

fixes #1117

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation available at https://rasbt.github.io/mlxtend/contributing/.
-->

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
