### PR TITLE
validate proportion inputs in proportion_difference

### DIFF
--- a/mlxtend/evaluate/proportion_difference.py
+++ b/mlxtend/evaluate/proportion_difference.py
@@ -39,6 +39,10 @@ def proportion_difference(proportion_1, proportion_2, n_1, n_2=None):
     https://rasbt.github.io/mlxtend/user_guide/evaluate/proportion_difference/
 
     """
+    if not 0 <= proportion_1 <= 1:
+        raise ValueError("proportion_1 must be in the interval [0, 1].")
+    if not 0 <= proportion_2 <= 1:
+        raise ValueError("proportion_2 must be in the interval [0, 1].")
     if n_2 is None:
         n_2 = n_1
 

--- a/mlxtend/evaluate/tests/test_proportion_difference.py
+++ b/mlxtend/evaluate/tests/test_proportion_difference.py
@@ -444,3 +444,13 @@ def test_on_dataset():
     z, p_value = proportion_difference(acc_2, acc_3, n_1=y_true.shape[0])
     assert round(z, 3) == 0.0
     assert round(p_value, 3) == 0.5
+
+
+    
+def test_proportion_difference_rejects_out_of_range():
+    import pytest
+    from mlxtend.evaluate import proportion_difference
+    with pytest.raises(ValueError):
+        proportion_difference(1.5, 0.3, n_1=50)
+    with pytest.raises(ValueError):
+        proportion_difference(0.3, -0.2, n_1=50)

--- a/mlxtend/evaluate/tests/test_proportion_difference.py
+++ b/mlxtend/evaluate/tests/test_proportion_difference.py
@@ -450,6 +450,7 @@ def test_proportion_difference_rejects_out_of_range():
     import pytest
 
     from mlxtend.evaluate import proportion_difference
+
     with pytest.raises(ValueError):
         proportion_difference(1.5, 0.3, n_1=50)
     with pytest.raises(ValueError):

--- a/mlxtend/evaluate/tests/test_proportion_difference.py
+++ b/mlxtend/evaluate/tests/test_proportion_difference.py
@@ -446,7 +446,6 @@ def test_on_dataset():
     assert round(p_value, 3) == 0.5
 
 
-    
 def test_proportion_difference_rejects_out_of_range():
     import pytest
     from mlxtend.evaluate import proportion_difference

--- a/mlxtend/evaluate/tests/test_proportion_difference.py
+++ b/mlxtend/evaluate/tests/test_proportion_difference.py
@@ -448,6 +448,7 @@ def test_on_dataset():
 
 def test_proportion_difference_rejects_out_of_range():
     import pytest
+
     from mlxtend.evaluate import proportion_difference
     with pytest.raises(ValueError):
         proportion_difference(1.5, 0.3, n_1=50)

--- a/mlxtend/evaluate/tests/test_proportion_difference.py
+++ b/mlxtend/evaluate/tests/test_proportion_difference.py
@@ -5,6 +5,7 @@
 # License: BSD 3 clause
 
 import numpy as np
+import pytest
 
 from mlxtend.evaluate import proportion_difference
 
@@ -447,11 +448,15 @@ def test_on_dataset():
 
 
 def test_proportion_difference_rejects_out_of_range():
-    import pytest
+    invalid_cases = [
+        (-0.2, 0.3, "proportion_1"),
+        (1.5, 0.3, "proportion_1"),
+        (np.nan, 0.3, "proportion_1"),
+        (0.3, -0.2, "proportion_2"),
+        (0.3, 1.5, "proportion_2"),
+        (0.3, np.nan, "proportion_2"),
+    ]
 
-    from mlxtend.evaluate import proportion_difference
-
-    with pytest.raises(ValueError):
-        proportion_difference(1.5, 0.3, n_1=50)
-    with pytest.raises(ValueError):
-        proportion_difference(0.3, -0.2, n_1=50)
+    for proportion_1, proportion_2, invalid_parameter in invalid_cases:
+        with pytest.raises(ValueError, match=invalid_parameter):
+            proportion_difference(proportion_1, proportion_2, n_1=50)


### PR DESCRIPTION
proportion_difference silenlty returned (nan, nan) (with a RuntimeWarning) when a proportion was outside [0, 1], for  e.g. proportion_difference(1.5, 0.3, 50). This adds validation that raises a clear ValueError when proportion_1 or proportion_2 is not in [0, 1] — consistent with the input checks already in mcnemar and cochrans_q. Valid-input behavior is unchanged; a unit test was added.