### PR TITLE
feat: add pandas DataFrame/Series support to bias_variance_decomp

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -23,6 +23,8 @@ The CHANGELOG for the current development version is available at
 
 - Fixes an edge-case bug where decision regions plots didn't have unique colors ([#1157](https://github.com/rasbt/mlxtend/issues/1157) via [mariam851](https://github.com/mariam851))
 
+- `bias_variance_decomp` now accepts pandas DataFrames and Series as input, in addition to NumPy arrays. ([#1070](https://github.com/rasbt/mlxtend/issues/1070) via [berns722](https://github.com/berns722))
+
 
 ### Version 0.24.0  (13 Dec 2025)
 

--- a/mlxtend/evaluate/bias_variance_decomp.py
+++ b/mlxtend/evaluate/bias_variance_decomp.py
@@ -25,26 +25,26 @@ def bias_variance_decomp(
     loss="0-1_loss",
     num_rounds=200,
     random_seed=None,
-    **fit_params
+    **fit_params,
 ):
     """
     estimator : object
         A classifier or regressor object or class implementing both a
         `fit` and `predict` method similar to the scikit-learn API.
 
-    X_train : array-like, shape=(num_examples, num_features)
-        A training dataset for drawing the bootstrap samples to carry
-        out the bias-variance decomposition.
+    X_train : array-like or pandas DataFrame, shape=(num_examples, num_features)
+    A training dataset for drawing the bootstrap samples to carry
+    out the bias-variance decomposition.
 
-    y_train : array-like, shape=(num_examples)
+    y_train : array-like or pandas Series, shape=(num_examples)
         Targets (class labels, continuous values in case of regression)
         associated with the `X_train` examples.
 
-    X_test : array-like, shape=(num_examples, num_features)
+    X_test : array-like or pandas DataFrame, shape=(num_examples, num_features)
         The test dataset for computing the average loss, bias,
         and variance.
 
-    y_test : array-like, shape=(num_examples)
+    y_test : array-like or pandas Series, shape=(num_examples)
         Targets (class labels, continuous values in case of regression)
         associated with the `X_test` examples.
 
@@ -81,17 +81,15 @@ def bias_variance_decomp(
     if loss not in supported:
         raise NotImplementedError("loss must be one of the following: %s" % supported)
 
-    for ary in (X_train, y_train, X_test, y_test):
-        if hasattr(ary, "loc"):
-            raise ValueError(
-                "The bias_variance_decomp does not "
-                "support pandas DataFrames yet. "
-                "Please check the inputs to "
-                "X_train, y_train, X_test, y_test. "
-                "If e.g., X_train is a pandas "
-                "DataFrame, try passing it as NumPy array via "
-                "X_train=X_train.values."
-            )
+        # Convert pandas inputs to numpy arrays
+    if hasattr(X_train, "loc"):
+        X_train = X_train.to_numpy() if hasattr(X_train, "to_numpy") else X_train.values
+    if hasattr(y_train, "loc"):
+        y_train = y_train.to_numpy() if hasattr(y_train, "to_numpy") else y_train.values
+    if hasattr(X_test, "loc"):
+        X_test = X_test.to_numpy() if hasattr(X_test, "to_numpy") else X_test.values
+    if hasattr(y_test, "loc"):
+        y_test = y_test.to_numpy() if hasattr(y_test, "to_numpy") else y_test.values
 
     rng = np.random.RandomState(random_seed)
 

--- a/mlxtend/evaluate/tests/test_bias_variance_decomp.py
+++ b/mlxtend/evaluate/tests/test_bias_variance_decomp.py
@@ -19,20 +19,34 @@ from mlxtend.data import boston_housing_data, iris_data
 from mlxtend.evaluate import bias_variance_decomp
 
 
-def pandas_input_fail():
+def test_pandas_input():
     X, y = iris_data()
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.3, random_state=123, shuffle=True, stratify=y
     )
 
-    X_train = pd.DataFrame(X_train)
+    # Convert to pandas
+    X_train_df = pd.DataFrame(X_train)
+    y_train_series = pd.Series(y_train)
+    X_test_df = pd.DataFrame(X_test)
+    y_test_series = pd.Series(y_test)
 
     tree = DecisionTreeClassifier(random_state=123)
 
-    with pytest.raises(ValueError):
-        avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(
-            tree, X_train, y_train, X_test, y_test, loss="0-1_loss", random_seed=123
-        )
+    avg_expected_loss, avg_bias, avg_var = bias_variance_decomp(
+        tree,
+        X_train_df,
+        y_train_series,
+        X_test_df,
+        y_test_series,
+        loss="0-1_loss",
+        random_seed=123,
+    )
+
+    # Should produce same results as numpy version
+    assert round(avg_expected_loss, 3) == 0.062
+    assert round(avg_bias, 3) == 0.022
+    assert round(avg_var, 3) == 0.040
 
 
 def test_01_loss_tree():


### PR DESCRIPTION
### Code of Conduct

I have read and agree to follow the mlxtend Code of Conduct.

### Description

This PR adds native support for pandas DataFrame and Series inputs to `bias_variance_decomp`, replacing the previous behavior of raising a `ValueError`.

DataFrame and Series inputs are now automatically converted to numpy arrays internally, allowing users to integrate the function seamlessly into pandas-based workflows.

### Related issues or pull requests

Closes #1070.

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (not applicable)
- [x] Ran `pytest` on the modified test file — all 5 relevant tests pass (test_keras skipped, requires tensorflow)
- [x] Code style verified via pre-commit hooks (black, isort, flake8)