### PR TITLE
Add tol support to SequentialFeatureSelector

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -23,6 +23,11 @@ The CHANGELOG for the current development version is available at
 
 - Fixes an edge-case bug where decision regions plots didn't have unique colors ([#1157](https://github.com/rasbt/mlxtend/issues/1157) via [mariam851](https://github.com/mariam851))
 
+- Added functional `tol` support to `SequentialFeatureSelector` for auto-like
+  modes (`k_features="best"`/`"parsimonious"`) with forward-stop validation.
+  ([#1079](https://github.com/rasbt/mlxtend/issues/1079) via
+  [@vaaven](https://github.com/vaaven))
+
 
 ### Version 0.24.0  (13 Dec 2025)
 


### PR DESCRIPTION
Hi @rasbt!

Added `tol` support to `SequentialFeatureSelector` for auto-like modes (`k_features="best"` or `"parsimonious"`), with tolerance-based early stopping logic in both forward/backward paths (including forward positive `tol` restriction)

### Related issues or pull requests

Fixes #1079

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`
