### PR TITLE
style: apply ruff formatting and fix label mapping for #589

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -21,6 +21,8 @@ The CHANGELOG for the current development version is available at
 
 - Added multiprocessing support for apriori via the `n_jobs` parameter ([#1151](https://github.com/rasbt/mlxtend/issues/1151) via [mariam851](https://github.com/mariam851))
 
+- Fixes an edge-case bug where decision regions plots didn't have unique colors ([#1157](https://github.com/rasbt/mlxtend/issues/1157) via [mariam851](https://github.com/mariam851))
+
 
 ### Version 0.24.0  (13 Dec 2025)
 

--- a/mlxtend/externals/adjust_text.py
+++ b/mlxtend/externals/adjust_text.py
@@ -630,10 +630,8 @@ def adjust_text(
         try:
             add_bboxes = get_bboxes(add_objects, r, (1, 1), ax)
         except ValueError:
-            raise ValueError(
-                "Can't get bounding boxes from add_objects - is'\
-                             it a flat list of matplotlib objects?"
-            )
+            raise ValueError("Can't get bounding boxes from add_objects - is'\
+                             it a flat list of matplotlib objects?")
             return
         text_from_objects = True
     for text in texts:

--- a/mlxtend/externals/signature_py27.py
+++ b/mlxtend/externals/signature_py27.py
@@ -4,6 +4,7 @@
 Back port of Python 3.3's function signature tools from the inspect module,
 modified to be compatible with Python 2.7 and 3.2+.
 """
+
 from __future__ import absolute_import, division, print_function
 
 import functools

--- a/mlxtend/frequent_patterns/association_rules.py
+++ b/mlxtend/frequent_patterns/association_rules.py
@@ -133,10 +133,8 @@ def association_rules(
 
     # check for mandatory columns
     if not all(col in df.columns for col in ["support", "itemsets"]):
-        raise ValueError(
-            "Dataframe needs to contain the\
-                         columns 'support' and 'itemsets'"
-        )
+        raise ValueError("Dataframe needs to contain the\
+                         columns 'support' and 'itemsets'")
 
     def kulczynski_helper(sAC, sA, sC, disAC, disA, disC, dis_int, dis_int_):
         conf_AC = sAC * (num_itemsets - disAC) / (sA * (num_itemsets - disA) - dis_int)

--- a/mlxtend/plotting/decision_regions.py
+++ b/mlxtend/plotting/decision_regions.py
@@ -6,6 +6,7 @@
 #
 # License: BSD 3 clause
 
+
 import multiprocessing as mp
 from itertools import cycle
 from math import ceil, floor
@@ -29,7 +30,6 @@ def get_feature_range_mask(X, filler_feature_values=None, filler_feature_ranges=
         raise ValueError("filler_feature_values must not be None")
     elif filler_feature_ranges is None:
         raise ValueError("filler_feature_ranges must not be None")
-
     mask = np.ones(X.shape[0], dtype=bool)
     for feature_idx in filler_feature_ranges:
         feature_value = filler_feature_values[feature_idx]
@@ -38,7 +38,6 @@ def get_feature_range_mask(X, filler_feature_values=None, filler_feature_ranges=
         low_limit = feature_value - feature_width
         feature_mask = (X[:, feature_idx] > low_limit) & (X[:, feature_idx] < upp_limit)
         mask = mask & feature_mask
-
     return mask
 
 
@@ -163,10 +162,8 @@ def plot_decision_regions(
 
     if n_jobs is None:
         n_jobs = 1
-
     if ax is None:
         ax = plt.gca()
-
     plot_testdata = True
     if not isinstance(X_highlight, np.ndarray):
         if X_highlight is not None:
@@ -175,9 +172,9 @@ def plot_decision_regions(
             plot_testdata = False
     elif len(X_highlight.shape) < 2:
         raise ValueError("X_highlight must be a 2D array")
-
     if feature_index is not None:
         # Unpack and validate the feature_index values
+
         if dim == 1:
             raise ValueError("feature_index requires more than one training feature")
         try:
@@ -197,23 +194,22 @@ def plot_decision_regions(
     else:
         feature_index = (0, 1)
         x_index, y_index = feature_index
-
     # Extra input validation for higher number of training features
+
     if dim > 2:
         if filler_feature_values is None:
             raise ValueError(
                 "Filler values must be provided when "
                 "X has more than 2 training features."
             )
-
         if filler_feature_ranges is not None:
             if not set(filler_feature_values) == set(filler_feature_ranges):
                 raise ValueError(
                     "filler_feature_values and filler_feature_ranges must "
                     "have the same keys"
                 )
-
         # Check that all columns in X are accounted for
+
         column_check = np.zeros(dim, dtype=bool)
         for idx in filler_feature_values:
             column_check[idx] = True
@@ -225,28 +221,26 @@ def plot_decision_regions(
                 "Column(s) {} need to be accounted for in either "
                 "feature_index or filler_feature_values".format(missing_cols)
             )
-
     # Check that the n_jobs isn't higher than the available CPU cores
+
     if n_jobs > mp.cpu_count():
         raise ValueError(
             "Number of defined CPU cores is more than the available resources {} ".format(
                 mp.cpu_count()
             )
         )
-
     marker_gen = cycle(list(markers))
 
     unique_labels = np.unique(y)
     n_classes = unique_labels.shape[0]
-    label_to_index = {
-        label: i for i, label in enumerate(unique_labels)
-    } 
+    label_to_index = {label: i for i, label in enumerate(unique_labels)}
 
     colors = colors.split(",")
     colors_gen = cycle(colors)
     colors = [next(colors_gen) for c in range(n_classes)]
 
     # Get minimum and maximum
+
     x_min, x_max = (
         X[:, x_index].min() - 1.0 / zoom_factor,
         X[:, x_index].max() + 1.0 / zoom_factor,
@@ -258,7 +252,6 @@ def plot_decision_regions(
             X[:, y_index].min() - 1.0 / zoom_factor,
             X[:, y_index].max() + 1.0 / zoom_factor,
         )
-
     xnum, ynum = plt.gcf().dpi * plt.gcf().get_size_inches()
     xnum, ynum = floor(xnum), ceil(ynum)
     xx, yy = np.meshgrid(
@@ -275,7 +268,6 @@ def plot_decision_regions(
         if dim > 2:
             for feature_idx in filler_feature_values:
                 X_predict[:, feature_idx] = filler_feature_values[feature_idx]
-
     if n_jobs == 1:
         Z = clf.predict(X_predict.astype(X.dtype))
         Z = Z.reshape(xx.shape)
@@ -299,12 +291,12 @@ def plot_decision_regions(
         pool.close()
         Z = np.concatenate(Z)
         Z = Z.reshape(xx.shape)
-
     Z_indexed = np.vectorize(label_to_index.get)(Z)
     Z_indexed = Z_indexed.reshape(xx.shape)
 
     # Plot decisoin region
     # Make sure contourf_kwargs has backwards compatible defaults
+
     contourf_kwargs_default = {"alpha": 0.45, "antialiased": True}
     contourf_kwargs = format_kwarg_dictionaries(
         default_kwargs=contourf_kwargs_default,
@@ -332,6 +324,7 @@ def plot_decision_regions(
 
     # Scatter training data samples
     # Make sure scatter_kwargs has backwards compatible defaults
+
     scatter_kwargs_default = {"alpha": 0.8, "edgecolor": "black"}
     scatter_kwargs = format_kwarg_dictionaries(
         default_kwargs=scatter_kwargs_default,
@@ -356,7 +349,6 @@ def plot_decision_regions(
             x_data = X[class_mask & feature_range_mask, x_index]
         else:
             continue
-
         ax.scatter(
             x=x_data,
             y=y_data,
@@ -365,7 +357,6 @@ def plot_decision_regions(
             label=c,
             **scatter_kwargs,
         )
-
     if hide_spines:
         ax.spines["right"].set_visible(False)
         ax.spines["top"].set_visible(False)
@@ -375,7 +366,6 @@ def plot_decision_regions(
     ax.xaxis.set_ticks_position("bottom")
     if dim == 1:
         ax.axes.get_yaxis().set_ticks([])
-
     if plot_testdata:
         if dim == 1:
             x_data = X_highlight
@@ -391,8 +381,8 @@ def plot_decision_regions(
             )
             y_data = X_highlight[feature_range_mask, y_index]
             x_data = X_highlight[feature_range_mask, x_index]
-
         # Make sure scatter_highlight_kwargs backwards compatible defaults
+
         scatter_highlight_defaults = {
             "c": "none",
             "edgecolor": "black",
@@ -406,12 +396,10 @@ def plot_decision_regions(
             user_kwargs=scatter_highlight_kwargs,
         )
         ax.scatter(x_data, y_data, **scatter_highlight_kwargs)
-
     if legend:
         if dim > 2 and filler_feature_ranges is None:
             pass
         else:
             handles, labels = ax.get_legend_handles_labels()
             ax.legend(handles, labels, framealpha=0.3, scatterpoints=1, loc=legend)
-
     return ax


### PR DESCRIPTION
Hi @rasbt,

I hope you are doing well.

I have submitted this PR to address issue #589, where plot_decision_regions was missing colors when dealing with non-consecutive or negative class labels (e.g., [-1, 1]).

The Problem: The function previously relied on the actual class label values as indices for color mapping, which caused issues when labels were not starting from 0 or contained negative integers.

The Solution: I modified the internal logic to map arbitrary class labels to a zero-indexed range (0, 1, 2...) specifically for the coloring and contouring process. This ensures that:

Decision regions are always colored correctly regardless of the label values.

The original labels are preserved for the scatter plot and legend to maintain data integrity.

Changes made:

Introduced a label_to_index mapping.

Mapped Z predictions to Z_indexed for the contourf and contour calls.

Verified the fix with a Perceptron classifier using [-1, 1] labels.

Applied Ruff for formatting and linting to ensure code quality.

<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/6136f88f-3ae1-4dd2-9ea1-bd8baf3e9765" />


Fixes #589