### PR TITLE
fix(preprocessing): map constant columns to min_val in minmax_scaling (#1167)

### DIFF
--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -25,6 +25,8 @@ The CHANGELOG for the current development version is available at
 
 - `bias_variance_decomp` now accepts pandas DataFrames and Series as input, in addition to NumPy arrays. ([#1070](https://github.com/rasbt/mlxtend/issues/1070) via [berns722](https://github.com/berns722))
 
+- Fix `preprocessing.minmax_scaling` returning `NaN` for constant columns; constant columns are now mapped to `min_val` instead of triggering a `0 / 0` divide. ([#1167](https://github.com/rasbt/mlxtend/issues/1167))
+
 
 ### Version 0.24.0  (13 Dec 2025)
 

--- a/mlxtend/preprocessing/scaling.py
+++ b/mlxtend/preprocessing/scaling.py
@@ -48,7 +48,9 @@ def minmax_scaling(array, columns, min_val=0, max_val=1):
 
     numerator = ary_newt[:, columns] - ary_newt[:, columns].min(axis=0)
     denominator = ary_newt[:, columns].max(axis=0) - ary_newt[:, columns].min(axis=0)
-    ary_newt[:, columns] = numerator / denominator
+    # Constant columns have a zero numerator and zero denominator; substitute 1 to avoid NaN.
+    safe_denominator = np.where(denominator == 0, 1.0, denominator)
+    ary_newt[:, columns] = numerator / safe_denominator
 
     if not min_val == 0 and not max_val == 1:
         ary_newt[:, columns] = ary_newt[:, columns] * (max_val - min_val) + min_val

--- a/mlxtend/preprocessing/tests/test__scaling__minmax_scaling.py
+++ b/mlxtend/preprocessing/tests/test__scaling__minmax_scaling.py
@@ -72,3 +72,25 @@ def test_numpy_minmax_scaling():
 
     np.testing.assert_allclose(df_out1, ary_out1, rtol=1e-03)
     assert (df_out2 == ary_out2).all()
+
+
+def test_constant_column_numpy_issue_1167():
+    ary = np.array([[5, 1], [5, 2], [5, 3]])
+    result = minmax_scaling(ary, columns=[0, 1])
+    expected = np.array([[0.0, 0.0], [0.0, 0.5], [0.0, 1.0]])
+    assert result.shape == (3, 2)
+    assert not np.isnan(result).any()
+    np.testing.assert_allclose(result, expected, rtol=1e-03)
+
+
+def test_constant_column_pandas_issue_1167():
+    df = pd.DataFrame(
+        {"s1": pd.Series([5, 5, 5, 5, 5, 5]), "s2": pd.Series([10, 9, 8, 7, 6, 5])}
+    )
+    result = minmax_scaling(df, ["s1", "s2"])
+    expected = np.array(
+        [[0.0, 1.0], [0.0, 0.8], [0.0, 0.6], [0.0, 0.4], [0.0, 0.2], [0.0, 0.0]]
+    )
+    assert result.shape == (6, 2)
+    assert not np.isnan(result.values).any()
+    np.testing.assert_allclose(result.values, expected, rtol=1e-03)


### PR DESCRIPTION
### Code of Conduct

I have read the project's Code of Conduct.

### Description

`minmax_scaling` silently returns `NaN` for constant columns because the `(max - min)` denominator is zero. This change substitutes the zero denominator with 1.0, so the numerator (also zero on those columns) divides cleanly and constant columns end up at `min_val`, matching how `standardize` already handles its zero-variance case.

### Related issues or pull requests

Fixes #1167

### Pull Request Checklist

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (not applicable, behavior matches expectation in the issue)
- [x] Ran `PYTHONPATH='.' pytest ./mlxtend/preprocessing -sv` and all tests pass (40/40 including 2 new regression tests)
- [x] Checked for style issues by running `flake8 ./mlxtend` and `ruff check` (clean)
