### PR TITLE
Improve apriori efficiency

### DIFF
--- a/mlxtend/frequent_patterns/apriori.py
+++ b/mlxtend/frequent_patterns/apriori.py
@@ -3,13 +3,32 @@
 # Author: Sebastian Raschka <sebastianraschka.com>
 #
 # License: BSD 3 clause
-
+from itertools import groupby
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 
 from ..frequent_patterns import fpcommon as fpc
+
+
+def _apriori_gen(old_combinations):
+    old_combinations = sorted(tuple(combination) for combination in old_combinations)
+    set_old_combinations = set(old_combinations)
+
+    for i, old_combination in enumerate(old_combinations):
+        prefix = old_combination[:-1]
+        for other_combination in old_combinations[i + 1 :]:
+            if prefix != other_combination[:-1]:
+                break
+
+            candidate = old_combination + (other_combination[-1],)
+            for idx in range(len(candidate) - 2):
+                test_candidate = candidate[:idx] + candidate[idx + 1 :]
+                if test_candidate not in set_old_combinations:
+                    break
+            else:
+                yield candidate
 
 
 def generate_new_combinations(old_combinations):
@@ -33,8 +52,10 @@ def generate_new_combinations(old_combinations):
 
     Returns
     -----------
-    Generator of all combinations from the last step x items
-    from the previous step.
+    Generator of combinations based on the last state of Apriori algorithm.
+    In order to reduce the number of candidates, this function implements the
+    apriori-gen join and prune steps described in section 2.1.1 of the
+    Apriori paper.
 
     Examples
     -----------
@@ -43,15 +64,8 @@ def generate_new_combinations(old_combinations):
 
     """
 
-    items_types_in_previous_step = np.unique(old_combinations.flatten())
-    for old_combination in old_combinations:
-        max_combination = old_combination[-1]
-        mask = items_types_in_previous_step > max_combination
-        valid_items = items_types_in_previous_step[mask]
-        old_tuple = tuple(old_combination)
-        for item in valid_items:
-            yield from old_tuple
-            yield item
+    for candidate in _apriori_gen(old_combinations):
+        yield from candidate
 
 
 def generate_new_combinations_low_memory(old_combinations, X, min_support, is_sparse):
@@ -111,25 +125,25 @@ def generate_new_combinations_low_memory(old_combinations, X, min_support, is_sp
 
     """
 
-    items_types_in_previous_step = np.unique(old_combinations.flatten())
     rows_count = X.shape[0]
     threshold = min_support * rows_count
-    for old_combination in old_combinations:
-        max_combination = old_combination[-1]
-        mask = items_types_in_previous_step > max_combination
-        valid_items = items_types_in_previous_step[mask]
-        old_tuple = tuple(old_combination)
+    for prefix, candidates in groupby(
+        _apriori_gen(old_combinations), key=lambda x: x[:-1]
+    ):
+        valid_items = np.fromiter(
+            (candidate[-1] for candidate in candidates), dtype=int
+        )
         if is_sparse:
-            mask_rows = X[:, old_tuple].toarray().all(axis=1)
+            mask_rows = X[:, prefix].toarray().all(axis=1)
             X_cols = X[:, valid_items].toarray()
             supports = X_cols[mask_rows].sum(axis=0)
         else:
-            mask_rows = X[:, old_tuple].all(axis=1)
+            mask_rows = X[:, prefix].all(axis=1)
             supports = X[mask_rows][:, valid_items].sum(axis=0)
         valid_indices = (supports >= threshold).nonzero()[0]
         for index in valid_indices:
             yield supports[index]
-            yield from old_tuple
+            yield from prefix
             yield valid_items[index]
 
 

