### PR TITLE
Respect y_int flag in check_Xy input validation

### DIFF
--- a/mlxtend/utils/checking.py
+++ b/mlxtend/utils/checking.py
@@ -16,7 +16,7 @@ def check_Xy(X, y, y_int=True):
     if not isinstance(y, np.ndarray):
         raise ValueError("y must be a NumPy array. Found %s" % type(y))
 
-    if "int" not in str(y.dtype):
+    if y_int and "int" not in str(y.dtype):
         raise ValueError(
             "y must be an integer array. Found %s. "
             "Try passing the array as y.astype(np.int_)" % y.dtype

--- a/mlxtend/utils/tests/test_checking_inputs.py
+++ b/mlxtend/utils/tests/test_checking_inputs.py
@@ -38,6 +38,18 @@ def test_check_Xy_float16_y():
     check_Xy(X, y.astype(np.int16))
 
 
+def test_check_Xy_float_y_allowed_if_y_int_false():
+    check_Xy(X, y.astype(float), y_int=False)
+
+
+def test_check_Xy_float_y_rejected_if_y_int_true():
+    expect = (
+        "y must be an integer array. Found float64. "
+        "Try passing the array as y.astype(np.int_)"
+    )
+    assert_raises(ValueError, expect, check_Xy, X, y.astype(float), y_int=True)
+
+
 def test_check_Xy_invalid_type_y():
     expect = "y must be a NumPy array. Found <class 'list'>"
     if sys.version_info < (3, 0):


### PR DESCRIPTION
### Code of Conduct

<!-- 
If this is your first Pull Request for the MLxtend repository, please review
the code of conduct, which is available at https://rasbt.github.io/mlxtend/Code-of-Conduct/. 
-->


### Description

<!--  
This pull request fixes an issue in 'check_Xy' where the 'y_int' parameter
was not being respected. The integer type check for 'y' is now conditional
on 'y_int', making the function behavior consistent with its API.
-->

### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation available at https://rasbt.github.io/mlxtend/contributing/.
-->

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