--- a/mlxtend/frequent_patterns/tests/speedtests/apriori.py
+++ b/mlxtend/frequent_patterns/tests/speedtests/apriori.py
@@ -1,0 +1,213 @@
+# Sebastian Raschka 2014-2026
+# mlxtend Machine Learning Library Extensions
+# Author: Sebastian Raschka <sebastianraschka.com>
+#
+# License: BSD 3 clause
+
+"""Speedtest for apriori candidate generation.
+
+Run from the repository root:
+
+    uv run --group dev python mlxtend/frequent_patterns/tests/speedtests/apriori.py
+
+To compare the working tree implementation against HEAD:
+
+    uv run --group dev python mlxtend/frequent_patterns/tests/speedtests/apriori.py --compare-head
+"""
+
+import argparse
+import importlib
+import subprocess
+import time
+import types
+
+import numpy as np
+import pandas as pd
+
+PRESETS = {
+    "quick": {
+        "rows": 2400,
+        "groups": 18,
+        "items_per_group": 5,
+        "groups_per_transaction": 5,
+        "min_support": 0.045,
+        "max_len": 4,
+        "repeats": 7,
+    },
+    "realistic": {
+        "rows": 10000,
+        "groups": 40,
+        "items_per_group": 6,
+        "groups_per_transaction": 5,
+        "min_support": 0.03,
+        "max_len": 4,
+        "repeats": 5,
+    },
+}
+
+
+def make_dataset(
+    seed=123,
+    n_rows=10000,
+    n_groups=40,
+    items_per_group=6,
+    groups_per_transaction=5,
+):
+    rng = np.random.default_rng(seed)
+    n_cols = n_groups * items_per_group
+    ary = np.zeros((n_rows, n_cols), dtype=bool)
+
+    for row in range(n_rows):
+        groups = rng.choice(n_groups, size=groups_per_transaction, replace=False)
+        for group in groups:
+            start = group * items_per_group
+            size = rng.integers(2, items_per_group + 1)
+            items = rng.choice(items_per_group, size=size, replace=False)
+            ary[row, start + items] = True
+
+    columns = ["i%d" % idx for idx in range(n_cols)]
+    return pd.DataFrame(ary, columns=columns)
+
+
+def load_head_apriori_module():
+    source = subprocess.check_output(
+        ["git", "show", "HEAD:mlxtend/frequent_patterns/apriori.py"], text=True
+    )
+    module = types.ModuleType("mlxtend.frequent_patterns.apriori_head")
+    module.__package__ = "mlxtend.frequent_patterns"
+    exec(compile(source, "apriori_head.py", "exec"), module.__dict__)
+    return module
+
+
+def normalize_result(result):
+    return sorted(
+        (tuple(sorted(itemset)), round(float(support), 12))
+        for support, itemset in zip(result["support"], result["itemsets"])
+    )
+
+
+def run_benchmark(label, apriori_func, df, kwargs, repeats):
+    times = []
+    result = None
+
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = apriori_func(df, **kwargs)
+        times.append(time.perf_counter() - start)
+
+    print("%s rows: %d" % (label, result.shape[0]))
+    print("%s times: %s" % (label, " ".join("%.4f" % t for t in times)))
+    print("%s median: %.4f" % (label, np.median(times)))
+    return result, times
+
+
+def run_candidate_benchmark(label, generate_new_combinations, old_combinations):
+    start = time.perf_counter()
+    generated = np.fromiter(generate_new_combinations(old_combinations), dtype=int)
+    elapsed = time.perf_counter() - start
+    count = generated.size // (old_combinations.shape[1] + 1)
+
+    print("%s candidate count: %d" % (label, count))
+    print("%s candidate time: %.6f" % (label, elapsed))
+
+
+def run(args):
+    current = importlib.import_module("mlxtend.frequent_patterns.apriori")
+    modules = [("current", current)]
+    if args.compare_head:
+        modules.insert(0, ("head", load_head_apriori_module()))
+
+    print("preset: %s" % args.preset)
+    print(
+        "dataset: rows=%d, columns=%d, groups=%d, items_per_group=%d, "
+        "groups_per_transaction=%d"
+        % (
+            args.rows,
+            args.groups * args.items_per_group,
+            args.groups,
+            args.items_per_group,
+            args.groups_per_transaction,
+        )
+    )
+    print(
+        "apriori: min_support=%.4f, max_len=%d, repeats=%d"
+        % (args.min_support, args.max_len, args.repeats)
+    )
+
+    df = make_dataset(
+        seed=args.seed,
+        n_rows=args.rows,
+        n_groups=args.groups,
+        items_per_group=args.items_per_group,
+        groups_per_transaction=args.groups_per_transaction,
+    )
+    base_kwargs = {
+        "min_support": args.min_support,
+        "use_colnames": False,
+        "max_len": args.max_len,
+    }
+
+    for low_memory in [False, True]:
+        print("\nlow_memory: %s" % low_memory)
+        kwargs = dict(base_kwargs, low_memory=low_memory)
+        baseline_result = None
+        baseline_times = None
+
+        for label, module in modules:
+            result, times = run_benchmark(
+                label, module.apriori, df, kwargs, repeats=args.repeats
+            )
+            if baseline_result is None:
+                baseline_result = result
+                baseline_times = times
+            else:
+                same_output = normalize_result(baseline_result) == normalize_result(
+                    result
+                )
+                speedup = np.median(baseline_times) / np.median(times)
+                print("same output vs %s: %s" % (modules[0][0], same_output))
+                print("speedup vs %s: %.2fx" % (modules[0][0], speedup))
+
+        if low_memory:
+            continue
+
+        old_combinations = np.array(
+            sorted(
+                tuple(sorted(itemset))
+                for itemset in baseline_result["itemsets"]
+                if len(itemset) == 3
+            )
+        )
+        if old_combinations.size == 0:
+            continue
+
+        print("\ncandidate generation from frequent 3-itemsets")
+        for label, module in modules:
+            run_candidate_benchmark(
+                label, module.generate_new_combinations, old_combinations
+            )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--preset", choices=sorted(PRESETS), default="realistic")
+    parser.add_argument("--compare-head", action="store_true")
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--rows", type=int)
+    parser.add_argument("--groups", type=int)
+    parser.add_argument("--items-per-group", type=int)
+    parser.add_argument("--groups-per-transaction", type=int)
+    parser.add_argument("--min-support", type=float)
+    parser.add_argument("--max-len", type=int)
+    parser.add_argument("--repeats", type=int)
+    args = parser.parse_args()
+
+    for key, value in PRESETS[args.preset].items():
+        if getattr(args, key) is None:
+            setattr(args, key, value)
+
+    return args
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/mlxtend/frequent_patterns/tests/test_apriori.py
+++ b/mlxtend/frequent_patterns/tests/test_apriori.py
@@ -7,6 +7,7 @@
 import unittest
 
 import numpy as np
+import pandas as pd
 from test_fpbase import (
     FPTestEdgeCases,
     FPTestErrors,
@@ -16,6 +17,25 @@ from test_fpbase import (
 )
 
 from mlxtend.frequent_patterns import apriori
+from mlxtend.frequent_patterns.apriori import generate_new_combinations
+
+
+def _sorted_itemsets_with_support(df):
+    rows = []
+    for support, itemset in zip(df["support"], df["itemsets"]):
+        rows.append((tuple(sorted(itemset)), support))
+    return sorted(rows)
+
+
+def _assert_itemsets_equal(result, expected):
+    result_rows = _sorted_itemsets_with_support(result)
+    expected_rows = _sorted_itemsets_with_support(expected)
+
+    assert [row[0] for row in result_rows] == [row[0] for row in expected_rows]
+    np.testing.assert_allclose(
+        [row[1] for row in result_rows],
+        [row[1] for row in expected_rows],
+    )
 
 
 def apriori_wrapper_low_memory(*args, **kwargs):
@@ -90,6 +110,118 @@ class TestAprioriBoolInput(unittest.TestCase, FPTestEx1All):
             ]
         )
         FPTestEx1All.setUp(self, apriori, one_ary=one_ary)
+
+
+class TestAprioriSpecific(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame(
+            [
+                [1, 1, 1, 0],
+                [1, 1, 0, 1],
+                [1, 0, 1, 1],
+                [0, 1, 1, 1],
+                [1, 1, 1, 1],
+            ],
+            columns=["A", "B", "C", "D"],
+        )
+
+    def test_n_jobs_matches_single_threaded_result(self):
+        res_single = apriori(
+            self.df, min_support=0.4, use_colnames=True, max_len=3, n_jobs=1
+        )
+        res_parallel = apriori(
+            self.df, min_support=0.4, use_colnames=True, max_len=3, n_jobs=2
+        )
+
+        _assert_itemsets_equal(res_parallel, res_single)
+
+    def test_low_memory_matches_default_result(self):
+        res_default = apriori(self.df, min_support=0.4, use_colnames=True, max_len=3)
+        res_low_memory = apriori(
+            self.df, min_support=0.4, use_colnames=True, max_len=3, low_memory=True
+        )
+
+        _assert_itemsets_equal(res_low_memory, res_default)
+
+    def test_max_len_one_returns_only_single_itemsets(self):
+        result = apriori(self.df, min_support=0.6, use_colnames=True, max_len=1)
+        expected = pd.DataFrame(
+            [
+                [0.8, frozenset(["A"])],
+                [0.8, frozenset(["B"])],
+                [0.8, frozenset(["C"])],
+                [0.8, frozenset(["D"])],
+            ],
+            columns=["support", "itemsets"],
+        )
+
+        _assert_itemsets_equal(result, expected)
+
+    def test_min_support_one_includes_itemsets_present_in_every_transaction(self):
+        df = pd.DataFrame(
+            [
+                [1, 1, 0],
+                [1, 1, 1],
+                [1, 1, 0],
+            ],
+            columns=["A", "B", "C"],
+        )
+
+        result = apriori(df, min_support=1.0, use_colnames=True)
+        expected = pd.DataFrame(
+            [
+                [1.0, frozenset(["A"])],
+                [1.0, frozenset(["B"])],
+                [1.0, frozenset(["A", "B"])],
+            ],
+            columns=["support", "itemsets"],
+        )
+
+        _assert_itemsets_equal(result, expected)
+
+    def test_returns_empty_result_if_no_item_meets_min_support(self):
+        df = pd.DataFrame(
+            [
+                [1, 0],
+                [0, 1],
+            ],
+            columns=["A", "B"],
+        )
+
+        result = apriori(df, min_support=1.0, use_colnames=True)
+
+        assert result.columns.tolist() == ["support", "itemsets"]
+        assert result.empty
+
+    def test_candidate_generation_joins_only_matching_prefixes(self):
+        old_combinations = np.array(
+            [
+                [0, 1],
+                [0, 2],
+                [1, 2],
+                [1, 3],
+                [2, 3],
+            ]
+        )
+
+        candidates = np.fromiter(
+            generate_new_combinations(old_combinations), dtype=int
+        ).reshape(-1, 3)
+
+        np.testing.assert_array_equal(candidates, np.array([[0, 1, 2], [1, 2, 3]]))
+
+    def test_candidate_generation_prunes_missing_subsets(self):
+        old_combinations = np.array(
+            [
+                [0, 1, 2],
+                [0, 1, 3],
+                [0, 2, 3],
+            ]
+        )
+
+        candidates = np.fromiter(generate_new_combinations(old_combinations), dtype=int)
+
+        assert candidates.size == 0
 
 
 class TestEx2(unittest.TestCase, FPTestEx2All):


### PR DESCRIPTION
Improves efficiency of the apriori implementation based on reviving the great work in #646

 This results in an almost (up to) 10x speedup with default settings on a reasonably sized dataset.

```
low_memory=False
head median:    4.1144s
current median: 0.4330s
same output:    True
speedup:        9.50x

candidate generation from frequent 3-itemsets
head:    94200 candidates
current:   600 candidates

low_memory=True
head median:    0.1065s
current median: 0.0605s
same output:    True
speedup:        1.76x
```

Fixes #646